### PR TITLE
[BUG #3551]: [QA] [Notice failure count is displaying 1 if we edit the name of the accused ]

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/hearings/src/configs/UICustomizations.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/hearings/src/configs/UICustomizations.js
@@ -283,10 +283,12 @@ export const UICustomizations = {
               locality = "",
               address = "",
             }) => {
-              if (address) {
+              if (address && typeof address === "string") {
                 return address;
-              }
-              return `${locality} ${district} ${city} ${state} ${pincode ? ` - ${pincode}` : ""}`.trim();
+              } else if (address && typeof address === "object") {
+                const { pincode = "", district = "", city = "", state = "", locality } = address;
+                return `${locality} ${district} ${city} ${state} ${pincode ? ` - ${pincode}` : ""}`.trim();
+              } else return `${locality} ${district} ${city} ${state} ${pincode ? ` - ${pincode}` : ""}`.trim();
             };
             const taskData = data?.list
               ?.filter(


### PR DESCRIPTION
issue: #3551

## Summary
changes: sorted respondent type notices and summons by uniqueId instead of name, because name can be edited now through profile editing, but uniqueId will remain same for a respondent. 
after filtering respondents uniqueId wise, the latest edited name of that respondent will be used to show in the modal tabs.
## Requirements



- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/<issue-number>-workflow.json`





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced address formatting to accurately handle both simple and structured address inputs.
	- Introduced a utility for constructing full names and refined order grouping, ensuring clearer categorization and sorting of party details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->