### PR TITLE
 [BUG 2018 in develop branch] filtering out hearings with status "ABATED"

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/NextHearingCard.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/NextHearingCard.js
@@ -33,7 +33,7 @@ const NextHearingCard = ({ caseData, width }) => {
   );
 
   const scheduledHearing = hearingRes?.HearingList?.filter(
-    (hearing) => ![HearingWorkflowState.COMPLETED, HearingWorkflowState?.OPTOUT].includes(hearing?.status)
+    (hearing) => ![HearingWorkflowState.COMPLETED, HearingWorkflowState?.OPTOUT, HearingWorkflowState?.ABATED].includes(hearing?.status)
   ).sort((hearing1, hearing2) => hearing1.startTime - hearing2.startTime)[0];
 
   const formattedTime = () => {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/components/UpComingHearing.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/components/UpComingHearing.js
@@ -3,6 +3,7 @@ import { Loader } from "@egovernments/digit-ui-react-components";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { CalenderIcon } from "../../homeIcon";
+import { HearingWorkflowState } from "@egovernments/digit-ui-module-orders/src/utils/hearingWorkflow";
 
 function timeInMillisToDateTime(timeInMillis) {
   if (!timeInMillis || typeof timeInMillis !== "number") {
@@ -287,9 +288,11 @@ const UpcomingHearings = ({ t, userInfoType, ...props }) => {
   const hearingCountsByType = useMemo(() => {
     const hearingCountsByType = {};
 
-    earliestHearingSlot?.hearings.forEach((hearing) => {
-      hearingCountsByType[hearing.hearingType] = (hearingCountsByType[hearing.hearingType] || 0) + 1;
-    });
+    earliestHearingSlot?.hearings
+      .filter((hearing) => ![HearingWorkflowState.COMPLETED, HearingWorkflowState?.OPTOUT, HearingWorkflowState?.ABATED].includes(hearing?.status))
+      .forEach((hearing) => {
+        hearingCountsByType[hearing.hearingType] = (hearingCountsByType[hearing.hearingType] || 0) + 1;
+      });
 
     return Object.keys(hearingCountsByType)
       .map((hearingType) => {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/utils/hearingWorkflow.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/utils/hearingWorkflow.js
@@ -9,4 +9,5 @@ export const HearingWorkflowState = {
   OPTOUT: "OPT_OUT",
   INPROGRESS: "IN_PROGRESS",
   COMPLETED: "COMPLETED",
+  ABATED: "ABATED",
 };


### PR DESCRIPTION
https://github.com/pucardotorg/dristi/issues/2018

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new hearing state, `ABATED`, enhancing the existing workflow states.
- **Improvements**
	- Updated filtering logic in the Next Hearing Card to refine which hearings are considered scheduled by excluding the `ABATED` state.
	- Enhanced the Upcoming Hearings component to exclude hearings with statuses of `COMPLETED`, `OPTOUT`, or `ABATED` from the count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->