### PR TITLE
[BUG 2968 update]: enable document upload when judge sends remark (advocate page)

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/MultipleAdvocatesAndPip.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/MultipleAdvocatesAndPip.js
@@ -14,6 +14,7 @@ import RenderFileCard from "./RenderFileCard";
 import { FileUploader } from "react-drag-drop-files";
 import { useToast } from "./Toast/useToast";
 import { FSOErrorIcon } from "../icons/svgIndex";
+import { CaseWorkflowState } from "../Utils/caseWorkflow";
 
 function ScrutinyInfoAdvocate({ message, t }) {
   return (
@@ -245,7 +246,10 @@ function MultipleAdvocatesAndPip({ t, config, onSelect, formData, errors, setErr
 
   const isCaseReAssigned = useMemo(() => {
     const caseStatus = caseDetails?.status;
-    if (caseStatus === "CASE_REASSIGNED") {
+    if (caseStatus === CaseWorkflowState.CASE_REASSIGNED) {
+      if (caseDetails?.additionalDetails?.judge?.comment) {
+        return { vakalatnamaFileUpload: true, pipAffidavitFileUpload: true };
+      }
       const curentFormIndex = advocateAndPipData?.boxComplainant?.index;
       const currentFormErrorObject =
         caseDetails?.additionalDetails?.scrutiny?.data?.additionalDetails?.advocateDetails?.form?.[curentFormIndex] || {};
@@ -1002,7 +1006,7 @@ function MultipleAdvocatesAndPip({ t, config, onSelect, formData, errors, setErr
                     }
                     {input.documentSubText && <p className="custom-document-sub-header">{t(input.documentSubText)}</p>}
                   </div>
-                  {isCaseReAssigned && isCaseReAssigned.hasOwnProperty(input?.fileKey) && (
+                  {isCaseReAssigned && isCaseReAssigned.hasOwnProperty(input?.fileKey) && isCaseReAssigned?.message && (
                     <ScrutinyInfoAdvocate message={isCaseReAssigned?.message} t={t}></ScrutinyInfoAdvocate>
                   )}
                   {currentValue.map((file, index) => (


### PR DESCRIPTION

Issue: https://github.com/pucardotorg/dristi/issues/2968
## Summary
enable document upload when judge sends remark

## Requirements



- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/<issue-number>-workflow.json`




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the UI to display more informative messages when a case is reassigned, ensuring that users see additional details when available.
	- Improved conditional rendering to better indicate when specific actions, such as document uploads, should be accessible based on extra case details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->