### PR TITLE
added scrolldown when payment types are more than 5

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingPayment.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingPayment.js
@@ -335,31 +335,53 @@ function EFilingPayment({ t, submitModalInfo = mockSubmitModalInfo, path }) {
                 <span style={{ fontWeight: 700 }}>Rs {totalAmount}/-.</span>
                 {` ${t("CS_MANDATORY_STEP_TO_FILE_CASE")}`}
               </div>
+              <div className="payment-calculator-wrapper" style={{ display: "flex", flexDirection: "column", maxHeight: "150px", overflowY: "auto" }}>
+                {paymentCalculation
+                  .filter((item) => !item.isTotalFee)
+                  .map((item) => (
+                    <div
+                      style={{
+                        display: "flex",
+                        justifyContent: "space-between",
+                        alignItems: "center",
+                        paddingRight: "16px",
+                      }}
+                    >
+                      <span>{item.key}</span>
+                      <span>
+                        {item.currency} {parseFloat(item.value).toFixed(2)}
+                      </span>
+                    </div>
+                  ))}
+              </div>
               <div className="payment-calculator-wrapper" style={{ display: "flex", flexDirection: "column" }}>
-                {paymentCalculation.map((item) => (
-                  <div
-                    style={{
-                      display: "flex",
-                      justifyContent: "space-between",
-                      alignItems: "center",
-                      borderTop: item.isTotalFee && "1px solid #BBBBBD",
-                      fontSize: item.isTotalFee && "16px",
-                      fontWeight: item.isTotalFee && "700",
-                      paddingTop: item.isTotalFee && "12px",
-                    }}
-                  >
-                    <span>{item.key}</span>
-                    <span>
-                      {item.currency} {parseFloat(item.value).toFixed(2)}
-                    </span>
-                  </div>
-                ))}
+                {paymentCalculation
+                  .filter((item) => item.isTotalFee)
+                  .map((item) => (
+                    <div
+                      style={{
+                        display: "flex",
+                        justifyContent: "space-between",
+                        alignItems: "center",
+                        borderTop: "1px solid #BBBBBD",
+                        fontSize: "16px",
+                        fontWeight: "700",
+                        paddingTop: "12px",
+                        paddingRight: "28px",
+                      }}
+                    >
+                      <span>{item.key}</span>
+                      <span>
+                        {item.currency} {parseFloat(item.value).toFixed(2)}
+                      </span>
+                    </div>
+                  ))}
               </div>
               <div>
                 <InfoCard
                   variant={"default"}
                   label={t("CS_COMMON_NOTE")}
-                  style={{ margin: "100px 0 0 0", backgroundColor: "#ECF3FD" }}
+                  style={{ backgroundColor: "#ECF3FD" }}
                   additionalElements={[
                     <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
                       <span>{t("CS_OFFLINE_PAYMENT_STEP_TEXT")}</span>

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingPayment.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingPayment.js
@@ -367,7 +367,7 @@ function EFilingPayment({ t, submitModalInfo = mockSubmitModalInfo, path }) {
                         fontSize: "16px",
                         fontWeight: "700",
                         paddingTop: "12px",
-                        paddingRight: "28px",
+                        paddingRight: paymentCalculation.length >6 ? "28px" : "16px",
                       }}
                     >
                       <span>{item.key}</span>

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/components/EfilingPaymentDropdown.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/components/EfilingPaymentDropdown.js
@@ -233,31 +233,53 @@ function EfilingPaymentBreakdown({ setShowModal, header, subHeader }) {
             <span style={{ fontWeight: 700 }}>Rs {totalAmount}/-.</span>
             {` ${t("CS_MANDATORY_STEP_TO_FILE_CASE")}`}
           </div>
+          <div className="payment-calculator-wrapper" style={{ display: "flex", flexDirection: "column", maxHeight: "150px", overflowY: "auto" }}>
+            {paymentCalculation
+              .filter((item) => !item.isTotalFee)
+              .map((item) => (
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                    paddingRight: "16px",
+                  }}
+                >
+                  <span>{item.key}</span>
+                  <span>
+                    {item.currency} {parseFloat(item.value).toFixed(2)}
+                  </span>
+                </div>
+              ))}
+          </div>
           <div className="payment-calculator-wrapper" style={{ display: "flex", flexDirection: "column" }}>
-            {paymentCalculation.map((item) => (
-              <div
-                style={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  alignItems: "center",
-                  borderTop: item.isTotalFee && "1px solid #BBBBBD",
-                  fontSize: item.isTotalFee && "16px",
-                  fontWeight: item.isTotalFee && "700",
-                  paddingTop: item.isTotalFee && "12px",
-                }}
-              >
-                <span>{item.key}</span>
-                <span>
-                  {item.currency} {parseFloat(item.value).toFixed(2)}
-                </span>
-              </div>
-            ))}
+            {paymentCalculation
+              .filter((item) => item.isTotalFee)
+              .map((item) => (
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                    borderTop: "1px solid #BBBBBD",
+                    fontSize: "16px",
+                    fontWeight: "700",
+                    paddingTop: "12px",
+                    paddingRight: "28px",
+                  }}
+                >
+                  <span>{item.key}</span>
+                  <span>
+                    {item.currency} {parseFloat(item.value).toFixed(2)}
+                  </span>
+                </div>
+              ))}
           </div>
           <div>
             <InfoCard
               variant={"default"}
               label={t("CS_COMMON_NOTE")}
-              style={{ margin: "100px 0 0 0", backgroundColor: "#ECF3FD" }}
+              style={{ backgroundColor: "#ECF3FD" }}
               additionalElements={[
                 <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
                   <span>{t("CS_OFFLINE_PAYMENT_STEP_TEXT")}</span>

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/components/EfilingPaymentDropdown.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/components/EfilingPaymentDropdown.js
@@ -265,7 +265,7 @@ function EfilingPaymentBreakdown({ setShowModal, header, subHeader }) {
                     fontSize: "16px",
                     fontWeight: "700",
                     paddingTop: "12px",
-                    paddingRight: "28px",
+                    paddingRight: paymentCalculation.length >6 ? "28px" : "16px"
                   }}
                 >
                   <span>{item.key}</span>


### PR DESCRIPTION
#2544

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced payment breakdown display in the payment modal, separating total fees from individual payment items for improved clarity.
	- Adjusted styling for total fee items to make them more prominent.

- **Bug Fixes**
	- Removed unnecessary margin styles for a more consistent layout in the modal.

- **Refactor**
	- Restructured how payment calculation items are processed and displayed, improving layout and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->