### PR TITLE
Bulk sign redirection from tabs if in pending e-sign stage, added BOTD in additional details of order, download order on addBulk success fix

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/Utils/orderWorkflow.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/Utils/orderWorkflow.js
@@ -3,6 +3,7 @@ export const OrderTypes = { SCHEDULE_OF_HEARING_DATE: "SCHEDULE_OF_HEARING_DATE"
 export const OrderWorkflowState = {
   ABATED: "ABATED",
   DRAFT_IN_PROGRESS: "DRAFT_IN_PROGRESS",
+  PENDING_BULK_E_SIGN: "PENDING_BULK_E-SIGN",
 };
 
 export const OrderWorkflowAction = {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCase.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCase.js
@@ -582,6 +582,8 @@ const AdmittedCases = () => {
         } else {
           if (order?.status === OrderWorkflowState.DRAFT_IN_PROGRESS) {
             history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${order?.orderNumber}`);
+          } else if (order?.status === OrderWorkflowState.PENDING_BULK_E_SIGN) {
+            history.push(`/${window.contextPath}/employee/home/home-pending-task`, { isBulkEsignSelected: true });
           } else {
             setCurrentOrder(order);
             setShowOrderReviewModal(true);

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/CaseOverview.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/CaseOverview.js
@@ -269,6 +269,8 @@ const CaseOverview = ({
                             history.push(
                               `/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${order?.orderNumber}`
                             );
+                          } else if (order?.status === OrderWorkflowState.PENDING_BULK_E_SIGN) {
+                            history.push(`/${window.contextPath}/employee/home/home-pending-task`, { isBulkEsignSelected: true });
                           } else {
                             setShowReviewModal(true);
                             setCurrentOrder(order);

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/HomeView.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/HomeView.js
@@ -60,6 +60,7 @@ const HomeView = () => {
 
   const [showSubmitResponseModal, setShowSubmitResponseModal] = useState(false);
   const [responsePendingTask, setResponsePendingTask] = useState({});
+  const isBulkEsignSelected = history.location?.state?.isBulkEsignSelected;
   const [showBulkSignAllModal, setShowBulkSignAllModal] = useState(false);
   const [issueBulkSuccessData, setIssueBulkSuccessData] = useState({
     show: false,
@@ -174,7 +175,10 @@ const HomeView = () => {
 
   useEffect(() => {
     state && state.taskType && setTaskType(state.taskType);
-  }, [state]);
+    if (isBulkEsignSelected) {
+      setShowBulkSignAllModal(true);
+    }
+  }, [state, isBulkEsignSelected]);
 
   const { isLoading: isOutcomeLoading, data: outcomeTypeData } = Digit.Hooks.useCustomMDMS(
     Digit.ULBService.getStateId(),
@@ -468,6 +472,9 @@ const HomeView = () => {
       {showBulkSignAllModal && (
         <OrderBulkReviewModal
           t={t}
+          history={history}
+          location={location}
+          isBulkEsignSelected={isBulkEsignSelected}
           showActions={isJudge}
           refetchOrdersData={refetchOrdersData}
           pendingSignOrderList={ordersData?.list}

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pageComponents/OrderBulkReviewModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pageComponents/OrderBulkReviewModal.js
@@ -16,7 +16,17 @@ const parseXml = (xmlString, tagName) => {
   return element ? element.textContent.trim() : null;
 };
 
-function OrderBulkReviewModal({ t, showActions, refetchOrdersData, pendingSignOrderList, setShowBulkSignAllModal, setIssueBulkSuccessData }) {
+function OrderBulkReviewModal({
+  t,
+  history,
+  location,
+  isBulkEsignSelected,
+  showActions,
+  refetchOrdersData,
+  pendingSignOrderList,
+  setShowBulkSignAllModal,
+  setIssueBulkSuccessData,
+}) {
   const [pendingOrderList, setPendingOrderList] = useState(pendingSignOrderList);
   const [selectedOrder, setSelectedOrder] = useState(pendingOrderList?.[0]);
   const tenantId = window?.Digit.ULBService.getCurrentTenantId();
@@ -39,6 +49,12 @@ function OrderBulkReviewModal({ t, showActions, refetchOrdersData, pendingSignOr
       return () => clearTimeout(timer);
     }
   }, [showErrorToast]);
+
+  useEffect(() => {
+    if (pendingOrderList?.length === 0) {
+      setShowBulkSignAllModal(false);
+    }
+  });
 
   const Heading = (props) => {
     return <h1 className="heading-m">{props.label}</h1>;
@@ -198,6 +214,9 @@ function OrderBulkReviewModal({ t, showActions, refetchOrdersData, pendingSignOr
               if (isLoading) return;
               setShowBulkSignAllModal(false);
               await refetchOrdersData();
+              if (isBulkEsignSelected) {
+                history.replace({ ...location, state: null });
+              }
             }}
           />
         }

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pageComponents/OrderReviewModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pageComponents/OrderReviewModal.js
@@ -32,6 +32,7 @@ function OrderReviewModal({
   businessOfDay,
   updateOrder,
   setShowBulkModal,
+  setPrevOrder,
 }) {
   const [fileStoreId, setFileStoreID] = useState(null);
   const [fileName, setFileName] = useState();
@@ -193,10 +194,11 @@ function OrderReviewModal({
             },
           };
           await updateOrder(updatedOrder, OrderWorkflowAction.SUBMIT_BULK_E_SIGN, fileStoreId)
-            .then(() => {
+            .then((response) => {
               setShowReviewModal(false);
               setShowBulkModal(true);
               setUpdateLoading(false);
+              setPrevOrder(response?.order);
             })
             .catch((e) => {
               setShowErrorToast({ label: t("INTERNAL_ERROR_OCCURRED"), error: true });

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pageComponents/OrderReviewModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pageComponents/OrderReviewModal.js
@@ -185,7 +185,14 @@ function OrderReviewModal({
       setUpdateLoading(true);
       handleDocumentUpload(async (fileStoreId) => {
         if (fileStoreId) {
-          await updateOrder(order, OrderWorkflowAction.SUBMIT_BULK_E_SIGN, fileStoreId)
+          const updatedOrder = {
+            ...order,
+            additionalDetails: {
+              ...order.additionalDetails,
+              businessOfTheDay: businessDay,
+            },
+          };
+          await updateOrder(updatedOrder, OrderWorkflowAction.SUBMIT_BULK_E_SIGN, fileStoreId)
             .then(() => {
               setShowReviewModal(false);
               setShowBulkModal(true);

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrders.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrders.js
@@ -3803,6 +3803,11 @@ const GenerateOrders = () => {
     // });
   };
 
+  const handleBulkDownloadOrder = () => {
+    const fileStoreId = prevOrder?.documents?.find((doc) => doc?.documentType === "UNSIGNED")?.fileStore;
+    downloadPdf(tenantId, fileStoreId);
+  };
+
   const handleCustomSubmit = () => {
     modifiedFormConfig.forEach((_, index) => {
       formValueChangeTriggerRefs.current[index]();
@@ -4441,6 +4446,7 @@ const GenerateOrders = () => {
           businessOfDay={businessOfTheDay}
           updateOrder={updateOrder}
           setShowBulkModal={setShowBulkModal}
+          setPrevOrder={setPrevOrder}
         />
       )}
       {showsignatureModal && (
@@ -4516,7 +4522,7 @@ const GenerateOrders = () => {
         <OrderAddToBulkSuccessModal
           t={t}
           order={currentOrder}
-          handleDownloadOrders={handleDownloadOrders}
+          handleDownloadOrders={handleBulkDownloadOrder}
           handleClose={handleClose}
           handleCloseSuccessModal={handleCloseSuccessModal}
           actionSaveLabel={successModalActionSaveLabel}


### PR DESCRIPTION
## Requirements
#3367


- [x] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new bulk e-signature status for orders.
  - Updated navigation so that orders in this status now direct users to a dedicated task page.
  - Enhanced the display logic to conditionally reveal a bulk signing modal based on user selection.
  - Added functionality for bulk downloading unsigned order documents.
  - Improved order update handling by incorporating additional details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->