### PR TITLE
auto filling address using google live location disabled for accused …

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/LocationComponent.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/LocationComponent.js
@@ -10,7 +10,7 @@ const getLocation = (places, code) => {
   })?.long_name;
   return location ? location : null;
 };
-const LocationComponent = ({ t, config, onLocationSelect, locationFormData, errors, mapIndex, disable = false }) => {
+const LocationComponent = ({ t, config, onLocationSelect, locationFormData, errors, mapIndex, disable = false, isAutoFilledDisabled = false }) => {
   const [coordinateData, setCoordinateData] = useState({ callbackFunc: () => {} });
   const inputs = useMemo(
     () =>
@@ -132,6 +132,7 @@ const LocationComponent = ({ t, config, onLocationSelect, locationFormData, erro
                     position={locationFormData?.[config.key]?.coordinates || {}}
                     setCoordinateData={setCoordinateData}
                     index={mapIndex}
+                    isAutoFilledDisabled={isAutoFilledDisabled}
                     onChange={(pincode, location, coordinates = {}) => {
                       setValue(
                         {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/LocationSearch.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/LocationSearch.js
@@ -347,7 +347,7 @@ const initAutocomplete = (onChange, position, isPlaceRequired = false, index) =>
 };
 
 const LocationSearch = (props) => {
-  const { setCoordinateData, isAutoFilledDisabled } = props;
+  const { setCoordinateData, isAutoFilledDisabled = false } = props;
   const [coordinates, setCoordinates] = useState({ lat: 31.6160638, lng: 74.8978579 });
   useEffect(() => {
     async function mapScriptCall() {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/LocationSearch.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/LocationSearch.js
@@ -347,7 +347,7 @@ const initAutocomplete = (onChange, position, isPlaceRequired = false, index) =>
 };
 
 const LocationSearch = (props) => {
-  const { setCoordinateData } = props;
+  const { setCoordinateData, isAutoFilledDisabled } = props;
   const [coordinates, setCoordinates] = useState({ lat: 31.6160638, lng: 74.8978579 });
   useEffect(() => {
     async function mapScriptCall() {
@@ -370,7 +370,7 @@ const LocationSearch = (props) => {
       const initMaps = () => {
         if (props.position?.latitude && props.position?.longitude) {
           getLatLng({ coords: props.position });
-        } else if (navigator?.geolocation) {
+        } else if (!isAutoFilledDisabled && navigator?.geolocation) {
           navigator.geolocation.getCurrentPosition(getLatLng, getLatLngError);
         } else {
           getLatLngError();

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/SelectComponentsMulti.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/SelectComponentsMulti.js
@@ -170,6 +170,7 @@ const SelectComponentsMulti = ({ t, config, onSelect, formData, errors }) => {
               errors={{}}
               mapIndex={data.id}
               disable={config?.disable}
+              isAutoFilledDisabled={true}
             ></LocationComponent>
           </div>
         ))}


### PR DESCRIPTION
…address

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an `isAutoFilledDisabled` option in the LocationComponent, allowing users to control auto-fill behavior for location inputs.
	- Updated LocationSearch to conditionally use the browser's geolocation API based on the new `isAutoFilledDisabled` prop.
	- Integrated the `isAutoFilledDisabled` property into the SelectComponentsMulti, disabling auto-fill functionality for the location component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->