### PR TITLE
using filing number inplace of cnr for idgen numbers

### DIFF
--- a/backend/application/src/main/java/org/pucar/dristi/enrichment/ApplicationEnrichment.java
+++ b/backend/application/src/main/java/org/pucar/dristi/enrichment/ApplicationEnrichment.java
@@ -34,7 +34,7 @@ public class ApplicationEnrichment {
     public void enrichApplication(ApplicationRequest applicationRequest) {
         try {
             if (applicationRequest.getRequestInfo().getUserInfo() != null) {
-                String tenantId = applicationRequest.getApplication().getCnrNumber();
+                String tenantId = applicationRequest.getApplication().getFilingNumber().replace("-","");;
                 String idName = configuration.getApplicationConfig();
                 String idFormat = configuration.getApplicationFormat();
 
@@ -51,7 +51,7 @@ public class ApplicationEnrichment {
                 application.setId(UUID.randomUUID());
                 application.setCreatedDate(System.currentTimeMillis());
                 application.setIsActive(true);
-                application.setApplicationNumber(application.getCnrNumber() + "-" + applicationIdList.get(0));
+                application.setApplicationNumber(tenantId + "-" + applicationIdList.get(0));
 
                 if (application.getStatuteSection() != null) {
                     application.getStatuteSection().setId(UUID.randomUUID());

--- a/backend/application/src/main/java/org/pucar/dristi/enrichment/ApplicationEnrichment.java
+++ b/backend/application/src/main/java/org/pucar/dristi/enrichment/ApplicationEnrichment.java
@@ -51,7 +51,7 @@ public class ApplicationEnrichment {
                 application.setId(UUID.randomUUID());
                 application.setCreatedDate(System.currentTimeMillis());
                 application.setIsActive(true);
-                application.setApplicationNumber(tenantId + "-" + applicationIdList.get(0));
+                application.setApplicationNumber(applicationRequest.getApplication().getFilingNumber() + "-" + applicationIdList.get(0));
 
                 if (application.getStatuteSection() != null) {
                     application.getStatuteSection().setId(UUID.randomUUID());

--- a/backend/application/src/main/java/org/pucar/dristi/web/models/Application.java
+++ b/backend/application/src/main/java/org/pucar/dristi/web/models/Application.java
@@ -72,7 +72,7 @@ public class Application {
     private String applicationType = null;
 
     @JsonProperty("applicationNumber")
-    @Size(min = 20, max = 48)
+    @Size(min = 2, max = 48)
     private String applicationNumber = null;
 
     @JsonProperty("issuedBy")

--- a/backend/application/src/test/java/org/pucar/dristi/enrichment/ApplicationEnrichmentTest.java
+++ b/backend/application/src/test/java/org/pucar/dristi/enrichment/ApplicationEnrichmentTest.java
@@ -43,6 +43,7 @@ class ApplicationEnrichmentTest {
         RequestInfo requestInfo = RequestInfo.builder().userInfo(userInfo).build();
         Application application = Application.builder()
                 .statuteSection(new StatuteSection())
+                .filingNumber("KL-123")
                 .documents(Collections.singletonList(new Document()))
                 .build();
         applicationRequest = ApplicationRequest.builder()

--- a/backend/application/src/test/java/org/pucar/dristi/enrichment/ApplicationEnrichmentTest.java
+++ b/backend/application/src/test/java/org/pucar/dristi/enrichment/ApplicationEnrichmentTest.java
@@ -54,14 +54,18 @@ class ApplicationEnrichmentTest {
 
     @Test
     void enrichApplication() {
+        String mockedTenantId = "KL123";
+        String mockedAppNumber = "KL-123-AP1";
         when(idgenUtil.getIdList(any(), any(), any(), any(), anyInt(),any()))
-                .thenReturn(Collections.singletonList("application-number"));
+                .thenReturn(Collections.singletonList("AP1"));
 
         when(configuration.getApplicationConfig()).thenReturn("config");
         when(configuration.getApplicationFormat()).thenReturn("format");
         applicationEnrichment.enrichApplication(applicationRequest);
 
         Application application = applicationRequest.getApplication();
+        assertEquals(mockedAppNumber, application.getApplicationNumber());
+
         assertNotNull(application.getId());
         assertNotNull(application.getAuditDetails());
         assertNotNull(application.getStatuteSection().getId());
@@ -71,7 +75,7 @@ class ApplicationEnrichmentTest {
             assertNotNull(document.getId());
         });
 
-        verify(idgenUtil).getIdList(any(), any(), any(), any(), anyInt(),any());
+        verify(idgenUtil).getIdList(any(), eq(mockedTenantId), any(), any(), anyInt(),any());
     }
 
     @Test

--- a/backend/evidence/src/main/java/org/pucar/dristi/enrichment/EvidenceEnrichment.java
+++ b/backend/evidence/src/main/java/org/pucar/dristi/enrichment/EvidenceEnrichment.java
@@ -46,7 +46,7 @@ public class EvidenceEnrichment {
                     false
             );
 
-            evidenceRequest.getArtifact().setArtifactNumber(tenantId+"-"+artifactNumberList.get(0));
+            evidenceRequest.getArtifact().setArtifactNumber(evidenceRequest.getArtifact().getFilingNumber()+"-"+artifactNumberList.get(0));
 
             AuditDetails auditDetails = AuditDetails.builder()
                     .createdBy(evidenceRequest.getRequestInfo().getUserInfo().getUuid())
@@ -127,7 +127,7 @@ public class EvidenceEnrichment {
                     false
             );
 
-            evidenceRequest.getArtifact().setEvidenceNumber(tenantId+"-"+evidenceNumberList.get(0));
+            evidenceRequest.getArtifact().setEvidenceNumber(evidenceRequest.getArtifact().getFilingNumber()+"-"+evidenceNumberList.get(0));
             evidenceRequest.getArtifact().setIsEvidence(true);
         } catch (Exception e) {
             log.error("Error enriching evidence number upon update: {}", e.toString());

--- a/backend/evidence/src/test/java/org/pucar/dristi/enrichment/EvidenceEnrichmentTest.java
+++ b/backend/evidence/src/test/java/org/pucar/dristi/enrichment/EvidenceEnrichmentTest.java
@@ -70,10 +70,12 @@ public class EvidenceEnrichmentTest {
         // Ensure that comments are initialized to an empty list
         artifact.setComments(new ArrayList<>());
         evidenceRequest.setArtifact(artifact);
+        String mockTenantId = "filingnumber";
+        String mockEvidenceNumber = "filing-number-AR1";
 
         // Mock idList and ensure it contains "artifactNumber"
         List<String> idList = new ArrayList<>();
-        idList.add("artifactNumber");
+        idList.add("AR1");
         when(idgenUtil.getIdList(any(), any(), any(), any(), any(),any())).thenReturn(idList);
         when(configuration.getArtifactConfig()).thenReturn("config");
         when(configuration.getArtifactFormat()).thenReturn("testformat");
@@ -82,7 +84,8 @@ public class EvidenceEnrichmentTest {
         evidenceEnrichment.enrichEvidenceRegistration(evidenceRequest);
 
         // Verify that getIdList method is called with appropriate parameters
-        verify(idgenUtil, times(1)).getIdList(any(), any(), any(), any(), any(),any());
+        verify(idgenUtil, times(1)).getIdList(any(), eq(mockTenantId), any(), any(), any(),any());
+        assertEquals(mockEvidenceNumber, evidenceRequest.getArtifact().getArtifactNumber());
 
         // Assert that the Artifact object and its attributes are modified as expected
         assertNotNull(artifact.getAuditdetails());

--- a/backend/hearing/src/main/java/org/pucar/dristi/enrichment/HearingRegistrationEnrichment.java
+++ b/backend/hearing/src/main/java/org/pucar/dristi/enrichment/HearingRegistrationEnrichment.java
@@ -53,7 +53,7 @@ public class HearingRegistrationEnrichment {
             String idFormat = configuration.getHearingFormat();
 
             List<String> hearingIdList = idgenUtil.getIdList(hearingRequest.getRequestInfo(), tenantId, idName, idFormat, 1, false);
-            hearing.setHearingId(tenantId +"-"+hearingIdList.get(0));
+            hearing.setHearingId(hearing.getFilingNumber().get(0) +"-"+hearingIdList.get(0));
 
             if(null != hearing.getCourtCaseNumber())
                 hearing.setCaseReferenceNumber(hearing.getCourtCaseNumber());

--- a/backend/hearing/src/main/java/org/pucar/dristi/enrichment/HearingRegistrationEnrichment.java
+++ b/backend/hearing/src/main/java/org/pucar/dristi/enrichment/HearingRegistrationEnrichment.java
@@ -47,13 +47,13 @@ public class HearingRegistrationEnrichment {
                     document.setDocumentUid(document.getId());
                 });
             }
-            String tenantId = hearing.getCnrNumbers().get(0);
+            String tenantId = hearing.getFilingNumber().get(0).replace("-","");
 
             String idName = configuration.getHearingConfig();
             String idFormat = configuration.getHearingFormat();
 
             List<String> hearingIdList = idgenUtil.getIdList(hearingRequest.getRequestInfo(), tenantId, idName, idFormat, 1, false);
-            hearing.setHearingId(hearing.getCnrNumbers().get(0) +"-"+hearingIdList.get(0));
+            hearing.setHearingId(tenantId +"-"+hearingIdList.get(0));
 
             if(null != hearing.getCourtCaseNumber())
                 hearing.setCaseReferenceNumber(hearing.getCourtCaseNumber());

--- a/backend/hearing/src/test/java/org/pucar/dristi/enrichment/HearingRegistrationEnrichmentTest.java
+++ b/backend/hearing/src/test/java/org/pucar/dristi/enrichment/HearingRegistrationEnrichmentTest.java
@@ -1,311 +1,155 @@
-//package org.pucar.dristi.enrichment;
-//
-//import org.egov.common.contract.models.AuditDetails;
-//import org.egov.common.contract.models.Document;
-//import org.egov.common.contract.request.RequestInfo;
-//import org.egov.common.contract.request.User;
-//import org.egov.tracer.model.CustomException;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.MockitoAnnotations;
-//import org.pucar.dristi.config.Configuration;
-//import org.pucar.dristi.util.IdgenUtil;
-//import org.pucar.dristi.web.models.Hearing;
-//import org.pucar.dristi.web.models.HearingRequest;
-//
-//import java.util.ArrayList;
-//import java.util.List;
-//
-//import static org.junit.jupiter.api.Assertions.*;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.ArgumentMatchers.anyInt;
-//import static org.mockito.ArgumentMatchers.anyString;
-//import static org.mockito.Mockito.*;
-//import static org.pucar.dristi.config.ServiceConstants.ENRICHMENT_EXCEPTION;
-//
-//class HearingRegistrationEnrichmentTest {
-//
-//    @Mock
-//    private IdgenUtil idgenUtil;
-//
-//    @Mock
-//    private Configuration configuration;
-//
-//    @InjectMocks
-//    private HearingRegistrationEnrichment hearingRegistrationEnrichment;
-//
-//    @BeforeEach
-//    void setUp() {
-//        MockitoAnnotations.openMocks(this);
-//    }
-//
-//    @Test
-//    void enrichHearingRegistrationTest() {
-//        // Setup mock request and expected results
-//        HearingRequest hearingRequest = new HearingRequest();
-//        Hearing hearing = new Hearing();
-//        hearing.setTenantId("tenantId");
-//        Document document = new Document();
-//        List<Document> list = new ArrayList<>();
-//        list.add(document);
-//        hearing.setDocuments(list);
-//        List<String> cnr = new ArrayList<>();
-//        cnr.add("test");
-//        hearing.setCnrNumbers(cnr);
-//        hearingRequest.setHearing(hearing);
-//        RequestInfo requestInfo = new RequestInfo();
-//        User userInfo = new User();
-//        userInfo.setUuid("user-uuid");
-//        requestInfo.setUserInfo(userInfo);
-//        requestInfo.getUserInfo().setTenantId("tenantId");
-//        hearingRequest.setRequestInfo(requestInfo);
-//        List<String> idList = List.of("Hearing123");
-//        when(idgenUtil.getIdList(any(), anyString(), anyString(), any(), anyInt(),any())).thenReturn(idList);
-//
-//        // Call the method to test
-//        hearingRegistrationEnrichment.enrichHearingRegistration(hearingRequest);
-//
-//        // Verify IdgenUtil was called correctly
-//        verify(idgenUtil, times(1)).getIdList(requestInfo, "tenantId", "hearing.id", null, 1,true);
-//
-//        // Assert that the hearing has been enriched as expected
-//        assertNotNull(hearing.getId());
-//        assertNotNull(hearing.getAuditDetails());
-//        assertEquals(false, hearing.getIsActive());
-//        assertEquals("user-uuid", hearing.getAuditDetails().getCreatedBy());
-//        assertNotNull(hearing.getAuditDetails().getCreatedTime());
-//        assertEquals("user-uuid", hearing.getAuditDetails().getLastModifiedBy());
-//        assertNotNull(hearing.getAuditDetails().getLastModifiedTime());
-//        assertEquals("Hearing123", hearing.getHearingId());
-//        assertNotNull(hearing.getDocuments());
-//        hearing.getDocuments().forEach(doc -> {
-//            assertNotNull(doc.getId());
-//            assertEquals(doc.getId(), doc.getDocumentUid());
-//        });
-//    }
-//
-//    @Test
-//    void enrichHearingRegistrationNoDocumentsTest() {
-//        // Setup mock request without documents
-//        HearingRequest hearingRequest = new HearingRequest();
-//        Hearing hearing = new Hearing();
-//        hearing.setTenantId("tenantId");
-//        hearingRequest.setHearing(hearing);
-//        RequestInfo requestInfo = new RequestInfo();
-//        User userInfo = new User();
-//        userInfo.setUuid("user-uuid");
-//        userInfo.setTenantId("tenantId");
-//        requestInfo.setUserInfo(userInfo);
-//        hearingRequest.setRequestInfo(requestInfo);
-//        List<String> idList = List.of("Hearing123");
-//        when(idgenUtil.getIdList(any(), any(), anyString(), any(), anyInt(),any())).thenReturn(idList);
-//
-//        // Call the method to test
-//        hearingRegistrationEnrichment.enrichHearingRegistration(hearingRequest);
-//
-//        // Verify IdgenUtil was called correctly
-//        verify(idgenUtil, times(1)).getIdList(requestInfo, "tenantId", "hearing.id", null, 1,true);
-//
-//        // Assert that the hearing has been enriched as expected
-//        assertNotNull(hearing.getId());
-//        assertNotNull(hearing.getAuditDetails());
-//        assertEquals(false, hearing.getIsActive());
-//        assertEquals("user-uuid", hearing.getAuditDetails().getCreatedBy());
-//        assertNotNull(hearing.getAuditDetails().getCreatedTime());
-//        assertEquals("user-uuid", hearing.getAuditDetails().getLastModifiedBy());
-//        assertNotNull(hearing.getAuditDetails().getLastModifiedTime());
-//        assertEquals("Hearing123", hearing.getHearingId());
-//        assertTrue(hearing.getDocuments().isEmpty());
-//    }
-//
-//    @Test
-//    void enrichHearingRegistrationMultipleDocumentsTest() {
-//        // Setup mock request with multiple documents
-//        HearingRequest hearingRequest = new HearingRequest();
-//        Hearing hearing = new Hearing();
-//        hearing.setTenantId("tenantId");
-//        Document document1 = new Document();
-//        Document document2 = new Document();
-//        List<Document> list = new ArrayList<>();
-//        list.add(document1);
-//        list.add(document2);
-//        hearing.setDocuments(list);
-//        hearingRequest.setHearing(hearing);
-//        RequestInfo requestInfo = new RequestInfo();
-//        User userInfo = new User();
-//        userInfo.setTenantId("tenantId");
-//        userInfo.setUuid("user-uuid");
-//        requestInfo.setUserInfo(userInfo);
-//        hearingRequest.setRequestInfo(requestInfo);
-//        List<String> idList = List.of("Hearing123");
-//        when(idgenUtil.getIdList(any(), any(), anyString(), any(), anyInt(),any())).thenReturn(idList);
-//
-//        // Call the method to test
-//        hearingRegistrationEnrichment.enrichHearingRegistration(hearingRequest);
-//
-//        // Verify IdgenUtil was called correctly
-//        verify(idgenUtil, times(1)).getIdList(requestInfo, "tenantId", "hearing.id", null, 1,true);
-//
-//        // Assert that the hearing has been enriched as expected
-//        assertNotNull(hearing.getId());
-//        assertNotNull(hearing.getAuditDetails());
-//        assertEquals(false, hearing.getIsActive());
-//        assertEquals("user-uuid", hearing.getAuditDetails().getCreatedBy());
-//        assertNotNull(hearing.getAuditDetails().getCreatedTime());
-//        assertEquals("user-uuid", hearing.getAuditDetails().getLastModifiedBy());
-//        assertNotNull(hearing.getAuditDetails().getLastModifiedTime());
-//        assertEquals("Hearing123", hearing.getHearingId());
-//        assertNotNull(hearing.getDocuments());
-//        hearing.getDocuments().forEach(doc -> {
-//            assertNotNull(doc.getId());
-//            assertEquals(doc.getId(), doc.getDocumentUid());
-//        });
-//    }
-//
-//    @Test
-//    void enrichHearingRegistrationMissingFieldsInRequestInfoTest() {
-//        // Setup mock request with missing optional fields in RequestInfo
-//        HearingRequest hearingRequest = new HearingRequest();
-//        Hearing hearing = new Hearing();
-//        hearing.setTenantId("tenantId");
-//        hearingRequest.setHearing(hearing);
-//        RequestInfo requestInfo = new RequestInfo();
-//        User userInfo = new User();
-//        userInfo.setTenantId("tenantId");
-//        requestInfo.setUserInfo(userInfo);
-//        hearingRequest.setRequestInfo(requestInfo);
-//        List<String> idList = List.of("Hearing123");
-//        when(idgenUtil.getIdList(any(), any(), anyString(), any(), anyInt(),any())).thenReturn(idList);
-//
-//        // Call the method to test
-//        hearingRegistrationEnrichment.enrichHearingRegistration(hearingRequest);
-//
-//        // Verify IdgenUtil was called correctly
-//        verify(idgenUtil, times(1)).getIdList(requestInfo, "tenantId", "hearing.id", null, 1,true);
-//
-//        // Assert that the hearing has been enriched as expected
-//        assertNotNull(hearing.getId());
-//        assertNotNull(hearing.getAuditDetails());
-//        assertEquals(false, hearing.getIsActive());
-//        assertNull(hearing.getAuditDetails().getCreatedBy());
-//        assertNotNull(hearing.getAuditDetails().getCreatedTime());
-//        assertNull(hearing.getAuditDetails().getLastModifiedBy());
-//        assertNotNull(hearing.getAuditDetails().getLastModifiedTime());
-//        assertEquals("Hearing123", hearing.getHearingId());
-//    }
-//
-//    @Test
-//    void enrichHearingRegistrationThrowsCustomExceptionTest() {
-//        // Setup mock request
-//        HearingRequest hearingRequest = new HearingRequest();
-//        Hearing hearing = new Hearing();
-//        hearingRequest.setHearing(hearing);
-//        RequestInfo requestInfo = new RequestInfo();
-//        User userInfo = new User();
-//        userInfo.setUuid("user-uuid");
-//        requestInfo.setUserInfo(userInfo);
-//        hearingRequest.setRequestInfo(requestInfo);
-//
-//        // Mock IdgenUtil to throw CustomException
-//        when(idgenUtil.getIdList(any(), any(), anyString(), any(), anyInt(),any())).thenThrow(new CustomException("ID_GENERATION_ERROR", "ID generation failed"));
-//
-//        // Expect CustomException to propagate
-//        CustomException exception = assertThrows(CustomException.class, () -> hearingRegistrationEnrichment.enrichHearingRegistration(hearingRequest));
-//        assertEquals("ID_GENERATION_ERROR", exception.getCode());
-//    }
-//
-//    @Test
-//    void enrichHearingRegistrationThrowsExceptionTest() {
-//        // Setup mock request
-//        HearingRequest hearingRequest = new HearingRequest();
-//        Hearing hearing = new Hearing();
-//        hearingRequest.setHearing(hearing);
-//        RequestInfo requestInfo = new RequestInfo();
-//        User userInfo = new User();
-//        userInfo.setUuid("user-uuid");
-//        requestInfo.setUserInfo(userInfo);
-//        hearingRequest.setRequestInfo(requestInfo);
-//
-//        // Mock IdgenUtil to throw RuntimeException
-//        when(idgenUtil.getIdList(any(), any(), anyString(), any(), anyInt(),any())).thenThrow(new RuntimeException("Random error"));
-//
-//        // Expect CustomException to be thrown and check the message
-//        CustomException exception = assertThrows(CustomException.class, () -> hearingRegistrationEnrichment.enrichHearingRegistration(hearingRequest));
-//        assertEquals("ENRICHMENT_EXCEPTION", exception.getCode());
-//        assertTrue(exception.getMessage().contains("Random error"));
-//    }
-//
-//    @Test
-//    void enrichHearingApplicationUponUpdateTest() {
-//        // Setup mock request
-//        HearingRequest hearingRequest = new HearingRequest();
-//        Hearing hearing = new Hearing();
-//        AuditDetails auditDetails = AuditDetails.builder().createdBy("user-uuid-1").createdTime(System.currentTimeMillis()).lastModifiedBy("user-uuid-1").lastModifiedTime(System.currentTimeMillis()).build();
-//        hearing.setAuditDetails(auditDetails);
-//        hearingRequest.setHearing(hearing);
-//        RequestInfo requestInfo = new RequestInfo();
-//        User userInfo = new User();
-//        userInfo.setUuid("user-uuid-2");
-//        requestInfo.setUserInfo(userInfo);
-//        hearingRequest.setRequestInfo(requestInfo);
-//
-//        // Call the method to test
-//        hearingRegistrationEnrichment.enrichHearingApplicationUponUpdate(hearingRequest);
-//
-//        // Assert that the hearing has been enriched as expected
-//        assertNotNull(hearing.getAuditDetails());
-//        assertEquals("user-uuid-2", hearing.getAuditDetails().getLastModifiedBy());
-//        assertNotNull(hearing.getAuditDetails().getLastModifiedTime());
-//    }
-//
-//    @Test
-//    void enrichHearingApplicationUponUpdateExceptionTest() {
-//        // Setup mock request
-//        HearingRequest hearingRequest = new HearingRequest();
-//        hearingRequest.setHearing(null); // This should trigger an exception
-//        RequestInfo requestInfo = new RequestInfo();
-//        User userInfo = new User();
-//        userInfo.setUuid("user-uuid-2");
-//        requestInfo.setUserInfo(userInfo);
-//        hearingRequest.setRequestInfo(requestInfo);
-//
-//        // Expect CustomException due to null hearing
-//        CustomException exception = assertThrows(CustomException.class, () -> hearingRegistrationEnrichment.enrichHearingApplicationUponUpdate(hearingRequest));
-//        assertEquals("ENRICHMENT_EXCEPTION", exception.getCode());
-//        assertTrue(exception.getMessage().contains("Error in hearing enrichment service during hearing update process"));
-//    }
-//
-//    @Test
-//    void enrichHearingRegistrationNullHearingTest() {
-//        // Setup mock request
-//        HearingRequest hearingRequest = new HearingRequest();
-//        hearingRequest.setHearing(null); // This should trigger an exception
-//        RequestInfo requestInfo = new RequestInfo();
-//        User userInfo = new User();
-//        userInfo.setUuid("user-uuid");
-//        requestInfo.setUserInfo(userInfo);
-//        hearingRequest.setRequestInfo(requestInfo);
-//
-//        // Expect CustomException due to null hearing
-//        CustomException exception = assertThrows(CustomException.class, () -> hearingRegistrationEnrichment.enrichHearingRegistration(hearingRequest));
-//        assertEquals(ENRICHMENT_EXCEPTION, exception.getCode());
-//        assertTrue(exception.getMessage().contains("Error hearing in enrichment service:"));
-//    }
-//
-//    @Test
-//    void enrichHearingRegistrationNullRequestInfoTest() {
-//        // Setup mock request
-//        HearingRequest hearingRequest = new HearingRequest();
-//        Hearing hearing = new Hearing();
-//        hearing.setTenantId("tenantId");
-//        hearingRequest.setHearing(hearing);
-//        hearingRequest.setRequestInfo(null); // This should trigger an exception
-//
-//        // Expect CustomException due to null requestInfo
-//        CustomException exception = assertThrows(CustomException.class, () -> hearingRegistrationEnrichment.enrichHearingRegistration(hearingRequest));
-//        assertEquals(ENRICHMENT_EXCEPTION, exception.getCode());
-//        assertTrue(exception.getMessage().contains("Error hearing in enrichment service:"));
-//    }
-//}
+package org.pucar.dristi.enrichment;
+
+import org.egov.common.contract.models.AuditDetails;
+import org.egov.common.contract.models.Document;
+import org.egov.common.contract.request.RequestInfo;
+import org.egov.common.contract.request.User;
+import org.egov.tracer.model.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.pucar.dristi.config.Configuration;
+import org.pucar.dristi.util.IdgenUtil;
+import org.pucar.dristi.web.models.Hearing;
+import org.pucar.dristi.web.models.HearingRequest;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class HearingRegistrationEnrichmentTest {
+
+    @InjectMocks
+    private HearingRegistrationEnrichment hearingRegistrationEnrichment;
+
+    @Mock
+    private IdgenUtil idgenUtil;
+
+    @Mock
+    private Configuration configuration;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    // Helper method to create a mock HearingRequest
+    private HearingRequest createMockHearingRequest() {
+        Hearing hearing = new Hearing();
+        hearing.setAuditDetails(new AuditDetails());
+        hearing.setDocuments(Arrays.asList(new Document(), new Document()));
+        hearing.setFilingNumber(Collections.singletonList("tenant-123"));
+
+        RequestInfo requestInfo = new RequestInfo();
+        User userInfo = new User();
+        userInfo.setUuid(UUID.randomUUID().toString());
+        requestInfo.setUserInfo(userInfo);
+
+        HearingRequest hearingRequest = new HearingRequest();
+        hearingRequest.setHearing(hearing);
+        hearingRequest.setRequestInfo(requestInfo);
+
+        return hearingRequest;
+    }
+
+    @Test
+    void testEnrichHearingRegistration_Success() {
+        // Given
+        HearingRequest hearingRequest = createMockHearingRequest();
+        String mockTenantId = "tenant123";
+        String mockHearingId = "HEARING123";
+        String mockHearingNumber = mockTenantId + "-" + mockHearingId;
+
+        when(configuration.getHearingConfig()).thenReturn("hearingConfig");
+        when(configuration.getHearingFormat()).thenReturn("hearingFormat");
+        when(idgenUtil.getIdList(any(), any(), any(), any(),eq(1), eq(false))).thenReturn(Collections.singletonList(mockHearingId));
+
+        // When
+        hearingRegistrationEnrichment.enrichHearingRegistration(hearingRequest);
+
+        // Then
+        assertNotNull(hearingRequest.getHearing().getAuditDetails());
+        assertNotNull(hearingRequest.getHearing().getId());
+        assertEquals(mockHearingNumber, hearingRequest.getHearing().getHearingId());
+        verify(idgenUtil).getIdList(any(), eq(mockTenantId), eq("hearingConfig"), eq("hearingFormat"), eq(1), eq(false));
+    }
+
+    @Test
+    void testEnrichHearingRegistration_WithDocuments() {
+        // Given
+        HearingRequest hearingRequest = createMockHearingRequest();
+        when(configuration.getHearingConfig()).thenReturn("hearingConfig");
+        when(configuration.getHearingFormat()).thenReturn("hearingFormat");
+        when(idgenUtil.getIdList(any(), anyString(), anyString(), anyString(), anyInt(), anyBoolean())).thenReturn(Collections.singletonList("HEARING_ID"));
+
+        // When
+        hearingRegistrationEnrichment.enrichHearingRegistration(hearingRequest);
+
+        // Then
+        assertNotNull(hearingRequest.getHearing().getDocuments());
+        hearingRequest.getHearing().getDocuments().forEach(document -> {
+            assertNotNull(document.getId());
+            assertEquals(document.getId(), document.getDocumentUid());
+        });
+    }
+
+    @Test
+    void testEnrichHearingRegistration_ExceptionHandling() {
+        // Given
+        HearingRequest hearingRequest = createMockHearingRequest();
+        when(configuration.getHearingConfig()).thenReturn("hearingConfig");
+        when(configuration.getHearingFormat()).thenReturn("hearingFormat");
+        when(idgenUtil.getIdList(any(), anyString(), anyString(), anyString(), anyInt(), anyBoolean())).thenThrow(new RuntimeException("Test Exception"));
+
+        // When & Then
+        CustomException thrownException = assertThrows(CustomException.class, () -> {
+            hearingRegistrationEnrichment.enrichHearingRegistration(hearingRequest);
+        });
+        assertEquals("Error hearing in enrichment service: Test Exception", thrownException.getMessage());
+    }
+
+    @Test
+    void testEnrichHearingApplicationUponUpdate_Success() {
+        // Given
+        HearingRequest hearingRequest = createMockHearingRequest();
+        hearingRequest.getHearing().getDocuments().forEach(document -> document.setId(UUID.randomUUID().toString()));
+
+        // When
+        hearingRegistrationEnrichment.enrichHearingApplicationUponUpdate(hearingRequest);
+
+        // Then
+        assertNotNull(hearingRequest.getHearing().getAuditDetails().getLastModifiedTime());
+        assertNotNull(hearingRequest.getHearing().getAuditDetails().getLastModifiedBy());
+    }
+
+    @Test
+    void testEnrichHearingApplicationUponUpdate_NullDocumentIds() {
+        // Given
+        HearingRequest hearingRequest = createMockHearingRequest();
+        hearingRequest.getHearing().getDocuments().forEach(document -> document.setId(null));
+
+        // When
+        hearingRegistrationEnrichment.enrichHearingApplicationUponUpdate(hearingRequest);
+
+        // Then
+        hearingRequest.getHearing().getDocuments().forEach(document -> {
+            assertNotNull(document.getId());
+        });
+    }
+
+    @Test
+    void testEnrichHearingApplicationUponUpdate_ExceptionHandling() {
+        // Given
+        HearingRequest hearingRequest = createMockHearingRequest();
+        hearingRequest.setHearing(null);
+        // When & Then
+        assertThrows(CustomException.class, () -> {
+            hearingRegistrationEnrichment.enrichHearingApplicationUponUpdate(hearingRequest);
+        });
+    }
+}

--- a/backend/hearing/src/test/java/org/pucar/dristi/enrichment/HearingRegistrationEnrichmentTest.java
+++ b/backend/hearing/src/test/java/org/pucar/dristi/enrichment/HearingRegistrationEnrichmentTest.java
@@ -43,7 +43,7 @@ class HearingRegistrationEnrichmentTest {
         Hearing hearing = new Hearing();
         hearing.setAuditDetails(new AuditDetails());
         hearing.setDocuments(Arrays.asList(new Document(), new Document()));
-        hearing.setFilingNumber(Collections.singletonList("tenant123"));
+        hearing.setFilingNumber(Collections.singletonList("tenant-123"));
 
         RequestInfo requestInfo = new RequestInfo();
         User userInfo = new User();
@@ -63,7 +63,7 @@ class HearingRegistrationEnrichmentTest {
         HearingRequest hearingRequest = createMockHearingRequest();
         String mockTenantId = "tenant123";
         String mockHearingId = "HEARING123";
-        String mockHearingNumber = mockTenantId + "-" + mockHearingId;
+        String mockHearingNumber = "tenant-123" + "-" + mockHearingId;
 
         when(configuration.getHearingConfig()).thenReturn("hearingConfig");
         when(configuration.getHearingFormat()).thenReturn("hearingFormat");

--- a/backend/hearing/src/test/java/org/pucar/dristi/enrichment/HearingRegistrationEnrichmentTest.java
+++ b/backend/hearing/src/test/java/org/pucar/dristi/enrichment/HearingRegistrationEnrichmentTest.java
@@ -43,7 +43,7 @@ class HearingRegistrationEnrichmentTest {
         Hearing hearing = new Hearing();
         hearing.setAuditDetails(new AuditDetails());
         hearing.setDocuments(Arrays.asList(new Document(), new Document()));
-        hearing.setFilingNumber(Collections.singletonList("tenant-123"));
+        hearing.setFilingNumber(Collections.singletonList("tenant123"));
 
         RequestInfo requestInfo = new RequestInfo();
         User userInfo = new User();

--- a/backend/order/src/main/java/org/pucar/dristi/enrichment/OrderRegistrationEnrichment.java
+++ b/backend/order/src/main/java/org/pucar/dristi/enrichment/OrderRegistrationEnrichment.java
@@ -30,7 +30,7 @@ public class OrderRegistrationEnrichment {
     public void enrichOrderRegistration(OrderRequest orderRequest) {
         try {
             if (orderRequest.getRequestInfo().getUserInfo() != null) {
-                String tenantId = orderRequest.getOrder().getCnrNumber();
+                String tenantId = orderRequest.getOrder().getFilingNumber().replace("-","");
                 String idName = configuration.getOrderConfig();
                 String idFormat = configuration.getOrderFormat();
 
@@ -50,7 +50,7 @@ public class OrderRegistrationEnrichment {
                     });
                 }
 
-                String orderNumber = orderRequest.getOrder().getCnrNumber()+"-"+orderRegistrationIdList.get(0);
+                String orderNumber = tenantId+"-"+orderRegistrationIdList.get(0);
                 orderRequest.getOrder().setOrderNumber(orderNumber);
                 orderRequest.getOrder().setCreatedDate(System.currentTimeMillis());
             }

--- a/backend/order/src/main/java/org/pucar/dristi/enrichment/OrderRegistrationEnrichment.java
+++ b/backend/order/src/main/java/org/pucar/dristi/enrichment/OrderRegistrationEnrichment.java
@@ -50,7 +50,7 @@ public class OrderRegistrationEnrichment {
                     });
                 }
 
-                String orderNumber = tenantId+"-"+orderRegistrationIdList.get(0);
+                String orderNumber = orderRequest.getOrder().getFilingNumber()+"-"+orderRegistrationIdList.get(0);
                 orderRequest.getOrder().setOrderNumber(orderNumber);
                 orderRequest.getOrder().setCreatedDate(System.currentTimeMillis());
             }

--- a/backend/order/src/main/java/org/pucar/dristi/web/models/Order.java
+++ b/backend/order/src/main/java/org/pucar/dristi/web/models/Order.java
@@ -52,11 +52,11 @@ public class Order {
     private String hearingNumber = null;
 
     @JsonProperty("orderNumber")
-    @Size(min = 20, max = 256)
+    @Size(min = 2, max = 256)
     private String orderNumber = null;
 
     @JsonProperty("linkedOrderNumber")
-    @Size(min = 20, max = 256)
+    @Size(min = 2, max = 256)
     private String linkedOrderNumber = null;
 
     @JsonProperty("createdDate")

--- a/backend/order/src/test/java/org/pucar/dristi/enrichment/OrderRegistrationEnrichmentTest.java
+++ b/backend/order/src/test/java/org/pucar/dristi/enrichment/OrderRegistrationEnrichmentTest.java
@@ -1,6 +1,5 @@
 package org.pucar.dristi.enrichment;
 
-import org.egov.common.contract.models.AuditDetails;
 import org.egov.common.contract.request.RequestInfo;
 import org.egov.common.contract.request.User;
 import org.egov.tracer.model.CustomException;
@@ -19,6 +18,8 @@ import java.util.Collections;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 class OrderRegistrationEnrichmentTest {
@@ -37,71 +38,101 @@ class OrderRegistrationEnrichmentTest {
         MockitoAnnotations.openMocks(this);
     }
 
-//    @Test
-//    void testEnrichOrderRegistration() {
-//        User user = User.builder().uuid(UUID.randomUUID().toString()).build();
-//        RequestInfo requestInfo = RequestInfo.builder().userInfo(user).build();
-//        Order order = Order.builder().tenantId("tenant-123").statuteSection(new StatuteSection()).build();
-//        OrderRequest orderRequest = OrderRequest.builder().requestInfo(requestInfo).order(order).build();
-//
-//        when(idgenUtil.getIdList(any(), anyString(), anyString(), any(), anyInt(),any()))
-//                .thenReturn(Collections.singletonList("ORD-2024-0001"));
-//
-//        orderRegistrationEnrichment.enrichOrderRegistration(orderRequest);
-//
-//        assertNotNull(orderRequest.getOrder().getId());
-//        assertNotNull(orderRequest.getOrder().getStatuteSection().getId());
-//        assertNotNull(orderRequest.getOrder().getAuditDetails());
-//        assertEquals("ORD-2024-0001", orderRequest.getOrder().getOrderNumber());
-//        assertNotNull(orderRequest.getOrder().getAuditDetails().getCreatedBy());
-//        assertNotNull(orderRequest.getOrder().getAuditDetails().getCreatedTime());
-//        assertNotNull(orderRequest.getOrder().getAuditDetails().getLastModifiedBy());
-//        assertNotNull(orderRequest.getOrder().getAuditDetails().getLastModifiedTime());
-//    }
+    private OrderRequest createMockOrderRequest() {
+        OrderRequest orderRequest = new OrderRequest();
+        Order order = new Order();
+        order.setStatuteSection(new StatuteSection());
+        order.setFilingNumber("tenant123");
+        orderRequest.setOrder(order);
+        orderRequest.setRequestInfo(new RequestInfo());
+        orderRequest.getRequestInfo().setUserInfo(new User());
+        orderRequest.getRequestInfo().getUserInfo().setUuid(UUID.randomUUID().toString());
 
-    @Test
-    void testEnrichOrderRegistrationUponUpdate() {
-        User user = User.builder().uuid(UUID.randomUUID().toString()).build();
-        RequestInfo requestInfo = RequestInfo.builder().userInfo(user).build();
-        AuditDetails auditDetails = AuditDetails.builder().createdBy(user.getUuid()).createdTime(System.currentTimeMillis()).build();
-        Order order = Order.builder().tenantId("tenant-123").auditDetails(auditDetails).build();
-        OrderRequest orderRequest = OrderRequest.builder().requestInfo(requestInfo).order(order).build();
-
-        orderRegistrationEnrichment.enrichOrderRegistrationUponUpdate(orderRequest);
-
-        assertNotNull(orderRequest.getOrder().getAuditDetails().getLastModifiedBy());
-        assertNotNull(orderRequest.getOrder().getAuditDetails().getLastModifiedTime());
-        assertEquals(user.getUuid(), orderRequest.getOrder().getAuditDetails().getLastModifiedBy());
+        return orderRequest;
     }
 
-//    @Test
-//    void testEnrichOrderRegistrationCustomException() {
-//        User user = User.builder().uuid(UUID.randomUUID().toString()).build();
-//        RequestInfo requestInfo = RequestInfo.builder().userInfo(user).build();
-//        Order order = Order.builder().tenantId("tenant-123").statuteSection(new StatuteSection()).build();
-//        OrderRequest orderRequest = OrderRequest.builder().requestInfo(requestInfo).order(order).build();
-//
-//        when(idgenUtil.getIdList(any(), anyString(), anyString(), any(), anyInt(),any()))
-//                .thenThrow(new CustomException("IDGEN_ERROR", "Error generating ID"));
-//
-//        Exception exception = assertThrows(CustomException.class, () -> {
-//            orderRegistrationEnrichment.enrichOrderRegistration(orderRequest);
-//        });
-//
-//        assertEquals("Error generating ID", exception.getMessage());
-//    }
+    @Test
+    void testEnrichOrderRegistration_Success() {
+        // Given
+        OrderRequest orderRequest = createMockOrderRequest();  // Ensure mock request is fully initialized
+        String mockTenantId = "tenant123";
+        String mockOrderId = "ORDER123";  // Mock ID to return
+        String mockOrderNumber = mockTenantId + "-" + mockOrderId;
+
+        // Mock configuration and ID generation utility behavior
+        when(configuration.getOrderConfig()).thenReturn("orderConfigValue");  // Mock return for getOrderConfig
+        when(configuration.getOrderFormat()).thenReturn("orderFormatValue");  // Mock return for getOrderFormat
+        when(idgenUtil.getIdList(any(),any(), any(),any(), eq(1), eq(false)))
+                .thenReturn(Collections.singletonList(mockOrderId));  // Return list with one element
+
+        // When
+        orderRegistrationEnrichment.enrichOrderRegistration(orderRequest);
+
+        // Then
+        // Check that enrichment added correct fields
+        assertNotNull(orderRequest.getOrder().getAuditDetails());
+        assertNotNull(orderRequest.getOrder().getId());
+        assertEquals(mockOrderNumber, orderRequest.getOrder().getOrderNumber());
+        assertNotNull(orderRequest.getOrder().getStatuteSection().getId());
+
+        // Verify that the ID generation utility was called
+        verify(idgenUtil).getIdList(any(), eq(mockTenantId), any(), any(), eq(1), eq(false));
+    }
+
 
     @Test
-    void testEnrichOrderRegistrationUponUpdateException() {
-        User user = User.builder().uuid(UUID.randomUUID().toString()).build();
-        RequestInfo requestInfo = RequestInfo.builder().userInfo(user).build();
-        Order order = Order.builder().tenantId("tenant-123").build(); // Missing auditDetails
-        OrderRequest orderRequest = OrderRequest.builder().requestInfo(requestInfo).order(order).build();
+    void testEnrichOrderRegistration_WithoutUserInfo_ShouldDoNothing() {
+        // Given
+        OrderRequest orderRequest = new OrderRequest();
+        orderRequest.setRequestInfo(new RequestInfo());
+        // When
+        orderRegistrationEnrichment.enrichOrderRegistration(orderRequest);
 
+        // Then
+        verify(idgenUtil, never()).getIdList(any(), any(), any(), any(), anyInt(), anyBoolean());
+    }
+
+    @Test
+    void testEnrichOrderRegistration_ThrowsCustomException() {
+        // Given
+        OrderRequest orderRequest = createMockOrderRequest();
+
+        when(configuration.getOrderConfig()).thenReturn("orderConfig");
+        when(configuration.getOrderFormat()).thenReturn("orderFormat");
+        when(idgenUtil.getIdList(any(), anyString(), anyString(), anyString(), eq(1), eq(false)))
+                .thenThrow(new CustomException("IDGEN_ERROR", "Error generating ID"));
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            orderRegistrationEnrichment.enrichOrderRegistration(orderRequest);
+        });
+        assertEquals("IDGEN_ERROR", exception.getCode());
+        assertEquals("Error generating ID", exception.getMessage());
+    }
+
+    @Test
+    void testEnrichOrderRegistrationUponUpdate_Success() {
+        // Given
+        OrderRequest orderRequest = createMockOrderRequest();
+        orderRequest.getOrder().setAuditDetails(new org.egov.common.contract.models.AuditDetails());
+
+        // When
+        orderRegistrationEnrichment.enrichOrderRegistrationUponUpdate(orderRequest);
+
+        // Then
+        assertNotNull(orderRequest.getOrder().getAuditDetails().getLastModifiedTime());
+        assertNotNull(orderRequest.getOrder().getAuditDetails().getLastModifiedBy());
+    }
+
+    @Test
+    void testEnrichOrderRegistrationUponUpdate_ThrowsCustomException() {
+        // Given
+        OrderRequest orderRequest = new OrderRequest();  // Missing required data
+
+        // When & Then
         CustomException exception = assertThrows(CustomException.class, () -> {
             orderRegistrationEnrichment.enrichOrderRegistrationUponUpdate(orderRequest);
         });
-
-        assertEquals("Error in order enrichment service during order update process: Cannot invoke \"org.egov.common.contract.models.AuditDetails.setLastModifiedTime(java.lang.Long)\" because the return value of \"org.pucar.dristi.web.models.Order.getAuditDetails()\" is null", exception.getMessage());
+        assertEquals("ENRICHMENT_EXCEPTION", exception.getCode());
     }
 }

--- a/backend/order/src/test/java/org/pucar/dristi/enrichment/OrderRegistrationEnrichmentTest.java
+++ b/backend/order/src/test/java/org/pucar/dristi/enrichment/OrderRegistrationEnrichmentTest.java
@@ -42,7 +42,7 @@ class OrderRegistrationEnrichmentTest {
         OrderRequest orderRequest = new OrderRequest();
         Order order = new Order();
         order.setStatuteSection(new StatuteSection());
-        order.setFilingNumber("tenant123");
+        order.setFilingNumber("tenant-123");
         orderRequest.setOrder(order);
         orderRequest.setRequestInfo(new RequestInfo());
         orderRequest.getRequestInfo().setUserInfo(new User());
@@ -57,7 +57,7 @@ class OrderRegistrationEnrichmentTest {
         OrderRequest orderRequest = createMockOrderRequest();  // Ensure mock request is fully initialized
         String mockTenantId = "tenant123";
         String mockOrderId = "ORDER123";  // Mock ID to return
-        String mockOrderNumber = mockTenantId + "-" + mockOrderId;
+        String mockOrderNumber = "tenant-123" + "-" + mockOrderId;
 
         // Mock configuration and ID generation utility behavior
         when(configuration.getOrderConfig()).thenReturn("orderConfigValue");  // Mock return for getOrderConfig

--- a/backend/task/src/main/java/org/pucar/dristi/enrichment/TaskRegistrationEnrichment.java
+++ b/backend/task/src/main/java/org/pucar/dristi/enrichment/TaskRegistrationEnrichment.java
@@ -33,7 +33,7 @@ public class TaskRegistrationEnrichment {
     public void enrichTaskRegistration(TaskRequest taskRequest) {
         try {
             Task task = taskRequest.getTask();
-            String tenantId = task.getCnrNumber();
+            String tenantId = task.getFilingNumber().replace("-","");
 
             String idName = config.getTaskConfig();
             String idFormat = config.getTaskFormat();
@@ -75,7 +75,7 @@ public class TaskRegistrationEnrichment {
             }
             task.getAmount().setId(UUID.randomUUID());
             task.setCreatedDate(System.currentTimeMillis());
-            task.setTaskNumber(task.getCnrNumber() +"-"+taskRegistrationIdList.get(0));
+            task.setTaskNumber(tenantId +"-"+taskRegistrationIdList.get(0));
 
         } catch (Exception e) {
             log.error("Error enriching task application :: {}", e.toString());

--- a/backend/task/src/main/java/org/pucar/dristi/enrichment/TaskRegistrationEnrichment.java
+++ b/backend/task/src/main/java/org/pucar/dristi/enrichment/TaskRegistrationEnrichment.java
@@ -75,7 +75,7 @@ public class TaskRegistrationEnrichment {
             }
             task.getAmount().setId(UUID.randomUUID());
             task.setCreatedDate(System.currentTimeMillis());
-            task.setTaskNumber(tenantId +"-"+taskRegistrationIdList.get(0));
+            task.setTaskNumber(taskRequest.getTask().getFilingNumber() +"-"+taskRegistrationIdList.get(0));
 
         } catch (Exception e) {
             log.error("Error enriching task application :: {}", e.toString());

--- a/backend/task/src/test/java/org/pucar/dristi/enrichment/TaskRegistrationEnrichmentTest.java
+++ b/backend/task/src/test/java/org/pucar/dristi/enrichment/TaskRegistrationEnrichmentTest.java
@@ -6,10 +6,9 @@ import org.egov.common.contract.request.User;
 import org.egov.tracer.model.CustomException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.MockitoAnnotations;
 import org.pucar.dristi.config.Configuration;
 import org.pucar.dristi.util.IdgenUtil;
 import org.pucar.dristi.web.models.Amount;
@@ -17,81 +16,141 @@ import org.pucar.dristi.web.models.Task;
 import org.pucar.dristi.web.models.TaskRequest;
 
 import java.util.Collections;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
-import static org.pucar.dristi.config.ServiceConstants.ENRICHMENT_EXCEPTION;
 
-@ExtendWith(MockitoExtension.class)
-public class TaskRegistrationEnrichmentTest {
+class TaskRegistrationEnrichmentTest {
+
+    @InjectMocks
+    private TaskRegistrationEnrichment taskRegistrationEnrichment;
 
     @Mock
     private IdgenUtil idgenUtil;
 
     @Mock
-    private Configuration config;
-
-    @InjectMocks
-    private TaskRegistrationEnrichment taskRegistrationEnrichment;
-
-    private TaskRequest taskRequest;
-    private Task task;
-    private RequestInfo requestInfo;
-    private User userInfo;
+    private Configuration configuration;
 
     @BeforeEach
     void setUp() {
-        userInfo = User.builder().uuid("user-uuid").build();
-        requestInfo = RequestInfo.builder().userInfo(userInfo).build();
-        task = new Task();
-        task.setTenantId("tenant-id");
-        task.setFilingNumber("KL-123");
+        MockitoAnnotations.openMocks(this);
+    }
+
+    // Helper method to create a mock TaskRequest
+    private TaskRequest createMockTaskRequest() {
+        Task task = new Task();
         task.setAmount(new Amount());
-        taskRequest = new TaskRequest();
-        taskRequest.setRequestInfo(requestInfo);
+        task.setAuditDetails(new AuditDetails());
+        task.setFilingNumber("FIL123");
+
+        RequestInfo requestInfo = new RequestInfo();
+        User userInfo = new User();
+        userInfo.setUuid(UUID.randomUUID().toString());
+        requestInfo.setUserInfo(userInfo);
+
+        TaskRequest taskRequest = new TaskRequest();
         taskRequest.setTask(task);
-    }
+        taskRequest.setRequestInfo(requestInfo);
 
-//    @Test
-//    void testEnrichTaskRegistrationSuccess() {
-//        when(idgenUtil.getIdList(any(), any(), any(), any(), anyInt(),any())).thenReturn(Collections.singletonList("task-id"));
-//        when(config.getTaskNumber()).thenReturn("task-number");
-//
-//        taskRegistrationEnrichment.enrichTaskRegistration(taskRequest);
-//
-//        assertNotNull(task.getId());
-//        assertNotNull(task.getAuditDetails());
-//        assertEquals("task-id", task.getTaskNumber());
-//    }
-
-    @Test
-    void testEnrichTaskRegistrationException() {
-        when(idgenUtil.getIdList(any(), any(), any(), any(), anyInt(),any())).thenThrow(new RuntimeException("Error"));
-
-        CustomException exception = assertThrows(CustomException.class, () -> taskRegistrationEnrichment.enrichTaskRegistration(taskRequest));
-        assertEquals(ENRICHMENT_EXCEPTION, exception.getCode());
-        assertEquals("Error", exception.getMessage());
-        verify(idgenUtil, times(1)).getIdList(any(), any(), any(), any(), anyInt(),any());
+        return taskRequest;
     }
 
     @Test
-    void testEnrichCaseApplicationUponUpdateSuccess() {
-        AuditDetails auditDetails = AuditDetails.builder().build();
-        task.setAuditDetails(auditDetails);
+    void testEnrichTaskRegistration_Success() {
+        // Given
+        TaskRequest taskRequest = createMockTaskRequest();
+        String mockTenantId = "FIL123";
+        String mockTaskId = "TASK123";
+        String mockTaskNumber = mockTenantId + "-" + mockTaskId;
 
+        when(configuration.getTaskConfig()).thenReturn("taskConfigValue");
+        when(configuration.getTaskFormat()).thenReturn("taskFormatValue");
+        when(idgenUtil.getIdList(any(), any(),any(),any(), eq(1), eq(false)))
+                .thenReturn(Collections.singletonList(mockTaskId));
+
+        // When
+        taskRegistrationEnrichment.enrichTaskRegistration(taskRequest);
+
+        // Then
+        assertNotNull(taskRequest.getTask().getAuditDetails());
+        assertNotNull(taskRequest.getTask().getId());
+        assertEquals(mockTaskNumber, taskRequest.getTask().getTaskNumber());
+        verify(idgenUtil).getIdList(any(), eq(mockTenantId), eq("taskConfigValue"), eq("taskFormatValue"), eq(1), eq(false));
+    }
+
+    @Test
+    void testEnrichCaseApplicationUponUpdate_Success() {
+        // Given
+        TaskRequest taskRequest = createMockTaskRequest();
+        taskRequest.getTask().setAuditDetails(new AuditDetails());
+
+
+        // When
         taskRegistrationEnrichment.enrichCaseApplicationUponUpdate(taskRequest);
 
-        assertEquals("user-uuid", task.getAuditDetails().getLastModifiedBy());
-        assertNotNull(task.getAuditDetails().getLastModifiedTime());
+        // Then
+        assertNotNull(taskRequest.getTask().getAuditDetails().getLastModifiedTime());
+        assertNotNull(taskRequest.getTask().getAuditDetails().getLastModifiedBy());
     }
 
     @Test
-    void testEnrichCaseApplicationUponUpdateException() {
-        task.setAuditDetails(null); // This will cause NullPointerException
+    void testEnrichCaseApplicationUponUpdate_NoDocuments() {
+        // Given
+        TaskRequest taskRequest = createMockTaskRequest();
+        taskRequest.getTask().setDocuments(null); // No documents
 
-        CustomException exception = assertThrows(CustomException.class, () -> taskRegistrationEnrichment.enrichCaseApplicationUponUpdate(taskRequest));
-        assertEquals(ENRICHMENT_EXCEPTION, exception.getCode());
-        assertTrue(exception.getMessage().contains("Exception in task enrichment service during task update process"));
+        // When
+        taskRegistrationEnrichment.enrichCaseApplicationUponUpdate(taskRequest);
+
+        // Then
+        assertNotNull(taskRequest.getTask().getAuditDetails().getLastModifiedTime());
+        assertNotNull(taskRequest.getTask().getAuditDetails().getLastModifiedBy());
+        // Ensure no exception is thrown when documents are null
+    }
+
+    @Test
+    void testEnrichCaseApplicationUponUpdate_NonNullDocumentIds() {
+        // Given
+        TaskRequest taskRequest = createMockTaskRequest();
+        taskRequest.getTask().getDocuments().forEach(document -> document.setId(UUID.randomUUID().toString()));
+
+        // When
+        taskRegistrationEnrichment.enrichCaseApplicationUponUpdate(taskRequest);
+
+        // Then
+        // Ensure no document is updated since all documents already have an ID
+        taskRequest.getTask().getDocuments().forEach(document -> assertNotNull(document.getId()));
+    }
+
+    @Test
+    void testEnrichCaseApplicationUponUpdate_NullDocumentIds() {
+        // Given
+        TaskRequest taskRequest = createMockTaskRequest();
+        taskRequest.getTask().getDocuments().forEach(document -> document.setId(null));
+
+        // When
+        taskRegistrationEnrichment.enrichCaseApplicationUponUpdate(taskRequest);
+
+        // Then
+        // Ensure all documents without IDs are assigned new UUIDs
+        taskRequest.getTask().getDocuments().forEach(document -> {
+            assertNotNull(document.getId());
+            assertEquals(document.getId(), document.getDocumentUid());
+        });
+    }
+
+    @Test
+    void testEnrichCaseApplicationUponUpdate_ExceptionThrown() {
+        // Given
+        TaskRequest taskRequest = createMockTaskRequest();
+
+        taskRequest.setTask(null);
+        // When & Then
+        assertThrows(CustomException.class, () -> {
+            taskRegistrationEnrichment.enrichCaseApplicationUponUpdate(taskRequest);
+        });
     }
 }

--- a/backend/task/src/test/java/org/pucar/dristi/enrichment/TaskRegistrationEnrichmentTest.java
+++ b/backend/task/src/test/java/org/pucar/dristi/enrichment/TaskRegistrationEnrichmentTest.java
@@ -44,7 +44,7 @@ class TaskRegistrationEnrichmentTest {
         Task task = new Task();
         task.setAmount(new Amount());
         task.setAuditDetails(new AuditDetails());
-        task.setFilingNumber("FIL123");
+        task.setFilingNumber("FIL-123");
 
         RequestInfo requestInfo = new RequestInfo();
         User userInfo = new User();
@@ -64,7 +64,7 @@ class TaskRegistrationEnrichmentTest {
         TaskRequest taskRequest = createMockTaskRequest();
         String mockTenantId = "FIL123";
         String mockTaskId = "TASK123";
-        String mockTaskNumber = mockTenantId + "-" + mockTaskId;
+        String mockTaskNumber = "FIL-123" + "-" + mockTaskId;
 
         when(configuration.getTaskConfig()).thenReturn("taskConfigValue");
         when(configuration.getTaskFormat()).thenReturn("taskFormatValue");

--- a/backend/task/src/test/java/org/pucar/dristi/enrichment/TaskRegistrationEnrichmentTest.java
+++ b/backend/task/src/test/java/org/pucar/dristi/enrichment/TaskRegistrationEnrichmentTest.java
@@ -46,6 +46,7 @@ public class TaskRegistrationEnrichmentTest {
         requestInfo = RequestInfo.builder().userInfo(userInfo).build();
         task = new Task();
         task.setTenantId("tenant-id");
+        task.setFilingNumber("KL-123");
         task.setAmount(new Amount());
         taskRequest = new TaskRequest();
         taskRequest.setRequestInfo(requestInfo);


### PR DESCRIPTION
using filing number inplace of cnr for idgen numbers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced tenant ID retrieval and application data enrichment processes across several components, improving accuracy in application, order, hearing, and task registrations.
	- Updated logic for generating unique identifiers for evidence and artifacts, now incorporating `filingNumber`.
	- Adjusted validation constraints for `applicationNumber` to allow shorter values.

- **Bug Fixes**
	- Improved error handling for missing court IDs in application enrichment to ensure robust data processing.

- **Tests**
	- Updated test setups to include new `filingNumber` fields for better test accuracy and reliability.
	- Expanded test coverage for order and task registration enrichment, including scenarios for exceptions and null document IDs.
	- Complete rewrite of test classes for `HearingRegistrationEnrichment` and `TaskRegistrationEnrichment` for improved clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->