### PR TITLE
[#bug 2981]: modal for showing mandatory fields which are not filled on Advocate details page.

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingCases.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingCases.js
@@ -34,7 +34,6 @@ import { sideMenuConfig } from "./Config";
 import EditFieldsModal from "./EditFieldsModal";
 import axios from "axios";
 import {
-  advocateDetailsFileValidation,
   checkDuplicateMobileEmailValidation,
   checkIfscValidation,
   checkNameValidation,
@@ -45,6 +44,7 @@ import {
   debtLiabilityValidation,
   delayApplicationValidation,
   demandNoticeFileValidation,
+  getAdvocatesAndPipRemainingFields,
   getAllAssignees,
   getComplainantName,
   getRespondentName,
@@ -70,6 +70,7 @@ import CaseLockModal from "./CaseLockModal";
 import ConfirmCaseDetailsModal from "./ConfirmCaseDetailsModal";
 import { DocumentUploadError } from "../../../Utils/errorUtil";
 import ConfirmDcaSkipModal from "./ConfirmDcaSkipModal";
+import ErrorDataModal from "./ErrorDataModal";
 
 const OutlinedInfoIcon = () => (
   <svg width="19" height="19" viewBox="0 0 19 19" fill="none" xmlns="http://www.w3.org/2000/svg" style={{ position: "absolute", right: -22, top: 0 }}>
@@ -205,6 +206,7 @@ function EFilingCases({ path }) {
   const [showConfirmDcaSkipModal, setShowConfirmDcaSkipModal] = useState(false);
   const [shouldShowConfirmDcaModal, setShouldShowConfirmDcaModal] = useState(false);
   const [prevIsDcaSkipped, setPrevIsDcaSkipped] = useState("");
+  const [showErrorDataModal, setShowErrorDataModal] = useState({ page: "", showModal: false, errorData: [] });
 
   const [showConfirmCaseDetailsModal, setShowConfirmCaseDetailsModal] = useState(false);
 
@@ -1700,12 +1702,12 @@ function EFilingCases({ path }) {
     ) {
       return;
     }
-    if (
-      formdata
-        .filter((data) => data.isenabled)
-        .some((data) => advocateDetailsFileValidation({ formData: data?.data, selected, setShowErrorToast, setFormErrors: setFormErrors.current, t }))
-    ) {
-      return;
+    if (selected === "advocateDetails") {
+      const advocatesAndPipErrors = getAdvocatesAndPipRemainingFields(formdata, t);
+      if (advocatesAndPipErrors?.length > 0) {
+        setShowErrorDataModal({ page: "advocateDetails", show: true, errorData: advocatesAndPipErrors });
+        return;
+      }
     }
     if (
       formdata
@@ -2813,6 +2815,14 @@ function EFilingCases({ path }) {
       )}
       {showConfirmCaseDetailsModal && (
         <ConfirmCaseDetailsModal t={t} setShowConfirmCaseDetailsModal={setShowConfirmCaseDetailsModal}></ConfirmCaseDetailsModal>
+      )}
+      {showErrorDataModal?.page === selected && showErrorDataModal?.show === true && (
+        <ErrorDataModal
+          t={t}
+          setIsSubmitDisabled={setIsSubmitDisabled}
+          showErrorDataModal={showErrorDataModal}
+          setShowErrorDataModal={setShowErrorDataModal}
+        ></ErrorDataModal>
       )}
       {showConfirmDcaSkipModal && selected === "delayApplications" && (
         // This modal asks to confirm if the user wants to skip submitting Delay condonation Application.

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/ErrorDataModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/ErrorDataModal.js
@@ -1,0 +1,43 @@
+import { CloseSvg, Modal } from "@egovernments/digit-ui-react-components";
+import React, { useMemo } from "react";
+
+const Heading = (props) => {
+  return (
+    <h1 className="heading-m" style={{ marginLeft: "47px" }}>
+      {props.label}
+    </h1>
+  );
+};
+
+const CloseBtn = (props) => {
+  return (
+    <div onClick={props?.onClick} style={{ height: "100%", display: "flex", alignItems: "center", paddingRight: "20px", cursor: "pointer" }}>
+      <CloseSvg />
+    </div>
+  );
+};
+
+function ErrorDataModal({ t, setIsSubmitDisabled, showErrorDataModal, setShowErrorDataModal }) {
+  const handleOnClose = () => {
+    setShowErrorDataModal({ ...showErrorDataModal, show: false, errorData: [] });
+  };
+
+  return (
+    <Modal
+      headerBarMain={<Heading label={t("PLEASE_ENTER_THESE_REMAINING_DETAILS")} />}
+      headerBarEnd={<CloseBtn onClick={handleOnClose} />}
+      actionSaveLabel={t("CS_CLOSE")}
+      actionSaveOnSubmit={handleOnClose}
+      popupModuleActionBarStyles={{ display: "flex", justifyContent: "center" }}
+      popUpStyleMain={{ zIndex: "1000" }}
+    >
+      <div>
+        {showErrorDataModal?.errorData?.map((data) => {
+          return <h1>{`Complainant ${data?.complainant} : ${data?.errorKeys?.join(", ")}`}</h1>;
+        })}
+      </div>
+    </Modal>
+  );
+}
+
+export default ErrorDataModal;


### PR DESCRIPTION
Issue: https://github.com/pucardotorg/dristi/issues/2981

## Summary
When the user hits continue button on advocate details page, if there are some mandatory fields which are not filled on any of the form, we show the fields and the corresponding complainant's name as well on a modal, so that the user knows which are the fields which are missed.
Note: this is a work around because with the current FormComposer from digit, we are not able to validate mandatory fields for multiple forms.


## Requirements



- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/<issue-number>-workflow.json`









## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
	- Enhanced validations now prompt users with clear error feedback for missing or incorrect advocate and document details during case submissions.
	- Introduced an error modal that displays detailed guidance, ensuring a smoother, more intuitive filing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->