### PR TITLE
[UAT 2000]: UATv0.3.3 | Option to View Transcript for Hearing not conducted yet

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/configs/UICustomizations.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/configs/UICustomizations.js
@@ -9,6 +9,7 @@ import OverlayDropdown from "../components/OverlayDropdown";
 import CustomChip from "../components/CustomChip";
 import ReactTooltip from "react-tooltip";
 import { removeInvalidNameParts } from "../Utils";
+import { HearingWorkflowState } from "@egovernments/digit-ui-module-orders/src/utils/hearingWorkflow";
 
 const businessServiceMap = {
   "muster roll": "MR",
@@ -850,14 +851,46 @@ export const UICustomizations = {
         ];
       }
 
+      if (![HearingWorkflowState?.SCHEDULED, HearingWorkflowState?.ABATED, HearingWorkflowState?.OPTOUT].includes(row.status)) {
+        return [
+          {
+            label: "View transcript",
+            id: "view_transcript",
+            hide: false,
+            disabled: false,
+            action: (history, column, row) => {
+              column.clickFunc(row);
+            },
+          },
+          {
+            label: "View witness deposition",
+            id: "view_witness",
+            hide: false,
+            disabled: true,
+            action: (history) => {
+              alert("Not Yet Implemented");
+            },
+          },
+          {
+            label: "View pending task",
+            id: "view_pending_tasks",
+            hide: true,
+            disabled: true,
+            action: (history) => {
+              alert("Not Yet Implemented");
+            },
+          },
+        ];
+      }
+
       return [
         {
           label: "View transcript",
           id: "view_transcript",
           hide: false,
-          disabled: false,
-          action: (history, column, row) => {
-            column.clickFunc(row);
+          disabled: true,
+          action: (history) => {
+            alert("Not Yet Implemented");
           },
         },
         {


### PR DESCRIPTION
https://github.com/pucardotorg/dristi/issues/2000
Changes: disabled view transcript option if hearing is in opt out, abated or scheduled state.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced dropdown functionality in the History section to conditionally enable or disable the "View transcript" action based on the hearing workflow state.
	- Added alert notifications for disabled actions to improve user feedback.

- **Bug Fixes**
	- Ensured the "View transcript" action is only actionable when appropriate, preventing confusion for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->