### PR TITLE
[Bug 2397]: added auth token in headers for download file in nyaymitra user

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/Utils/authenticatedLink.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/Utils/authenticatedLink.js
@@ -15,7 +15,7 @@ const AuthenticatedLink = ({ t, uri, displayFilename = false }) => {
       })
       .then((response) => {
         if (response.status === 200) {
-          const blob = new Blob([response.data], { type: "application/pdf" });
+          const blob = new Blob([response.data], { type: "application/octet-stream" });
           const blobUrl = URL.createObjectURL(blob);
 
           window.open(blobUrl, "_blank");

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/Utils/authenticatedLink.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/Utils/authenticatedLink.js
@@ -1,0 +1,50 @@
+import React from "react";
+import axios from "axios";
+
+const AuthenticatedLink = ({ t, uri, displayFilename = false }) => {
+  const handleClick = (e) => {
+    e.preventDefault();
+
+    const authToken = localStorage.getItem("token");
+    axios
+      .get(uri, {
+        headers: {
+          "auth-token": `${authToken}`,
+        },
+        responseType: "blob",
+      })
+      .then((response) => {
+        if (response.status === 200) {
+          const blob = new Blob([response.data], { type: "application/pdf" });
+          const blobUrl = URL.createObjectURL(blob);
+
+          window.open(blobUrl, "_blank");
+        } else {
+          console.error("Failed to fetch the PDF:", response.statusText);
+        }
+      })
+      .catch((error) => {
+        console.error("Error during the API request:", error);
+      });
+  };
+
+  return (
+    <span
+      onClick={handleClick}
+      style={{
+        display: "flex",
+        color: "#007e7e",
+        width: 250,
+        whiteSpace: "nowrap",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        cursor: "pointer",
+        textDecoration: "underline",
+      }}
+    >
+      {displayFilename ? t(displayFilename) : t("CS_CLICK_TO_DOWNLOAD")}
+    </span>
+  );
+};
+
+export default AuthenticatedLink;

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/docViewerWrapper.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/docViewerWrapper.js
@@ -4,6 +4,7 @@ import DocViewer, { DocViewerRenderers } from "@cyntler/react-doc-viewer";
 import { useTranslation } from "react-i18next";
 import { Urls } from "../../hooks";
 import { Link } from "react-router-dom";
+import AuthenticatedLink from "../../Utils/authenticatedLink";
 const SUPPORTED_FILE_FORMATS = [
   ".pdf",
   ".bmp",
@@ -92,23 +93,7 @@ const DocViewerWrapper = ({
           </>
         )}
       </Card>
-      {showDownloadOption && (
-        <Link
-          to={{ pathname: uri }}
-          target="_blank"
-          rel="noreferrer"
-          style={{
-            display: "flex",
-            color: "#007e7e",
-            width: 250,
-            whiteSpace: "nowrap",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-          }}
-        >
-          {t(displayFilename) || t("CS_CLICK_TO_DOWNLOAD")}
-        </Link>
-      )}
+      {showDownloadOption && <AuthenticatedLink t={t} uri={uri} displayFilename={displayFilename}></AuthenticatedLink>}
       {documentName && (
         <p
           style={{


### PR DESCRIPTION
added the auth token in headers
https://github.com/pucardotorg/dristi/issues/2397

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the `AuthenticatedLink` component for secure file downloads, ensuring user authentication via a token.
	- Updated the `DocViewerWrapper` to utilize the new `AuthenticatedLink` for handling download links.

- **Bug Fixes**
	- Improved error handling during file download requests to enhance user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->