### PR TITLE
multiple litigant advocate e-sign workflow update

### DIFF
--- a/docs/Case/workflow/case-workflowConfig.json
+++ b/docs/Case/workflow/case-workflowConfig.json
@@ -96,19 +96,9 @@
                             ]
                         },
                         {
-                            "action": "E-SIGN_PIP_DONE",
-                            "nextState": "PENDING_PAYMENT",
-                            "roles": [
-                                "CASE_CREATOR",
-                                "SYSTEM",
-                                "SYSTEM_ADMIN"
-                            ]
-                        },
-                        {
                             "action": "E-SIGN_COMPLETE",
                             "nextState": "PENDING_PAYMENT",
                             "roles": [
-                                "CASE_CREATOR",
                                 "SYSTEM",
                                 "SYSTEM_ADMIN"
                             ]
@@ -269,21 +259,11 @@
                             ]
                         },
                         {
-                            "action": "E-SIGN_PARTY_IN_PERSON",
-                            "nextState": "UNDER_SCRUTINY",
-                            "roles": [
-                                "CASE_CREATOR",
-                                "SYSTEM",
-                                "SYSTEM_ADMIN"
-                            ]
-                        },
-                        {
-                            "action": "E-SIGN",
+                            "action": "E-SIGN_COMPLETE",
                             "nextState": "UNDER_SCRUTINY",
                             "roles": [
                                 "SYSTEM",
                                 "SYSTEM_ADMIN",
-                                "CASE_CREATOR"
                             ]
                         }
                     ]

--- a/docs/Case/workflow/case-workflowConfig.json
+++ b/docs/Case/workflow/case-workflowConfig.json
@@ -96,7 +96,7 @@
                             ]
                         },
                         {
-                            "action": "E-SIGN_PARTY_IN_PERSON",
+                            "action": "E-SIGN_PIP_DONE",
                             "nextState": "PENDING_PAYMENT",
                             "roles": [
                                 "CASE_CREATOR",
@@ -105,7 +105,7 @@
                             ]
                         },
                         {
-                            "action": "E-SIGN",
+                            "action": "E-SIGN_COMPLETE",
                             "nextState": "PENDING_PAYMENT",
                             "roles": [
                                 "CASE_CREATOR",

--- a/docs/Case/workflow/case-workflowConfig.json
+++ b/docs/Case/workflow/case-workflowConfig.json
@@ -88,7 +88,7 @@
                     "actions": [
                         {
                             "action": "E-SIGN",
-                            "nextState": "PENDING_E-SIGN-2",
+                            "nextState": "PENDING_E-SIGN",
                             "roles": [
                                 "CASE_CREATOR",
                                 "SYSTEM",
@@ -103,23 +103,12 @@
                                 "SYSTEM",
                                 "SYSTEM_ADMIN"
                             ]
-                        }
-                    ]
-                },
-                {
-                    "sla": null,
-                    "state": "PENDING_E-SIGN-2",
-                    "applicationStatus": "INWORKFLOW",
-                    "docUploadRequired": false,
-                    "isStartState": false,
-                    "isTerminateState": false,
-                    "isStateUpdatable": true,
-                    "actions": [
+                        },
                         {
                             "action": "E-SIGN",
                             "nextState": "PENDING_PAYMENT",
                             "roles": [
-                                "ADVOCATE_ROLE",
+                                "CASE_CREATOR",
                                 "SYSTEM",
                                 "SYSTEM_ADMIN"
                             ]
@@ -272,7 +261,7 @@
                     "actions": [
                         {
                             "action": "E-SIGN",
-                            "nextState": "PENDING_RE_E-SIGN-2",
+                            "nextState": "PENDING_RE_E-SIGN",
                             "roles": [
                                 "SYSTEM",
                                 "SYSTEM_ADMIN",
@@ -287,25 +276,14 @@
                                 "SYSTEM",
                                 "SYSTEM_ADMIN"
                             ]
-                        }
-                    ]
-                },
-                {
-                    "sla": null,
-                    "state": "PENDING_RE_E-SIGN-2",
-                    "applicationStatus": "INWORKFLOW",
-                    "docUploadRequired": false,
-                    "isStartState": false,
-                    "isTerminateState": false,
-                    "isStateUpdatable": true,
-                    "actions": [
+                        },
                         {
                             "action": "E-SIGN",
                             "nextState": "UNDER_SCRUTINY",
                             "roles": [
                                 "SYSTEM",
                                 "SYSTEM_ADMIN",
-                                "ADVOCATE_ROLE"
+                                "CASE_CREATOR"
                             ]
                         }
                     ]

--- a/docs/Case/workflow/case-workflowConfig.json
+++ b/docs/Case/workflow/case-workflowConfig.json
@@ -102,6 +102,13 @@
                                 "SYSTEM",
                                 "SYSTEM_ADMIN"
                             ]
+                        },
+                        {
+                            "action": "EDIT_CASE",
+                            "nextState": "DRAFT_IN_PROGRESS",
+                            "roles": [
+                                "CASE_CREATOR"
+                            ]
                         }
                     ]
                 },
@@ -121,6 +128,13 @@
                                 "ADVOCATE_ROLE",
                                 "SYSTEM",
                                 "SYSTEM_ADMIN"
+                            ]
+                        },
+                        {
+                            "action": "EDIT_CASE",
+                            "nextState": "DRAFT_IN_PROGRESS",
+                            "roles": [
+                                "CASE_CREATOR"
                             ]
                         }
                     ]
@@ -237,6 +251,13 @@
                                 "SYSTEM",
                                 "SYSTEM_ADMIN"
                             ]
+                        },
+                        {
+                            "action": "EDIT_CASE",
+                            "nextState": "CASE_REASSIGNED",
+                            "roles": [
+                                "CASE_CREATOR"
+                            ]
                         }
                     ]
                 },
@@ -263,7 +284,14 @@
                             "nextState": "UNDER_SCRUTINY",
                             "roles": [
                                 "SYSTEM",
-                                "SYSTEM_ADMIN",
+                                "SYSTEM_ADMIN"
+                            ]
+                        },
+                        {
+                            "action": "EDIT_CASE",
+                            "nextState": "CASE_REASSIGNED",
+                            "roles": [
+                                "CASE_CREATOR"
                             ]
                         }
                     ]


### PR DESCRIPTION
Multiple litigants (complainants) and their advocates need to e-sign or physically sign. Updated the workflow to handle multiple people e-signing. 

cc. @Ramu-kandimalla @suresh12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Workflow Updates**
	- Simplified case workflow state transitions.
	- Consolidated "PENDING_E-SIGN" and "PENDING_RE_E-SIGN" states.
	- Updated role assignments for e-signing actions to include "SYSTEM" and "SYSTEM_ADMIN".
	- Renamed action "E-SIGN_PARTY_IN_PERSON" to "E-SIGN_COMPLETE".
	- Adjusted transitions for actions "E-SIGN" to align with the new state structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->