### PR TITLE
[BUG  #2608]: [For faulty files Error message is not showing for only continue button ]

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/CaseLockModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/CaseLockModal.js
@@ -70,21 +70,30 @@ function CaseLockModal({
 
   const handleSaveOnSubmit = async () => {
     setShowCaseLockingModal(false);
+
     if (!isAdvocateFilingCase) {
       if (state === CaseWorkflowState.CASE_REASSIGNED) {
+        const result = await onSubmit("EDIT_CASE", true);
+        if (result?.error) {
+          return;
+        }
         try {
-          await onSubmit("EDIT_CASE", true);
-          await createPendingTask({ name: t("PENDING_RE_E_SIGN_FOR_CASE"), status: "PENDING_RE_E-SIGN" }); // check status
+          await createPendingTask({ name: t("PENDING_RE_E_SIGN_FOR_CASE"), status: "PENDING_RE_E-SIGN" });
           history.push(`${path}/sign-complaint?filingNumber=${filingNumber}`);
         } catch (error) {
-          toast.error(error);
+          console.error("An error occurred:", error);
+          toast.error(t("SOMETHING_WENT_WRONG"));
         }
       } else {
+        const result = await onSubmit("SUBMIT_CASE", true);
+        if (result?.error) {
+          return;
+        }
         try {
-          await onSubmit("SUBMIT_CASE", true);
-          await createPendingTask({ name: t("PENDING_E_SIGN_FOR_CASE"), status: "PENDING_E-SIGN" }); // check status
+          await createPendingTask({ name: t("PENDING_E_SIGN_FOR_CASE"), status: "PENDING_E-SIGN" });
           history.push(`${path}/sign-complaint?filingNumber=${filingNumber}`);
         } catch (error) {
+          console.error("An error occurred:", error);
           toast.error(t("SOMETHING_WENT_WRONG"));
         }
       }
@@ -97,21 +106,29 @@ function CaseLockModal({
     setShowCaseLockingModal(false);
     if (state === CaseWorkflowState.CASE_REASSIGNED) {
       if (isAdvocateFilingCase) {
+        const result = await onSubmit("EDIT_CASE_ADVOCATE", true);
+        if (result?.error) {
+          return;
+        }
         try {
-          await onSubmit("EDIT_CASE_ADVOCATE", true);
           await createPendingTask({ name: t("PENDING_RE_UPLOAD_SIGNATURE_FOR_CASE"), status: "PENDING_RE_SIGN" }); // check status
           history.push(`${path}/sign-complaint?filingNumber=${filingNumber}`);
         } catch (error) {
+          console.error("An error occurred:", error);
           toast.error(t("SOMETHING_WENT_WRONG"));
         }
       }
     } else {
       if (isAdvocateFilingCase) {
+        const result = await onSubmit("SUBMIT_CASE_ADVOCATE", true);
+        if (result?.error) {
+          return;
+        }
         try {
-          await onSubmit("SUBMIT_CASE_ADVOCATE", true);
           await createPendingTask({ name: t("PENDING_UPLOAD_SIGNATURE_FOR_CASE"), status: "PENDING_SIGN" }); // check status
           history.push(`${path}/sign-complaint?filingNumber=${filingNumber}`);
         } catch (error) {
+          console.error("An error occurred:", error);
           toast.error(t("SOMETHING_WENT_WRONG"));
         }
       }

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingCases.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingCases.js
@@ -1674,7 +1674,12 @@ function EFilingCases({ path }) {
           const contentDisposition = response.headers["content-disposition"];
           const filename = contentDisposition ? contentDisposition.split("filename=")[1]?.replace(/['"]/g, "") : "caseCompliantDetails.pdf";
           const pdfFile = new File([response?.data], filename, { type: "application/pdf" });
-          const document = await onDocumentUpload(pdfFile, pdfFile?.name);
+          let document = {};
+          try {
+            document = await onDocumentUpload(pdfFile, pdfFile?.name);
+          } catch (error) {
+            throw error;
+          }
           const fileStoreId = document?.file?.files?.[0]?.fileStoreId;
 
           if (fileStoreId) {
@@ -1732,9 +1737,10 @@ function EFilingCases({ path }) {
         } else if (extractCodeFromErrorMsg(error) === 413) {
           message = t("FAILED_TO_UPLOAD_FILE");
         }
+        toast.error(message);
         setIsDisabled(false);
         console.error("An error occurred:", error);
-        throw new Error(message);
+        return { error };
       }
     }
   };


### PR DESCRIPTION
https://github.com/pucardotorg/dristi/issues/2608
Changes:
1. Removed throw error from onSubmit catch block as formcomposer does not handle the rejected promise, instead returned an error object if it has to be needed where onSubmit is called.
2.added a Toast on continue button to show error message.