### PR TITLE
disabling right panel for advocate if other advocate have signed

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/ComplainantSignature.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/ComplainantSignature.js
@@ -442,6 +442,19 @@ const ComplainantSignature = ({ path }) => {
     return matchingRepresentatives;
   }
 
+  const isOtherAdvocateSigned = useMemo(() => {
+    // Find the litigant(s) that have a representative with current uuid
+    const litigantsWithCurrentAdv = litigants?.filter((litigant) =>
+      litigant?.representatives?.some((rep) => rep?.additionalDetails?.uuid === userInfo?.uuid)
+    );
+
+    // If there are no litigants with current uuid, return false
+    if (!litigantsWithCurrentAdv?.length) return false;
+
+    // Check if every such litigant has at least one signed representative
+    return litigantsWithCurrentAdv?.every((litigant) => litigant?.representatives?.some((rep) => rep?.hasSigned));
+  }, [litigants, userInfo?.uuid]);
+
   const handleCasePdf = () => {
     downloadPdf(tenantId, signatureDocumentId ? signatureDocumentId : DocumentFileStoreId);
   };
@@ -740,7 +753,7 @@ const ComplainantSignature = ({ path }) => {
 
   const isRightPannelEnable = () => {
     if (isAdvocateFilingCase) {
-      return !(isCurrentAdvocateSigned || isEsignSuccess || uploadDoc);
+      return !(isCurrentAdvocateSigned || isOtherAdvocateSigned || isEsignSuccess || uploadDoc);
     }
     return !(isCurrentLitigantSigned || isEsignSuccess);
   };
@@ -810,8 +823,8 @@ const ComplainantSignature = ({ path }) => {
                   litigant?.representatives?.length > 0 && (
                     <div style={{ ...styles.advocateDetails, marginTop: "5px", fontSize: "15px" }}>
                       {`${t("ADVOCATE_FOR")} ${litigant?.additionalDetails?.fullName}`}
-                      {litigant.representatives.some((rep) => rep?.hasSigned) ||
-                      (litigant.representatives.some((rep) => rep?.additionalDetails?.uuid === userInfo?.uuid) && (isEsignSuccess || uploadDoc)) ? (
+                      {litigant?.representatives?.some((rep) => rep?.hasSigned) ||
+                      (litigant?.representatives?.some((rep) => rep?.additionalDetails?.uuid === userInfo?.uuid) && (isEsignSuccess || uploadDoc)) ? (
                         <span style={styles.signedLabel}>{t("SIGNED")}</span>
                       ) : (
                         <span style={styles.unSignedLabel}>{t("PENDING")}</span>


### PR DESCRIPTION
## Requirements
#3044

- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the signing status display so that the system now verifies if all required representatives have signed. This improvement ensures that the right panel accurately reflects the correct signing status for advocates and litigants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->