### PR TITLE
[BUG  #2793]: [sol-dev | the file uploaded in dca field not appearing if we change the radio buttons.]

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingCases.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingCases.js
@@ -186,6 +186,7 @@ function EFilingCases({ path }) {
   const [showConfirmDcaSkipModal, setShowConfirmDcaSkipModal] = useState(false);
   const [shouldShowConfirmDcaModal, setShouldShowConfirmDcaModal] = useState(false);
   const [prevIsDcaSkipped, setPrevIsDcaSkipped] = useState("");
+  const [isDcaPageRefreshed, setIsDcaPageRefreshed] = useState(true);
 
   const [showConfirmCaseDetailsModal, setShowConfirmCaseDetailsModal] = useState(false);
 
@@ -472,7 +473,9 @@ function EFilingCases({ path }) {
   useEffect(() => {
     const isDcaSkipped = caseDetails?.caseDetails?.["delayApplications"]?.formdata?.[0]?.data?.isDcaSkippedInEFiling?.code;
     if (isDcaSkipped !== prevIsDcaSkipped) {
-      setPrevIsDcaSkipped(isDcaSkipped);
+      if (!isCaseReAssigned || (isCaseReAssigned && isDcaSkipped === "NO")) {
+        setPrevIsDcaSkipped(isDcaSkipped);
+      }
     }
   }, [caseDetails, prevIsDcaSkipped]);
 
@@ -568,6 +571,14 @@ function EFilingCases({ path }) {
         if (selected === "reviewCaseFile") {
           return scrutinyObj;
         }
+        if (selected === "delayApplications") {
+          if (caseDetails?.caseDetails?.delayApplications?.formdata?.[0]?.data?.condonationFileUpload && prevIsDcaSkipped === "NO") {
+            setFormDataValue.current?.(
+              "condonationFileUpload",
+              caseDetails?.caseDetails?.delayApplications?.formdata?.[0]?.data?.condonationFileUpload
+            );
+          }
+        }
         return (
           errorCaseDetails?.additionalDetails?.[selected]?.formdata?.[index]?.data ||
           errorCaseDetails?.caseDetails?.[selected]?.formdata?.[index]?.data ||
@@ -593,7 +604,15 @@ function EFilingCases({ path }) {
                   name: "NO",
                   showDcaFileUpload: true,
                 },
+            condonationFileUpload: caseDetails?.caseDetails?.delayApplications?.formdata?.[0]?.data?.condonationFileUpload,
           };
+          if (caseDetails?.caseDetails?.delayApplications?.formdata?.[0]?.data?.condonationFileUpload) {
+            setFormDataValue.current?.(
+              "condonationFileUpload",
+              caseDetails?.caseDetails?.delayApplications?.formdata?.[0]?.data?.condonationFileUpload
+            );
+          }
+
           return data;
         } else {
           return {
@@ -1418,11 +1437,12 @@ function EFilingCases({ path }) {
         history,
         caseId,
         setShowConfirmDcaSkipModal,
-        showConfirmDcaSkipModal,
         shouldShowConfirmDcaModal,
         setShouldShowConfirmDcaModal,
         prevIsDcaSkipped,
         setPrevIsDcaSkipped,
+        isDcaPageRefreshed,
+        setIsDcaPageRefreshed,
       });
       showToastForComplainant({ formData, setValue, selected, setSuccessToast, formState, clearErrors });
       setFormdata(
@@ -1811,6 +1831,7 @@ function EFilingCases({ path }) {
           multiUploadList,
           scrutinyObj,
           filingType: filingType,
+          setShouldShowConfirmDcaModal,
         });
 
         if (resetFormData.current) {
@@ -1862,6 +1883,7 @@ function EFilingCases({ path }) {
       multiUploadList,
       scrutinyObj,
       filingType: filingType,
+      setShouldShowConfirmDcaModal,
     })
       .then(() => {
         refetchCaseData().then(() => {
@@ -1937,6 +1959,7 @@ function EFilingCases({ path }) {
       multiUploadList,
       scrutinyObj,
       filingType: filingType,
+      setShouldShowConfirmDcaModal,
     })
       .then(() => {
         if (!isCaseReAssigned) {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EfilingValidationUtils.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EfilingValidationUtils.js
@@ -81,11 +81,12 @@ export const validateDateForDelayApplication = ({
   history,
   caseId,
   setShowConfirmDcaSkipModal,
-  showConfirmDcaSkipModal,
   shouldShowConfirmDcaModal,
   setShouldShowConfirmDcaModal,
   prevIsDcaSkipped,
   setPrevIsDcaSkipped,
+  isDcaPageRefreshed,
+  setIsDcaPageRefreshed,
 }) => {
   if (selected === "delayApplications") {
     if (
@@ -102,6 +103,11 @@ export const validateDateForDelayApplication = ({
       setShowConfirmDcaSkipModal(true);
       setShouldShowConfirmDcaModal(false);
       setPrevIsDcaSkipped("YES");
+    } else if (prevIsDcaSkipped === "NO" && !shouldShowConfirmDcaModal && formData?.isDcaSkippedInEFiling?.code === "YES" && isDcaPageRefreshed) {
+      setShowConfirmDcaSkipModal(true);
+      setShouldShowConfirmDcaModal(false);
+      setPrevIsDcaSkipped("YES");
+      setIsDcaPageRefreshed(false);
     }
     if (formData?.isDcaSkippedInEFiling?.code === "NO") {
       setShowConfirmDcaSkipModal(false);
@@ -2311,7 +2317,6 @@ export const updateCaseDetails = async ({
         data?.additionalDetails?.respondentDetails?.formdata?.[0]?.data || caseDetails?.additionalDetails?.respondentDetails?.formdata?.[0]?.data
       )}`
     : caseDetails?.caseTitle;
-
   setErrorCaseDetails({
     ...caseDetails,
     documents: tempDocList,


### PR DESCRIPTION
Issue: https://github.com/pucardotorg/dristi/issues/2793
## Requirements



- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/<issue-number>-workflow.json`



## Summary
If the case contained DCA file, on switching back from YES to NO in skip DCA radio option, the previously saved file should populate automatically in the file upload component.