### PR TITLE
fix for FSO/Magistrate: Add Document button should be enabled every t…

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/SelectUploadDocWithName.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/SelectUploadDocWithName.js
@@ -136,16 +136,22 @@ function SelectUploadDocWithName({ t, config, formData = {}, onSelect }) {
             <div key={index} className="file-uploader-with-name-sub">
               <div className="file-uploader-with-name-header">
                 <h1>{`${t("DOCUMENT_NUMBER_HEADING")} ${index + 1}`}</h1>
-                <span
-                  onClick={() => {
-                    if (!config?.disable) {
-                      handleDeleteDocument(index);
-                    }
-                  }}
-                  style={{ cursor: "pointer" }}
-                >
-                  <DeleteFileIcon />
-                </span>
+
+                {(config?.state === "DRAFT_IN_PROGRESS" || index >= config?.doclength) && (
+                  <span
+                    onClick={() => {
+                      if (!config?.disable && (config?.state === "DRAFT_IN_PROGRESS" || index >= config?.doclength)) {
+                        handleDeleteDocument(index);
+                      }
+                    }}
+                    style={{
+                      cursor: config?.disable ? "not-allowed" : "pointer",
+                      opacity: config?.disable ? 0.5 : 1,
+                    }}
+                  >
+                    <DeleteFileIcon />
+                  </span>
+                )}
               </div>
               <div className="drag-drop-visible-main-with-custom-name">
                 {inputs.map((input) => {
@@ -161,7 +167,7 @@ function SelectUploadDocWithName({ t, config, formData = {}, onSelect }) {
                           onChange={(e) => {
                             handleOnTextChange(e.target.value, input, index);
                           }}
-                          disable={input?.isDisabled || config?.disable}
+                          disable={input?.isDisabled || (index < config?.doclength ? true : config?.disable)}
                           defaultValue={undefined}
                           {...input?.validation}
                         />
@@ -189,7 +195,7 @@ function SelectUploadDocWithName({ t, config, formData = {}, onSelect }) {
                             t={t}
                             uploadErrorInfo={fileErrors}
                             input={input}
-                            disableUploadDelete={config?.disable}
+                            disableUploadDelete={index < config?.doclength ? true : config?.disable}
                           />
                         )}
                         {showFileUploader && (
@@ -216,7 +222,7 @@ function SelectUploadDocWithName({ t, config, formData = {}, onSelect }) {
           );
         })}
       <Button
-        isDisabled={config?.disable || (config?.state && config?.state !== CaseWorkflowState.DRAFT_IN_PROGRESS)}
+        // isDisabled={config?.disable || (config?.state && config?.state !== CaseWorkflowState.DRAFT_IN_PROGRESS)}
         variation="secondary"
         onButtonClick={handleAddDocument}
         className="add-new-document"

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingCases.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingCases.js
@@ -1085,6 +1085,12 @@ function EFilingCases({ path }) {
                 }
               }
 
+              if (selected === "respondentDetails") {
+                if (judgeObj && Object.keys(judgeObj).length > 0 && body?.key === "addressDetails") {
+                  body.isJudgeSendBack = true;
+                }
+              }
+
               if (body?.labelChildren === "optional" && Object.keys(caseDetails?.additionalDetails?.scrutiny?.data || {}).length === 0) {
                 body.labelChildren = <span style={{ color: "#77787B" }}>&nbsp;{`${t("CS_IS_OPTIONAL")}`}</span>;
               }
@@ -1272,6 +1278,8 @@ function EFilingCases({ path }) {
               scrutiny[key] = scrutinyObj[item][key];
             });
           });
+          const scrutinyFormLength = scrutiny?.[selected]?.form?.length || 0;
+          const SelectUploadDocLength = caseDetails?.additionalDetails?.prayerSwornStatement?.formdata?.[0]?.data?.SelectUploadDocWithName?.length || 0;
           let updatedBody = [];
           if (Object.keys(scrutinyObj).length > 0 || isPendingESign || isPendingReESign) {
             updatedBody = config.body
@@ -1326,8 +1334,28 @@ function EFilingCases({ path }) {
                     </React.Fragment>
                   );
                 }
+                
+                if(!isDraftInProgress && selected === "prayerSwornStatement" && SelectUploadDocLength < formdata?.[0]?.data?.SelectUploadDocWithName?.length){
+                  modifiedFormComponent.doclength = SelectUploadDocLength;
+                  modifiedFormComponent.disable = false;
+                }
+                else{
 
-                modifiedFormComponent.disable = scrutiny?.[selected]?.scrutinyMessage?.FSOError || (judgeObj && !isPendingReESign) ? false : true;
+                  // remove disability for new form
+                  modifiedFormComponent.disable =
+                    index + 1 > scrutinyFormLength
+                      ? false
+                      : scrutiny?.[selected]?.scrutinyMessage?.FSOError || (judgeObj && !isPendingReESign)
+                      ? false
+                      : true;
+                }
+
+                if (
+                  modifiedFormComponent?.type === "radio" &&
+                  !(index + 1 > scrutinyFormLength || scrutiny?.[selected]?.scrutinyMessage?.FSOError || (judgeObj && !isPendingReESign))
+                ) {
+                  modifiedFormComponent.populators.styles = { opacity: 0.5 };
+                }
                 if (judgeObj && !isPendingReESign) {
                   if (selected === "complainantDetails") {
                     const disabledFields = ["firstName", "middleName", "lastName", "complainantType", "complainantAge"];
@@ -2783,7 +2811,7 @@ function EFilingCases({ path }) {
               className="add-new-form"
               icon={<CustomAddIcon />}
               label={t(pageConfig.addFormText)}
-              isDisabled={!isDraftInProgress}
+              isDisabled={!isDraftInProgress && selected === "chequeDetails"}
             ></Button>
           )}
           {openConfigurationModal && (


### PR DESCRIPTION
…ime when case is sent back even if FSO didn't flag that

## Requirements

#3102

- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced document management: Deletion is now conditionally available, with visual indicators (e.g., disabled cursor and reduced opacity) clearly showing when actions are not permitted.
  - Refined e-filing experience: Form components dynamically enable or disable based on the case type and judge involvement, with the add form button adjusted to respect draft progress conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->