### PR TITLE
Removal of hardcoded Value in CRM and Duplicate Validation Check in B…

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/registration/AdvocateClerkAdditionalDetail.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/registration/AdvocateClerkAdditionalDetail.js
@@ -123,13 +123,13 @@ function AdvocateClerkAdditionalDetail({ params, setParams, path, config, pathOn
       setShowErrorToast(!validateFormData(formData));
       return;
     }
-    if (formData?.clientDetails?.barRegistrationNumber) {
-      const advocateDetail = await getUserForAdvocateUUID(formData?.clientDetails?.barRegistrationNumber);
-      if (advocateDetail?.advocates[0]?.responseList?.length !== 0) {
-        setFormErrors.current("barRegistrationNumber", { message: t("DUPLICATE_BAR_REGISTRATION") });
-        return;
-      }
-    }
+    // if (formData?.clientDetails?.barRegistrationNumber) {
+    //   const advocateDetail = await getUserForAdvocateUUID(formData?.clientDetails?.barRegistrationNumber);
+    //   if (advocateDetail?.advocates[0]?.responseList?.length !== 0) {
+    //     setFormErrors.current("barRegistrationNumber", { message: t("DUPLICATE_BAR_REGISTRATION") });
+    //     return;
+    //   }
+    // }
     setParams({
       ...params,
       formData: formData,

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/components/ReviewCard.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/components/ReviewCard.js
@@ -13,7 +13,6 @@ const ReviewCard = ({ data, userInfoType }) => {
             <div className="review-card-title">{row?.title}</div>
           </div>
           <div className="review-card-action-main">
-            <div className="review-card-action-count">{row?.pendingAction} new</div>
             <div className="review-card-action-arrow">
               <span
                 onClick={() => {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/HomeView.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/HomeView.js
@@ -453,13 +453,11 @@ const HomeView = () => {
     {
       logo: <InboxIcon />,
       title: t("REVIEW_SUMMON_NOTICE_WARRANTS_TEXT"),
-      pendingAction: 40,
       actionLink: "orders/Summons&Notice",
     },
     {
       logo: <DocumentIcon />,
       title: t("VIEW_ISSUED_ORDERS"),
-      pendingAction: 11,
       actionLink: "",
     },
   ];


### PR DESCRIPTION
- Removal of Harcoded Value of 40 and 11 in Court Room Manager for new Summons
- Removal of Duplicate Bar Registration Validation Check 
https://github.com/pucardotorg/dristi/issues/1785
https://github.com/pucardotorg/dristi/issues/1787

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Disabled validation for duplicate bar registration numbers in the registration form.
	- Removed display of pending action counts in the Review Card component.
	- Eliminated `pendingAction` property from specific objects in the Home View, streamlining the data presented to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->