### PR TITLE
[2809 - update-2] :in create orders page -> hearing purpose dropdown types -> hearing for delay condonation, hearing for delay con and admission option should be visible only if DCA is filed.

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrders.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrders.js
@@ -522,6 +522,9 @@ const GenerateOrders = () => {
       ),
     [applicationData]
   );
+  const isDcaFiled = useMemo(() => {
+    return caseDetails?.caseDetails?.delayApplications?.formdata?.[0]?.data?.isDcaSkippedInEFiling === "NO" || isDelayApplicationSubmitted;
+  }, [caseDetails, isDelayApplicationSubmitted]);
 
   const hearingId = useMemo(() => currentOrder?.hearingNumber || applicationDetails?.additionalDetails?.hearingId || "", [
     applicationDetails,
@@ -608,6 +611,22 @@ const GenerateOrders = () => {
                     !isCaseAdmitted && {
                       disable: true,
                     }),
+                  populators: {
+                    ...field.populators,
+                    mdmsConfig: {
+                      ...field.populators?.mdmsConfig,
+                      select: `(data) => {
+                        return (
+                          data?.Hearing?.HearingType?.filter((h) => {
+                            if (${!isDcaFiled}) {
+                              return !["DELAY_CONDONATION_HEARING", "DELAY_CONDONATION_AND_ADMISSION"].includes(h?.code);
+                            }
+                            return true;
+                          }) || []
+                        );
+                      }`,
+                    },
+                  },
                 };
               }
               if (field.key === "unjoinedPartiesNote") {


### PR DESCRIPTION
issue: https://github.com/pucardotorg/dristi/issues/2809
in create orders page -> hearing purpose dropdown types -> hearing for delay condonation, hearing for delay con and admission option should be visible only if DCA is filed.
## Requirements



- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a computed property to determine DCA (Delay Condonation Application) filing status
  - Enhanced form configuration to dynamically filter hearing types based on DCA status

- **Improvements**
  - Improved form rendering logic to provide more context-aware options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->