### PR TITLE
filename is not visible for complainant id type and card is appending when advocate is adding complainant

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/VerifyPhoneNumber.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/VerifyPhoneNumber.js
@@ -199,7 +199,7 @@ function VerifyPhoneNumber({ t, config, onSelect, formData = {}, errors, setErro
               individualDetails: {
                 individualId: individualData?.Individual?.[0]?.individualId,
                 document: identifierIdDetails?.fileStoreId
-                  ? [{ fileName: `${idType} Card`, fileStore: identifierIdDetails?.fileStoreId, documentName: identifierIdDetails?.filename }]
+                  ? [{ fileName: idType, fileStore: identifierIdDetails?.fileStoreId, documentName: identifierIdDetails?.filename }]
                   : null,
                 "addressDetails-select": data["addressDetails-select"],
                 addressDetails: data["addressDetails-select"],

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/CaseType.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/CaseType.js
@@ -250,7 +250,7 @@ function CaseType({ t }) {
                                   individualDetails: {
                                     individualId: individualId,
                                     document: identifierIdDetails?.fileStoreId
-                                      ? [{ name: idType, fileStore: identifierIdDetails?.fileStoreId, documentName: identifierIdDetails?.filename }]
+                                      ? [{ fileName: idType, fileStore: identifierIdDetails?.fileStoreId, documentName: identifierIdDetails?.filename }]
                                       : null,
                                     "addressDetails-select": {
                                       pincode: pincode,


### PR DESCRIPTION

#2720
## Requirements


- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/<issue-number>-workflow.json`



## Summary
filename is not visible for complainant id type and card is appending when advocate is adding complainant



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved document naming convention for individual details in the phone verification process.
	- Enhanced error messaging for locked accounts during OTP selection.

- **Bug Fixes**
	- Updated document identifier structure in case creation service for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->