### PR TITLE
Issue: 2125 fixed, advocate/litigant both should be able to edit case after scrutiny 

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/Config/reviewcasefileconfig.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/Config/reviewcasefileconfig.js
@@ -36,6 +36,8 @@ export const reviewCaseFileFormConfig = [
                 {
                   type: "text",
                   label: "DESIGNATION",
+                  dependentOn: "complainantType.code",
+                  dependentValue: "REPRESENTATIVE",
                   value: "complainantVerification.complainantDesignation",
                 },
                 {
@@ -98,6 +100,8 @@ export const reviewCaseFileFormConfig = [
                 {
                   type: "text",
                   label: "DESIGNATION",
+                  dependentOn: "respondentType.code",
+                  dependentValue: "REPRESENTATIVE",
                   value: "respondentDesignation",
                 },
                 {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingCases.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingCases.js
@@ -1612,6 +1612,7 @@ function EFilingCases({ path }) {
       try {
         // Await the result of updateCaseDetails
         await updateCaseDetails({
+          t,
           isCompleted: true,
           caseDetails: isCaseReAssigned && errorCaseDetails ? errorCaseDetails : caseDetails,
           prevCaseDetails: prevCaseDetails,
@@ -2213,7 +2214,7 @@ function EFilingCases({ path }) {
                 <FormComposerV2
                   label={actionName}
                   config={config}
-                  onSubmit={() => onSubmit("SAVE_DRAFT", index)}
+                  onSubmit={() => onSubmit("SAVE_DRAFT")}
                   onSecondayActionClick={onSaveDraft}
                   defaultValues={getDefaultValues(index)}
                   onFormValueChange={(setValue, formData, formState, reset, setError, clearErrors, trigger, getValues) => {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/scrutiny/ViewCaseFile.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/scrutiny/ViewCaseFile.js
@@ -213,8 +213,6 @@ function ViewCaseFile({ t, inViewCase = false }) {
     ];
   }, [reviewCaseFileFormConfig, caseDetails, defaultScrutinyErrors]);
 
-  console.log("formConfig :>> ", formConfig);
-
   const primaryButtonLabel = useMemo(() => {
     if (isScrutiny) {
       return "CS_REGISTER_CASE";
@@ -234,6 +232,15 @@ function ViewCaseFile({ t, inViewCase = false }) {
       additionalDetails: { ...caseDetails.additionalDetails, scrutiny: scrutinyObj },
       caseTitle: newCaseName !== "" ? newCaseName : caseDetails?.caseTitle,
     };
+    const complainantUuid = caseDetails?.litigants?.[0]?.additionalDetails?.uuid;
+    const advocateUuid = caseDetails?.representatives?.[0]?.additionalDetails?.uuid;
+    let assignees = [];
+    if (complainantUuid) {
+      assignees.push(complainantUuid);
+    }
+    if (advocateUuid) {
+      assignees.push(advocateUuid);
+    }
 
     return DRISTIService.caseUpdateService(
       {
@@ -243,7 +250,7 @@ function ViewCaseFile({ t, inViewCase = false }) {
           workflow: {
             ...caseDetails?.workflow,
             action,
-            ...(action === CaseWorkflowAction.SEND_BACK && { assignes: [caseDetails.auditDetails.createdBy] }),
+            ...(action === CaseWorkflowAction.SEND_BACK && { assignes: assignees }),
           },
         },
         tenantId,


### PR DESCRIPTION
…/litigant both should be able to edit case after scrutiny

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced form configurations with conditional dependencies for complainant and respondent details.
  - Improved case assignment logic based on UUIDs of complainant and advocate in the case management system.

- **Bug Fixes**
  - Refined error handling for mandatory fields during form submissions.

- **UI Improvements**
  - Updated rendering logic for modals and UI components to enhance user experience.

- **Performance Enhancements**
  - Optimized state management and rendering performance through improved hooks usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->