### PR TITLE
clearing out error when a party is chosen in summons/develop order

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/components/SummonsOrderComponent.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/components/SummonsOrderComponent.js
@@ -53,7 +53,7 @@ const RenderDeliveryChannels = ({ partyDetails, deliveryChannels, handleCheckbox
   );
 };
 
-const SummonsOrderComponent = ({ t, config, formData, onSelect }) => {
+const SummonsOrderComponent = ({ t, config, formData, onSelect, clearErrors }) => {
   const urlParams = new URLSearchParams(window.location.search);
   const filingNumber = urlParams.get("filingNumber");
   const tenantId = Digit.ULBService.getCurrentTenantId();
@@ -180,6 +180,7 @@ const SummonsOrderComponent = ({ t, config, formData, onSelect }) => {
   }, [caseDetails?.additionalDetails, tenantId]);
 
   const handleDropdownChange = (selectedOption) => {
+    clearErrors(config?.key);
     const isEqual = _.isEqual(selectedOption.value.data, formData?.[config.key]?.party?.data);
     if (!isEqual) {
       setSelectedChannels([]);


### PR DESCRIPTION
#2246 #2231

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling in the Summons Order component, allowing for automatic clearing of form validation errors upon dropdown selection. 

- **Bug Fixes**
	- Improved user experience by ensuring that errors are reset correctly when users interact with dropdowns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->