### PR TITLE
[hotfix-3129-toDev] Need to have all hearings in just 1 slot and freeze time shown to advocates for case hearing to 11am

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/NextHearingCard.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/NextHearingCard.js
@@ -20,6 +20,7 @@ const NextHearingCard = ({ caseData, width }) => {
   const { t } = useTranslation();
   const userRoles = Digit.UserService.getUser()?.info?.roles.map((role) => role.code);
   const isCourtRoomManager = userRoles.includes("COURT_ROOM_MANAGER");
+  const { data: slotTime } = Digit.Hooks.useCustomMDMS(Digit.ULBService.getStateId(), "court", [{ name: "slots" }]);
 
   const { data: hearingRes, isLoading: isHearingsLoading } = Digit.Hooks.hearings.useGetHearings(
     {
@@ -91,6 +92,19 @@ const NextHearingCard = ({ caseData, width }) => {
     }
   };
 
+  function formatTimeTo12Hour(timeString) {
+    // Extract hours and minutes, ignore seconds if present
+    let [hours, minutes] = timeString.split(":").slice(0, 2).map(Number);
+
+    const suffix = hours >= 12 ? "pm" : "am";
+    hours = hours % 12 || 12;
+
+    const formattedHours = String(hours).padStart(2, "0");
+    const formattedMinutes = String(minutes).padStart(2, "0");
+
+    return `${formattedHours}:${formattedMinutes} ${suffix}`;
+  }
+
   if (isHearingsLoading) {
     return <Loader />;
   }
@@ -136,7 +150,8 @@ const NextHearingCard = ({ caseData, width }) => {
                 marginTop: "5px",
               }}
             >
-              {formattedTime()}
+              {/* {formattedTime()} */}
+              {formatTimeTo12Hour(slotTime?.court?.slots[0]?.slotStartTime)} {" -"}
             </div>
             <div
               style={{

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/components/UpComingHearing.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/components/UpComingHearing.js
@@ -51,7 +51,8 @@ class HearingSlot {
 }
 
 function formatTimeTo12Hour(timeString) {
-  let [hours, minutes] = timeString.split(":").map(Number);
+  // Extract hours and minutes, ignore seconds if present
+  let [hours, minutes] = timeString.split(":").slice(0, 2).map(Number);
 
   const suffix = hours >= 12 ? "pm" : "am";
 


### PR DESCRIPTION
## Requirements
#3129


- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Hearing start times are now displayed in a standardized 12-hour AM/PM format for improved clarity.
- **Bug Fixes**
	- Enhanced the time display logic to correctly extract and format hours and minutes, ensuring accurate time presentation even when extra details are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->