### PR TITLE
Temporarily not allow to create pending task for warrant payment

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrders.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrders.js
@@ -1210,7 +1210,7 @@ const GenerateOrders = () => {
     }
     if (order?.orderType === "WARRANT") {
       entityType = "order-default";
-      create = true;
+      create = false; //Temporarily not allow to create pending task for warrant payment
       assignees = [...[...new Set([...Object.keys(allAdvocates)?.flat(), ...Object.values(allAdvocates)?.flat()])]?.map((uuid) => ({ uuid }))];
       name = t("PAYMENT_PENDING_FOR_WARRANT");
       status = `PAYMENT_PENDING_FOR_WARRANT`;


### PR DESCRIPTION
Temporarily not allow to create pending task for warrant payment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated order processing logic to temporarily disallow the creation of pending tasks for warrant payments.
  
- **Bug Fixes**
	- Adjusted control flow for handling orders of type "WARRANT".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->