### PR TITLE
[BUG 2481]: when the status is undelivered and when we click on that, the "Delivery status and details" pop up screen appears ]

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/ReviewSummonsNoticeAndWarrant.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/ReviewSummonsNoticeAndWarrant.js
@@ -482,7 +482,7 @@ const ReviewSummonsNoticeAndWarrant = () => {
     // if (rowData?.id) getTaskDocuments();
     if (rowData?.filingNumber) getHearingFromCaseId();
     setSelectedDelievery(
-      rowData?.status === "NOTICE_SENT" || rowData?.status === "SUMMON_SENT" || rowData?.status === "DELIVERED"
+      rowData?.status === "NOTICE_SENT" || rowData?.status === "SUMMON_SENT" || rowData?.status === "WARRANT_SENT" || rowData?.status === "DELIVERED"
         ? {
             key: "DELIVERED",
             value: "Delivered",
@@ -492,7 +492,7 @@ const ReviewSummonsNoticeAndWarrant = () => {
   }, [rowData]);
 
   const handleRowClick = (props) => {
-    if (props?.original?.status === "DELIVERED") {
+    if (["DELIVERED", "UNDELIVERED", "EXECUTED"].includes(props?.original?.status)) {
       return; // Do nothing if the row's status is 'Completed'
     }
 


### PR DESCRIPTION
https://github.com/pucardotorg/dristi/issues/2481
Change: updated the required status in condition check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced task status handling in the Review Summons Notice and Warrant component.
	- Introduced support for a new status, "WARRANT_SENT," improving delivery status selection.

- **Bug Fixes**
	- Improved control flow to prevent unnecessary actions for completed statuses ("DELIVERED", "UNDELIVERED", "EXECUTED").

- **Documentation**
	- Maintained error handling and logging for task detail parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->