### PR TITLE
Fix code scanning alert no. 38: Server-side request forgery

### DIFF
--- a/backend/e-sign-svc/src/main/java/org/drishti/esign/util/FileStoreUtil.java
+++ b/backend/e-sign-svc/src/main/java/org/drishti/esign/util/FileStoreUtil.java
@@ -39,6 +39,10 @@ public class FileStoreUtil {
 
     public Resource fetchFileStoreObjectById(String fileStoreId, String tenantId) {
 
+        if (!isValidFileStoreId(fileStoreId) || !isValidTenantId(tenantId)) {
+            throw new CustomException("INVALID_INPUT", "Invalid fileStoreId or tenantId");
+        }
+
         StringBuilder uri = new StringBuilder();
         uri.append(configs.getFilestoreHost()).append(configs.getFilestoreSearchEndPoint());
         uri = appendQueryParams(uri, "fileStoreId", fileStoreId, "tenantId", tenantId);
@@ -51,7 +55,6 @@ public class FileStoreUtil {
             throw new CustomException("FILESTORE_SERVICE_EXCEPTION", "exception occurred while calling filestore service");
 
         }
-
 
     }
 
@@ -99,4 +102,13 @@ public class FileStoreUtil {
     }
 
 
+    private boolean isValidFileStoreId(String fileStoreId) {
+        // Implement validation logic for fileStoreId
+        return fileStoreId != null && fileStoreId.matches("[a-zA-Z0-9_-]+");
+    }
+
+    private boolean isValidTenantId(String tenantId) {
+        // Implement validation logic for tenantId
+        return tenantId != null && tenantId.matches("[a-zA-Z0-9_-]+");
+    }
 }


### PR DESCRIPTION
Fixes [https://github.com/pucardotorg/dristi-solutions/security/code-scanning/38](https://github.com/pucardotorg/dristi-solutions/security/code-scanning/38)

To fix the SSRF vulnerability, we need to validate the `fileStoreId` and `tenantId` parameters before using them to construct the URI. One approach is to maintain a whitelist of valid `fileStoreId` and `tenantId` values or patterns. Alternatively, we can ensure that the constructed URI is limited to a particular host or more restrictive URL prefix.

In this case, we will implement a validation method that checks if the `fileStoreId` and `tenantId` match expected patterns. This method will be called before constructing the URI.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
