### PR TITLE
[2809- updated]: when DCA is not filed, after admission hearing is done, update hearing types

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCase.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCase.js
@@ -1501,6 +1501,17 @@ const AdmittedCases = () => {
     Boolean(filingNumber)
   );
 
+  const isDcaHearingScheduled = useMemo(() => {
+    const isDcaHearingScheduled = Boolean(
+      hearingDetails?.HearingList?.find(
+        (hearing) =>
+          ["DELAY_CONDONATION_HEARING", "DELAY_CONDONATION_AND_ADMISSION"].includes(hearing?.hearingType) &&
+          [HearingWorkflowState?.INPROGRESS, HearingWorkflowState?.SCHEDULED].includes(hearing?.status)
+      )
+    );
+    return isDcaHearingScheduled;
+  }, [hearingDetails]);
+
   const currentHearingId = useMemo(
     () =>
       hearingDetails?.HearingList?.find((list) => list?.hearingType === "ADMISSION" && !(list?.status === "COMPLETED" || list?.status === "ABATED"))
@@ -2375,7 +2386,7 @@ const AdmittedCases = () => {
                   onButtonClick={onSaveDraft}
                 />
               )}
-            {primaryAction.action && (
+            {primaryAction.action && !isDcaHearingScheduled && (
               <SubmitBar
                 label={t(
                   [CaseWorkflowState.ADMISSION_HEARING_SCHEDULED].includes(caseDetails?.status) && primaryAction?.action === "ADMIT"

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/admission/AdmissionActionModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/admission/AdmissionActionModal.js
@@ -96,7 +96,6 @@ function AdmissionActionModal({
 
   const [scheduleHearingParams, setScheduleHearingParam] = useState(!isCaseAdmitted ? { purpose: t("ADMISSION") } : {});
   const isGenerateOrderDisabled = useMemo(() => Boolean(!scheduleHearingParams?.purpose || !scheduleHearingParams?.date), [scheduleHearingParams]);
-  console.log("first", scheduleHearingParams, isGenerateOrderDisabled);
 
   const onSubmit = (props, wordLimit) => {
     const words = props?.commentForLitigant?.trim()?.split(/\s+/);

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/admission/ScheduleAdmission.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/admission/ScheduleAdmission.js
@@ -51,7 +51,6 @@ function ScheduleAdmission({
       return Boolean(hearingDetails?.HearingList?.find((hearing) => hearing?.hearingType === "ADMISSION"));
     }
   }, [hearingDetails]);
-  console.log("delayCondonationData", delayCondonationData, isDelayApplicationPending, isDelayApplicationCompleted);
 
   const isDcaHearingScheduled = useMemo(() => {
     debugger;
@@ -84,7 +83,11 @@ function ScheduleAdmission({
       if (!isAdmissionHearingScheduled) {
         return hearingTypeData?.HearingType?.filter((type) => ["ADMISSION"].includes(type?.code)) || [];
       }
-      return hearingTypeData?.HearingType || [];
+      return (
+        hearingTypeData?.HearingType?.filter(
+          (type) => !["DELAY_CONDONATION_HEARING", "ADMISSION", "DELAY_CONDONATION_AND_ADMISSION"].includes(type?.code)
+        ) || []
+      );
     }
   }, [hearingTypeData, isDelayApplicationPending, isDelayApplicationCompleted, isAdmissionHearingScheduled, isDcaHearingScheduled]);
 

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/admission/ScheduleAdmission.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/admission/ScheduleAdmission.js
@@ -4,6 +4,7 @@ import { Button, CardText, CustomDropdown, SubmitBar, TextInput, Toast, Loader }
 import CustomCaseInfoDiv from "../../../components/CustomCaseInfoDiv";
 import { formatDateInMonth, getMDMSObj } from "../../../Utils";
 import useGetStatuteSection from "../../../hooks/dristi/useGetStatuteSection";
+import { HearingWorkflowState } from "@egovernments/digit-ui-module-orders/src/utils/hearingWorkflow";
 
 function ScheduleAdmission({
   config,
@@ -48,16 +49,26 @@ function ScheduleAdmission({
     if (!hearingDetails?.HearingList?.length) {
       return false;
     } else {
-      return Boolean(hearingDetails?.HearingList?.find((hearing) => hearing?.hearingType === "ADMISSION"));
+      return Boolean(
+        hearingDetails?.HearingList?.find(
+          (hearing) =>
+            hearing?.hearingType === "ADMISSION" && [HearingWorkflowState?.INPROGRESS, HearingWorkflowState?.SCHEDULED].includes(hearing?.status)
+        )
+      );
     }
   }, [hearingDetails]);
 
   const isDcaHearingScheduled = useMemo(() => {
-    debugger;
     if (!hearingDetails?.HearingList?.length) {
       return false;
     } else {
-      return Boolean(hearingDetails?.HearingList?.find((hearing) => hearing?.hearingType === "DELAY_CONDONATION_HEARING"));
+      return Boolean(
+        hearingDetails?.HearingList?.find(
+          (hearing) =>
+            hearing?.hearingType === "DELAY_CONDONATION_HEARING" &&
+            [HearingWorkflowState?.INPROGRESS, HearingWorkflowState?.SCHEDULED].includes(hearing?.status)
+        )
+      );
     }
   }, [hearingDetails]);
 
@@ -73,11 +84,12 @@ function ScheduleAdmission({
       if (!isDcaHearingScheduled && isAdmissionHearingScheduled) {
         return hearingTypeData?.HearingType?.filter((type) => !["ADMISSION", "DELAY_CONDONATION_AND_ADMISSION"].includes(type?.code)) || [];
       }
-      if (isDcaHearingScheduled && !isAdmissionHearingScheduled) {
-        return hearingTypeData?.HearingType?.filter((type) => ["ADMISSION"].includes(type?.code)) || [];
-      }
-      if (isDcaHearingScheduled && isAdmissionHearingScheduled) {
-        return hearingTypeData?.HearingType || [];
+      if (isDcaHearingScheduled) {
+        return (
+          hearingTypeData?.HearingType?.filter(
+            (type) => !["DELAY_CONDONATION_HEARING", "ADMISSION", "DELAY_CONDONATION_AND_ADMISSION"].includes(type?.code)
+          ) || []
+        );
       }
     } else {
       if (!isAdmissionHearingScheduled) {
@@ -101,13 +113,8 @@ function ScheduleAdmission({
           isactive: true,
         };
       }
-      if (isDcaHearingScheduled && !isAdmissionHearingScheduled) {
-        return {
-          id: 5,
-          type: "ADMISSION",
-          isactive: true,
-          code: "ADMISSION",
-        };
+      if (isDcaHearingScheduled) {
+        return null;
       }
     } else {
       if (!isAdmissionHearingScheduled) {
@@ -133,10 +140,10 @@ function ScheduleAdmission({
 
   const setPurpose = useCallback((props) => setPurposeValue(props), []);
   useEffect(() => {
-    if (scheduleHearingParams?.purpose?.code !== defaultHearingType?.code) {
+    if (defaultHearingType) {
       setPurpose(defaultHearingType);
     }
-  }, [setPurpose, defaultHearingType, scheduleHearingParams]);
+  }, []);
 
   const handleSubmit = (props) => {
     if (!scheduleHearingParams?.date && !modalInfo?.showCustomDate) {


### PR DESCRIPTION
Issue: https://github.com/pucardotorg/dristi/issues/2809
scenarios: 
1. if there is no DCA filed for the case, show only admission hearing in dropdown of schedule of admission hearing modal.
2. if DCA if filed, show 3 hearing types in the dropdown of schedule of admission hearing modal i.e. hearing for Delay condonation, hearing for admission, hearing for delay con and admisson, but preset the value to hearing for delay condonation.
## Requirements



- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->