### PR TITLE
in orders tab createdTime -> createdDate

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/configs/UICustomizations.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/configs/UICustomizations.js
@@ -670,7 +670,7 @@ export const UICustomizations = {
           const month = (date.getMonth() + 1).toString().padStart(2, "0"); // Month is zero-based
           const year = date.getFullYear();
           const formattedDate = `${day}-${month}-${year}`;
-          return <span>{formattedDate}</span>;
+          return <span>{value && value !== "0" ? formattedDate : ""}</span>;
         case "Parties":
           if (value === null || value === undefined || value === "undefined" || value === "null") {
             return null;

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCasesConfig.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCasesConfig.js
@@ -271,7 +271,7 @@ export const TabSearchconfig = {
               },
               {
                 label: "Date Added",
-                jsonPath: "auditDetails.createdTime",
+                jsonPath: "createdDate",
                 additionalCustomization: true,
               },
             ],

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/admission/AdmissionActionModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/admission/AdmissionActionModal.js
@@ -187,7 +187,7 @@ function AdmissionActionModal({
   const handleIssueNotice = async (hearingDate, hearingNumber) => {
     try {
       const orderBody = {
-        createdDate: new Date().getTime(),
+        createdDate: null,
         tenantId,
         cnrNumber: caseDetails?.cnrNumber,
         filingNumber,


### PR DESCRIPTION
https://github.com/pucardotorg/dristi/issues/2279

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced payload structure for the "works.purchase" business service, improving data aggregation.
	- Improved handling of date representation in the UI, preventing display of empty dates.
	- Added better null handling for party information in the UI.

- **Bug Fixes**
	- Updated date retrieval for "Date Added" in search results, ensuring accurate data display.
	- Adjusted order creation logic to handle date properties correctly, impacting order tracking.

- **Chores**
	- Cleaned up commented-out code in search configurations for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->