### PR TITLE
[BUG #3551]: [QA] [Notice failure count is displaying 1 if we edit the name of the accused ] 

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/hearings/src/configs/UICustomizations.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/hearings/src/configs/UICustomizations.js
@@ -283,10 +283,12 @@ export const UICustomizations = {
               locality = "",
               address = "",
             }) => {
-              if (address) {
+              if (address && typeof address === "string") {
                 return address;
-              }
-              return `${locality} ${district} ${city} ${state} ${pincode ? ` - ${pincode}` : ""}`.trim();
+              } else if (address && typeof address === "object") {
+                const { pincode = "", district = "", city = "", state = "", locality } = address;
+                return `${locality} ${district} ${city} ${state} ${pincode ? ` - ${pincode}` : ""}`.trim();
+              } else return `${locality} ${district} ${city} ${state} ${pincode ? ` - ${pincode}` : ""}`.trim();
             };
             const taskData = data?.list
               ?.filter(


### PR DESCRIPTION
issue: #3551

## Summary
changes: sorted respondent type notices and summons by uniqueId instead of name, because name can be edited now through profile editing, but uniqueId will remain same for a respondent. 
after filtering respondents uniqueId wise, the latest edited name will be shown in the modal tabs.
## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/<issue-number>-workflow.json`



