### PR TITLE
[UAT | Judgement Order #1337]modal for viewing judgement order in view a case

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/JudgementViewCard.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/JudgementViewCard.js
@@ -1,11 +1,35 @@
 import { Button, Card } from "@egovernments/digit-ui-react-components";
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { JudgementIcon } from "../../../icons/svgIndex";
+import PublishedOrderModal from "./PublishedOrderModal";
+import useGetOrders from "../../../hooks/dristi/useGetOrders";
+import useDownloadCasePdf from "../../../hooks/dristi/useDownloadCasePdf";
 const JudgementViewCard = ({ caseData, width }) => {
   const { t } = useTranslation();
-  const handleButtonClick = () => {};
+  const [showJudgementOrder, setShowJudgementOrder] = useState(false);
   const tenantId = Digit.ULBService.getCurrentTenantId();
+  const { downloadPdf } = useDownloadCasePdf();
+
+  const { data: ordersRes, refetch: refetchOrdersData, isLoading: isOrdersLoading } = useGetOrders(
+    {
+      criteria: {
+        filingNumber: caseData?.filingNumber,
+        tenantId: tenantId,
+      },
+    },
+    {},
+    caseData?.filingNumber,
+    caseData?.filingNumber
+  );
+
+  const judgementOrder = useMemo(() => {
+    return ordersRes?.list?.filter((order) => order?.orderType === "JUDGEMENT")?.[0];
+  }, [ordersRes]);
+
+  const handleButtonClick = () => {
+    setShowJudgementOrder(true);
+  };
   const { data: hearingsData } = Digit.Hooks.hearings.useGetHearings(
     { criteria: { tenantId }, tenantId },
     { applicationNumber: "", cnrNumber: "", tenantId },
@@ -22,56 +46,72 @@ const JudgementViewCard = ({ caseData, width }) => {
     }
     return `${year}-${month}-${day}`;
   };
+
+  const handleCloseJudgementOrder = () => {
+    setShowJudgementOrder(false);
+  };
+
+  const handleDownload = (filestoreId) => {
+    if (filestoreId) {
+      downloadPdf(tenantId, filestoreId);
+    }
+  };
+
   return (
-    <Card
-      style={{
-        width: width,
-        marginTop: "10px",
-      }}
-    >
-      <div
+    <React.Fragment>
+      <Card
         style={{
-          fontWeight: 700,
-          fontSize: "16px",
-          lineHeight: "18.75px",
-          color: "#231F20",
-          display: "flex",
-          alignItems: "center",
-          gap: 15,
+          width: width,
+          marginTop: "10px",
         }}
       >
-        <JudgementIcon />
-        {t("FINAL_JUDGEMENT")}
-      </div>
-      <hr style={{ border: "1px solid #FFF6E880" }} />
-      <div style={{ display: "flex", justifyContent: "space-between", padding: "10px" }}>
-        <div style={{ display: "flex", gap: "10px", justifyContent: "start", flexDirection: "column" }}>
-          <div
-            style={{
-              fontWeight: 700,
-              fontSize: "24px",
-              lineHeight: "28.13px",
-              color: "#231F20",
-              marginTop: "5px",
-            }}
-          >
-            {t(caseData?.case?.outcome)}
-          </div>
-          <div
-            style={{
-              fontWeight: 400,
-              fontSize: "14px",
-              lineHeight: "16.41px",
-              color: "#3D3C3C",
-              marginTop: "5px",
-            }}
-          >
-            {formatDate(new Date(hearingsList?.[hearingsList?.length - 1]?.startTime), "DD-MM-YYYY")}
-          </div>
+        <div
+          style={{
+            fontWeight: 700,
+            fontSize: "16px",
+            lineHeight: "18.75px",
+            color: "#231F20",
+            display: "flex",
+            alignItems: "center",
+            gap: 15,
+          }}
+        >
+          <JudgementIcon />
+          {t("FINAL_JUDGEMENT")}
         </div>
-        <Button variation={"outlined"} onButtonClick={handleButtonClick} label={t("VIEW_JUDGEMENT_ORDER")} />
-      </div>
-    </Card>
+        <hr style={{ border: "1px solid #FFF6E880" }} />
+        <div style={{ display: "flex", justifyContent: "space-between", padding: "10px" }}>
+          <div style={{ display: "flex", gap: "10px", justifyContent: "start", flexDirection: "column" }}>
+            <div
+              style={{
+                fontWeight: 700,
+                fontSize: "24px",
+                lineHeight: "28.13px",
+                color: "#231F20",
+                marginTop: "5px",
+              }}
+            >
+              {t(caseData?.case?.outcome)}
+            </div>
+            <div
+              style={{
+                fontWeight: 400,
+                fontSize: "14px",
+                lineHeight: "16.41px",
+                color: "#3D3C3C",
+                marginTop: "5px",
+              }}
+            >
+              {formatDate(new Date(hearingsList?.[hearingsList?.length - 1]?.startTime), "DD-MM-YYYY")}
+            </div>
+          </div>
+          <Button variation={"outlined"} onButtonClick={handleButtonClick} label={t("VIEW_JUDGEMENT_ORDER")} />
+        </div>
+      </Card>
+      {showJudgementOrder && (
+        <PublishedOrderModal t={t} order={judgementOrder} handleDownload={handleDownload} handleOrdersTab={handleCloseJudgementOrder} />
+      )}
+    </React.Fragment>
   );
 };
 

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/PublishedOrderModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/PublishedOrderModal.js
@@ -3,7 +3,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import Modal from "../../../components/Modal";
 import { Button, SubmitBar } from "@egovernments/digit-ui-react-components";
 
-function PublishedOrderModal({ t, order, handleDownload, handleRequestLabel, handleSubmitDocument, showSubmissionButtons, handleOrdersTab }) {
+function PublishedOrderModal({ t, order, handleDownload, handleRequestLabel, handleSubmitDocument, showSubmissionButtons = false, handleOrdersTab }) {
   const [fileStoreId, setFileStoreID] = useState(null);
   const [fileName, setFileName] = useState();
   const tenantId = window?.Digit.ULBService.getCurrentTenantId();
@@ -21,7 +21,7 @@ function PublishedOrderModal({ t, order, handleDownload, handleRequestLabel, han
     );
   };
 
-  const signedOrder = useMemo(() => order?.documents?.filter((item) => item?.documentType == "SIGNED")[0], [order]);
+  const signedOrder = useMemo(() => order?.documents?.filter((item) => item?.documentType === "SIGNED")[0], [order]);
 
   useEffect(() => {
     const onDocumentUpload = async (fileData, filename) => {


### PR DESCRIPTION
used PublishedOrderModal component for viewing judgement order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the JudgementViewCard component to display and download judgement orders.
	- Introduced a modal for viewing judgement order details directly within the card interface.

- **Bug Fixes**
	- Improved the PublishedOrderModal to handle missing props more predictably.

- **Usability Improvements**
	- Updated the filtering logic in PublishedOrderModal for better type safety and robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->