### PR TITLE
[2463 develop]

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/SelectComponentsMulti.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/SelectComponentsMulti.js
@@ -77,13 +77,11 @@ const selectCompMultiConfig = {
         type: "text",
         name: "locality",
         validation: {
-          isRequired: true,
           minlength: 2,
           maxlength: 256,
           pattern: /^[^\$\"<>?\\\\~`!@$%^()={}\[\]*:;“”‘’]{2,256}$/i,
           errMsg: "CORE_COMMON_APPLICANT_ADDRESS_INVALID",
         },
-        isMandatory: true,
       },
     ],
     validation: {},

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/Config/complaindetailsConfig.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/Config/complaindetailsConfig.js
@@ -309,7 +309,6 @@ const complainantDetailsFormConfig = [
                 },
                 errMsg: "CORE_COMMON_APPLICANT_ADDRESS_INVALID",
               },
-              isMandatory: true,
             },
           ],
           validation: {},

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/Config/index.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/Config/index.js
@@ -1,5 +1,3 @@
-import { demandNoticeConfig } from "./demandNoticeConfig";
-
 export const sideMenuConfig = [
   {
     isOpen: false,
@@ -30,26 +28,26 @@ export const sideMenuConfig = [
           // "dateOfBirth",
           "complainantVerification.otpNumber", // checkThis- make sure to unset otpNumber if otp model is closed or canceled.
         ],
-        initialMandatoryFieldCount: 12,
+        initialMandatoryFieldCount: 10,
         dependentMandatoryFields: [
           { field: "addressCompanyDetails-select.pincode", dependentOn: "complainantType", dependentOnKey: "showCompanyDetails" },
           { field: "addressCompanyDetails-select.state", dependentOn: "complainantType", dependentOnKey: "showCompanyDetails" },
           { field: "addressCompanyDetails-select.district", dependentOn: "complainantType", dependentOnKey: "showCompanyDetails" },
           { field: "addressCompanyDetails-select.city", dependentOn: "complainantType", dependentOnKey: "showCompanyDetails" },
-          { field: "addressCompanyDetails-select.locality", dependentOn: "complainantType", dependentOnKey: "showCompanyDetails" },
           { field: "addressDetails-select.pincode", dependentOn: "complainantType", dependentOnKey: "isIndividual" },
           { field: "addressDetails-select.state", dependentOn: "complainantType", dependentOnKey: "isIndividual" },
           { field: "addressDetails-select.district", dependentOn: "complainantType", dependentOnKey: "isIndividual" },
           { field: "addressDetails-select.city", dependentOn: "complainantType", dependentOnKey: "isIndividual" },
-          { field: "addressDetails-select.locality", dependentOn: "complainantType", dependentOnKey: "isIndividual" },
           { field: "complainantCompanyName", dependentOn: "complainantType", dependentOnKey: "showCompanyDetails" },
           { field: "complainantTypeOfEntity", dependentOn: "complainantType", dependentOnKey: "showCompanyDetails" },
         ],
-        optionalFields: ["middleName", "lastName", "complainantAge"],
-        initialOptionalFieldCount: 3,
+        optionalFields: ["middleName", "lastName", "complainantAge", "addressCompanyDetails-select.locality", "addressDetails-select.locality"],
+        initialOptionalFieldCount: 5,
         dependentOptionalFields: [
+          { field: "addressCompanyDetails-select.locality", dependentOn: "complainantType", dependentOnKey: "showCompanyDetails" },
           { field: "companyDetailsUpload.document", dependentOn: "complainantType", dependentOnKey: "showCompanyDetails" },
           { field: "complainantDesignation", dependentOn: "complainantType", dependentOnKey: "showCompanyDetails" },
+          { field: "addressDetails-select.locality", dependentOn: "complainantType", dependentOnKey: "isIndividual" },
         ],
       },
       {
@@ -72,13 +70,7 @@ export const sideMenuConfig = [
         ifMultipleAddressLocations: {
           // using this for counting mandatory fields in case of multiple locations .
           dataKey: "addressDetails",
-          mandatoryFields: [
-            "addressDetails.pincode",
-            "addressDetails.state",
-            "addressDetails.district",
-            "addressDetails.city",
-            "addressDetails.locality",
-          ],
+          mandatoryFields: ["addressDetails.pincode", "addressDetails.state", "addressDetails.district", "addressDetails.city"],
         },
         initialMandatoryFieldCount: 10,
         dependentMandatoryFields: [
@@ -92,6 +84,7 @@ export const sideMenuConfig = [
           "phonenumbers.mobileNumber",
           "emails.emailId",
           "inquiryAffidavitFileUpload.document",
+          "addressDetails.locality",
         ],
         dependentOptionalFields: [
           { field: "companyDetailsUpload.document", dependentOn: "respondentType", dependentOnKey: "showCompanyDetails" },
@@ -272,17 +265,18 @@ export const sideMenuConfig = [
         ifMultipleAddressLocations: {
           // using this for counting mandatory fields in case of multiple locations .
           dataKey: "addressDetails",
-          mandatoryFields: [
-            "addressDetails.pincode",
-            "addressDetails.state",
-            "addressDetails.district",
-            "addressDetails.city",
-            "addressDetails.locality",
-          ],
+          mandatoryFields: ["addressDetails.pincode", "addressDetails.state", "addressDetails.district", "addressDetails.city"],
         },
         initialMandatoryFieldCount: 0,
         dependentMandatoryFields: [],
-        optionalFields: ["middleName", "lastName", "phonenumbers.mobileNumber", "emails.emailId", "witnessAdditionalDetails.text"],
+        optionalFields: [
+          "middleName",
+          "lastName",
+          "phonenumbers.mobileNumber",
+          "emails.emailId",
+          "witnessAdditionalDetails.text",
+          "addressDetails.locality",
+        ],
         dependentOptionalFields: [],
         initialOptionalFieldCount: 4,
       },

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/registration/config.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/registration/config.js
@@ -220,6 +220,8 @@ export const newConfig = [
               name: "locality",
               validation: {
                 isRequired: true,
+                minlength: 2,
+                maxlength: 256,
               },
               isMandatory: true,
             },


### PR DESCRIPTION
https://github.com/pucardotorg/dristi/issues/2463
Issue: at the time of registration, there is locality/street name field which didn't have any validation for min characters, but if we enter 1 or no character here, it will give validation error in efiling "ADDRESS" field because that is having mandatory filed with min 2 characters validation and it is obtained by combining the locality, building Name and door number field values from registration form(this is how the logic is present).

Changes Made: made address field "optional" in efiling also added min 2 characters validation for locality/street name field during registration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Address field in forms is now optional, improving user flexibility.
  - Enhanced validation for address and file upload components.
  - New terms and conditions checkbox added for user agreement.
  
- **Improvements**
  - Streamlined configuration for mandatory and optional fields across various forms.
  - Added validation rules for advocate and advocate clerk registration fields.

- **Bug Fixes**
  - Adjusted state management for address details to prevent state mutation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->