### PR TITLE
added action test and role actions for filestore delete

### DIFF
--- a/common/egov-filestore/src/main/resources/db/migration/ddl/V20250116123400__egfilestore__ddl.sql
+++ b/common/egov-filestore/src/main/resources/db/migration/ddl/V20250116123400__egfilestore__ddl.sql
@@ -1,1 +1,1 @@
-ALTER TABLE eg_filestoremap ADD COLUMN isdeleted boolean NOT NULL DEFAULT false;
+ALTER TABLE eg_filestoremap ADD COLUMN isdeleted boolean DEFAULT false;

--- a/support/1924-mdms-data.json
+++ b/support/1924-mdms-data.json
@@ -1,0 +1,46 @@
+[
+  {
+    "tenantId": "kl",
+    "moduleName": "ACCESSCONTROL-ACTIONS-TEST",
+    "masterName": "actions-test",
+    "mdmsPayload": [
+      {
+        "tenantId": "kl",
+        "schemaCode": "ACCESSCONTROL-ACTIONS-TEST.actions-test",
+        "data": {
+          "id": 2703,
+          "url": "/filestore/v1/files/delete",
+          "code": "null",
+          "name": "FilestoreUrl",
+          "path": "",
+          "enabled": false,
+          "displayName": "Filestore files Delete",
+          "orderNumber": 1,
+          "serviceCode": "filestore url",
+          "parentModule": ""
+        },
+        "isActive": true
+      }
+    ]
+  },
+  {
+    "tenantId": "kl",
+    "moduleName": "ACCESSCONTROL-ROLEACTIONS",
+    "masterName": "roleactions",
+   "mdmsPayload":[
+     {
+       "tenantId": "kl",
+       "schemaCode": "ACCESSCONTROL-ROLEACTIONS.roleactions",
+       "uniqueIdentifier": "419",
+       "data": {
+         "id": 419,
+         "actioncode": "2703",
+         "actionid": 2703,
+         "rolecode": "SUPERUSER",
+         "tenantid": "kl"
+       },
+       "isActive": true
+     }
+   ]
+  }
+]


### PR DESCRIPTION
#1924
## Requirements



- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [x] If this PR includes MDMS or workflow data changes:
  - [x] I have added MDMS data changes to `support/1924-mdms-data.json`
  - [ ] I have added workflow data changes to `support/<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
For MDMS or workflow changes, list the following:
- [x] Files modified: `support/1924-mdms-data.json`
- [x] Migration steps (if any):
  created the data in the files in the env where to migrate



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration**
	- Added new access control module configurations for testing and role actions.
	- Introduced detailed settings for file deletion and role-based access control.
- **Database Changes**
	- Modified the `isdeleted` column in the `eg_filestoremap` table to allow NULL values while retaining a default value of false.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->