### PR TITLE
bug -2169, minimum length of one character for building name

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/registration/config.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/registration/config.js
@@ -226,7 +226,7 @@ export const newConfig = [
               name: "buildingName",
               validation: {
                 errMsg: "ADDRESS_BUILDING_NAME_INVALID",
-                minlength: 2,
+                minlength: 1,
                 title: "",
               },
             },


### PR DESCRIPTION
#2169

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new verification requirement for the ADVOCATE_CLERK user type with the `hasStateRegistrationNo` property.
	- Added a `barRegistrationNumber` field with specific validation rules for advocate clerks.
	- Updated the `barCouncilId` field to include validation for required document uploads based on user type.

- **Bug Fixes**
	- Adjusted validation criteria for `BUILDING_NAME` and `LAST_NAME` fields to allow shorter inputs.

- **Enhancements**
	- Improved form configuration to dynamically populate user type options and refine validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->