### PR TITLE
removed flag from advocateIdProof

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/Config/reviewcasefileconfig.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/Config/reviewcasefileconfig.js
@@ -514,9 +514,14 @@ export const reviewCaseFileFormConfig = [
                 },
                 {
                   type: "image",
-                  label: "CS_DOCUMENT",
-                  value: ["vakalatnamaFileUpload.document", "AdvocateNameDetails.advocateIdProof"],
+                  label: "VAKALATNAMA",
+                  value: ["vakalatnamaFileUpload.document"],
                   enableScrutinyField: true,
+                },
+                {
+                  type: "image",
+                  label: "CS_ID_PROOF",
+                  value: ["AdvocateNameDetails.advocateIdProof"],
                 },
               ],
               data: {},


### PR DESCRIPTION
https://github.com/pucardotorg/dristi/issues/2370

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new image field for "CS_ID_PROOF" in the advocate details section for capturing identification proof.
	- Renamed the existing "CS_DOCUMENT" field to "VAKALATNAMA" for clarity.
  
These changes enhance the clarity and functionality of the advocate details form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->