### PR TITLE
[bug 3018 updated]: isActive updated in representatives

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EfilingValidationUtils.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EfilingValidationUtils.js
@@ -2182,9 +2182,7 @@ export const updateCaseDetails = async ({
     };
   }
   if (selected === "advocateDetails") {
-    const caseRepresentatives = () => {
-      return caseDetails?.representatives || [];
-    };
+    const caseRepresentatives = caseDetails?.representatives || [];
     const advocateDetails = [];
     let docList = [];
     const newFormData = await Promise.all(
@@ -2356,7 +2354,7 @@ export const updateCaseDetails = async ({
     // We will check that if a representative is already present in representatives array in case search api data,
     // we will just update the new documents and representinng data to that object.
     const updatedRepresentatives = representatives.map((rep) => {
-      const existingRep = caseRepresentatives().find((caseRep) => caseRep.advocateId === rep.advocateId);
+      const existingRep = caseRepresentatives.find((caseRep) => caseRep.advocateId === rep.advocateId);
       if (existingRep) {
         if (!isMatch(existingRep.documents, rep.documents)) {
           existingRep.documents = rep.documents;
@@ -2367,6 +2365,7 @@ export const updateCaseDetails = async ({
         if (!isMatch(existingRep.additionalDetails, rep.additionalDetails)) {
           existingRep.additionalDetails = rep.additionalDetails;
         }
+        existingRep.isActive = true;
         return existingRep;
       }
       return rep;
@@ -2374,7 +2373,7 @@ export const updateCaseDetails = async ({
 
     // If a representative object was present previously and now that representative is not present now,
     // the same object should again be copied with isActive as false and added in the updatedRepresentatives.
-    caseRepresentatives().forEach((caseRep) => {
+    caseRepresentatives.forEach((caseRep) => {
       const isAlreadyIncluded = updatedRepresentatives.some((rep) => rep.advocateId === caseRep.advocateId);
 
       if (!isAlreadyIncluded) {


### PR DESCRIPTION
Issue: https://github.com/pucardotorg/dristi/issues/3018
## Requirements



- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/<issue-number>-workflow.json`



## Summary
isActive updated for previous entries in representatives








<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the handling of advocate details for a more efficient and clear data retrieval.
- **Bug Fixes**
	- Improved document upload processes to ensure that advocate information is updated correctly, preventing duplicate entries and maintaining data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->