### PR TITLE
Removing advocate/v1/_search API dependency in generate orders

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/utils/caseUtils.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/utils/caseUtils.js
@@ -58,3 +58,7 @@ export const getuuidNameMap = (caseDetails) => {
     return acc;
   }, {});
 };
+
+export const getFullName = (seperator, ...strings) => {
+  return strings.filter(Boolean).join(seperator);
+};


### PR DESCRIPTION
Fetching individual ids using search individual endpoint instead of advocate/v1/_search
#2398