### PR TITLE
[bug - 3370] - parties name should include both (comp and acc) fixed

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/OrderName.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/OrderName.js
@@ -11,7 +11,7 @@ export const OrderName = ({ rowData, colData, value = "" }) => {
       }}
       onClick={() => colData?.clickFunc(rowData)}
     >
-      {rowData?.orderCategory === "COMPOSITE" ? value : t(`ORDER_TYPE_${value.toUpperCase()}`)}
+      {rowData?.orderCategory === "COMPOSITE" ? value : t(`ORDER_TYPE_${value?.toUpperCase()}`)}
     </div>
   );
 };

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrders.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrders.js
@@ -1168,7 +1168,7 @@ const GenerateOrders = () => {
     } else if (["WARRANT", "SUMMONS", "NOTICE"].includes(type)) {
       parties = orderSchema?.orderDetails?.respondentName ? [orderSchema?.orderDetails?.respondentName] : [];
     } else if (type === "SECTION_202_CRPC") {
-      parties = [orderSchema?.orderDetails.soughtOfDetails];
+      parties = [orderSchema?.orderDetails?.applicationFilledBy, orderSchema?.orderDetails.soughtOfDetails];
     } else if (
       orderSchema?.orderDetails?.parties?.length > 0 &&
       ["BAIL", "REJECT_VOLUNTARY_SUBMISSIONS", "APPROVE_VOLUNTARY_SUBMISSIONS", "REJECTION_RESCHEDULE_REQUEST", "CHECKOUT_REJECT"].includes(type)


### PR DESCRIPTION
## Requirements
https://github.com/pucardotorg/dristi/issues/3370


- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved stability in order displays by handling missing data gracefully to prevent runtime errors.
- **New Features**
	- Enhanced the order generation process by including additional party details for a more comprehensive view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->