### PR TITLE
[# 3543 -updated] : enabled id proof, name and address fields editing in efiling for complainant details page, even if user is already registered one.

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/SelectComponents.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/SelectComponents.js
@@ -173,21 +173,19 @@ const SelectComponents = ({ t, config, onSelect, formData = {}, errors, formStat
     } else {
       onSelect(`${configKey}.${input}`, value, { shouldValidate: true });
       onSelect(config.key, { ...formData?.[config.key], [input]: value }, { shouldValidate: true });
-      if (config?.state === "CASE_REASSIGNED") {
-        onSelect("complainantVerification", {
-          ...formData?.["complainantVerification"],
-          individualDetails: {
-            ...formData?.["complainantVerification"]?.individualDetails,
-            "addressDetails-select": { ...formData?.["addressDetails-select"], [input]: value },
-            addressDetails: {
-              ...formData?.["addressDetails"],
-              [input]: value,
-              coordinates: formData?.["addressDetails"]?.coordinates ? formData["addressDetails"].coordinates : { longitude: "", latitude: "" },
-            },
+      onSelect("complainantVerification", {
+        ...formData?.["complainantVerification"],
+        individualDetails: {
+          ...formData?.["complainantVerification"]?.individualDetails,
+          "addressDetails-select": { ...formData?.["addressDetails-select"], [input]: value },
+          addressDetails: {
+            ...formData?.["addressDetails"],
+            [input]: value,
+            coordinates: formData?.["addressDetails"]?.coordinates ? formData["addressDetails"].coordinates : { longitude: "", latitude: "" },
           },
-          isUserVerified: true,
-        });
-      }
+        },
+        isUserVerified: true,
+      });
     }
   }
 

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/VerificationComponent.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/VerificationComponent.js
@@ -135,10 +135,15 @@ function VerificationComponent({ t, config, onSelect, formData = {}, errors, set
     <div className="verification-component">
       {inputs?.map((input, index) => {
         let currentValue = (formData && formData[config.key] && formData[config.key][input.name]) || "";
+        const isComplainantId =
+          formData?.[config?.key]?.[input?.name] === true || formData?.complainantId?.complainantId?.complainantId?.["ID_Proof"]?.[0]?.[1]?.["file"];
+        if (isComplainantId) {
+          currentValue = formData?.complainantVerification?.individualDetails?.document;
+        }
         let fileErrors =
           currentValue?.["ID_Proof"]?.[0]?.[1]?.["file"] &&
-          [currentValue?.["ID_Proof"]?.[0]?.[1]?.["file"]].map((file) =>
-            fileValidator(file, idProofVerificationConfig?.[0].body[0]?.populators?.inputs?.[1])
+          [currentValue?.["ID_Proof"]?.[0]?.[1]?.["file"]]?.map((file) =>
+            fileValidator(file, idProofVerificationConfig?.[0]?.body[0]?.populators?.inputs?.[1])
           );
         const isUserVerified = isAadharVerified || (!config?.isScrutiny && formData?.[config.key]?.[config.key]);
         return (
@@ -171,19 +176,21 @@ function VerificationComponent({ t, config, onSelect, formData = {}, errors, set
                           );
                         }}
                       /> */}
-                      <Button
-                        className={"secondary-button-selector"}
-                        variation={"secondary"}
-                        label={t("VERIFY_ID_PROOF")}
-                        labelClassName={"secondary-label-selector"}
-                        onButtonClick={() => {
-                          setState((prev) => ({
-                            ...prev,
-                            showModal: true,
-                            verificationType: "uploadIdProof",
-                          }));
-                        }}
-                      />
+                      {!config?.isScrutiny && (
+                        <Button
+                          className={"secondary-button-selector"}
+                          variation={"secondary"}
+                          label={t("VERIFY_ID_PROOF")}
+                          labelClassName={"secondary-label-selector"}
+                          onButtonClick={() => {
+                            setState((prev) => ({
+                              ...prev,
+                              showModal: true,
+                              verificationType: "uploadIdProof",
+                            }));
+                          }}
+                        />
+                      )}
                     </div>
                     {errors?.[config.key] && <span className="alert-error">{t(errors?.[config.key].msg || "CORE_REQUIRED_FIELD_ERROR")}</span>}
                   </React.Fragment>
@@ -206,6 +213,20 @@ function VerificationComponent({ t, config, onSelect, formData = {}, errors, set
                     className={`adhaar-verification-info-card ${isUserVerified && "user-verified"}`}
                   />
                 )}
+                {isComplainantId &&
+                  currentValue?.map((file, index) => (
+                    <RenderFileCard
+                      key={`${input?.name}${index}`}
+                      index={index}
+                      fileData={file}
+                      handleChange={handleChange}
+                      handleDeleteFile={handleDeleteFile}
+                      t={t}
+                      uploadErrorInfo={fileErrors?.[index]}
+                      input={input}
+                      isDisabled={true}
+                    />
+                  ))}
               </React.Fragment>
             ) : (
               [currentValue?.["ID_Proof"]?.[0]?.[1]?.["file"]].map((file, index) => (

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingCases.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingCases.js
@@ -1022,21 +1022,22 @@ function EFilingCases({ path }) {
     }
     return modifiedFormData.map(({ data }, index) => {
       let disableConfigFields = [];
-      formConfig.forEach((config) => {
-        config.body.forEach((body) => {
-          if ("disableConfigFields" in body && "disableConfigKey" in body && "key" in body) {
-            if (!!data?.[body.key]?.[body.disableConfigKey]) {
-              const currentScrutinyObj = scrutinyObj?.litigentDetails?.complainantDetails?.form?.[index];
-              const isAddressDetailsMarked = currentScrutinyObj?.hasOwnProperty?.("addressDetails");
-              if (isAddressDetailsMarked) {
-                disableConfigFields = [...disableConfigFields, ...["firstName", "middleName", "lastName"]];
-              } else {
-                disableConfigFields = [...disableConfigFields, ...body.disableConfigFields];
-              }
-            }
-          }
-        });
-      });
+      // According to new feature (profile editing - #3425), we can edit fields in complainant details page so disabling the fields is no more required.
+      // formConfig.forEach((config) => {
+      //   config.body.forEach((body) => {
+      //     if ("disableConfigFields" in body && "disableConfigKey" in body && "key" in body) {
+      //       if (!!data?.[body.key]?.[body.disableConfigKey]) {
+      //         const currentScrutinyObj = scrutinyObj?.litigentDetails?.complainantDetails?.form?.[index];
+      //         const isAddressDetailsMarked = currentScrutinyObj?.hasOwnProperty?.("addressDetails");
+      //         if (isAddressDetailsMarked) {
+      //           disableConfigFields = [...disableConfigFields, ...["firstName", "middleName", "lastName"]];
+      //         } else {
+      //           disableConfigFields = [...disableConfigFields, ...body.disableConfigFields];
+      //         }
+      //       }
+      //     }
+      //   });
+      // });
       return formConfig
         .filter((config) => {
           const dependentKeys = config?.dependentKey;

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EfilingValidationUtils.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EfilingValidationUtils.js
@@ -1494,7 +1494,7 @@ export const updateCaseDetails = async ({
         updatedFormData
           .filter((item) => item.isenabled)
           .map(async (data, index) => {
-            if (data?.data?.complainantVerification?.individualDetails) {
+            if (data?.data?.complainantVerification?.individualDetails?.document) {
               const Individual = await DRISTIService.searchIndividualUser(
                 {
                   Individual: {
@@ -1711,6 +1711,7 @@ export const updateCaseDetails = async ({
       updatedFormData
         .filter((item) => item.isenabled)
         .map(async (data, index) => {
+          let updatedComplainantVerification = structuredClone(complainantVerification[index] || {});
           let documentData = {
             companyDetailsUpload: null,
           };
@@ -1744,6 +1745,9 @@ export const updateCaseDetails = async ({
             };
             docList.push(doc);
             individualDetails.document = [uploadedData];
+            updatedComplainantVerification.individualDetails = updatedComplainantVerification?.individualDetails
+              ? { ...updatedComplainantVerification?.individualDetails, document: [doc] }
+              : { ...data?.data?.complainantVerification?.individualDetails, document: [doc] };
           }
           if (
             !data?.data?.complainantVerification?.isUserVerified &&
@@ -1757,7 +1761,7 @@ export const updateCaseDetails = async ({
               ...data?.data?.complainantVerification?.individualDetails?.document?.[0],
               documentType: documentsTypeMapping["complainantId"],
             };
-            docList.push(doc);
+            !individualDetails?.document && docList.push(doc);
           }
           if (data?.data?.companyDetailsUpload?.document) {
             documentData.companyDetailsUpload = {};
@@ -1789,7 +1793,7 @@ export const updateCaseDetails = async ({
               ...documentData,
               complainantVerification: {
                 ...data?.data?.complainantVerification,
-                ...complainantVerification[index],
+                ...updatedComplainantVerification,
                 isUserVerified: Boolean(data?.data?.complainantVerification?.mobileNumber && data?.data?.complainantVerification?.otpNumber),
               },
               ...(data?.data?.complainantId?.complainantId?.ID_Proof?.[0]?.[1]?.file && idProof),

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/view-case/Config/editComplainantDetailsConfig.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/view-case/Config/editComplainantDetailsConfig.js
@@ -119,29 +119,29 @@ const editComplainantDetailsFormConfig = [
     },
   },
   {
+    dependentKey: { complainantType: ["commonFields"] },
     body: [
       {
         type: "component",
-        component: "SelectCustomDragDrop",
-        key: "complainantIDProofDocument",
-        isMandatory: true,
+        component: "VerificationComponent",
+        key: "complainantId",
         withoutLabel: true,
+        isMandatory: true,
         populators: {
+          name: "complainantId",
           inputs: [
             {
-              name: "document",
-              documentHeader: "COMPLAINANT_ID_PROOF",
-              type: "DragDropComponent",
-              uploadGuidelines: "UPLOAD_DOC_50",
-              maxFileSize: 50,
-              maxFileErrorMessage: "CS_FILE_LIMIT_50_MB",
-              fileTypes: ["JPG", "PDF", "PNG", "JPEG"],
-              isMultipleUpload: false,
-              documentHeaderStyle: {
-                margin: "0px",
-              },
+              label: "COMPLAINANT_ID",
+              updateLabelOn: "complainantType.showCompanyDetails",
+              updateLabel: { key: "label", value: "CS_ENTITY_ID" },
+              defaultLabel: { key: "label", value: "COMPLAINANT_ID" },
+              name: "complainantId",
+              verificationOn: "complainantVerification.individualDetails",
             },
           ],
+          customStyle: {
+            marginTop: 20,
+          },
         },
       },
     ],

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/view-case/Config/editRespondentConfig.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/view-case/Config/editRespondentConfig.js
@@ -539,6 +539,12 @@ const editRespondentFormconfig = [
               name: "text",
               textAreaSubHeader: "CS_REASON_FOR_CHANGE",
               type: "TextAreaComponent",
+              errorStyle: {
+                fontSize: "14px",
+                fontWeight: 400,
+                paddingTop: "20px",
+                color: "#d4351c",
+              },
             },
           ],
         },

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/view-case/editProfileValidationUtils.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/view-case/editProfileValidationUtils.js
@@ -32,6 +32,13 @@ export const editComplainantValidation = ({
     } else {
       clearFormDataErrors("complainantVerification");
     }
+    if (!formData?.complainantId?.complainantId?.ID_Proof?.[0]?.[1]?.file) {
+      setShowErrorToast(true);
+      setFormErrors("complainantId", { message: "COMPLAINANT_ID_PROOF_IS_MANDATORY" });
+      return true;
+    } else {
+      clearFormDataErrors("complainantId");
+    }
     const respondentData = caseDetails?.additionalDetails?.respondentDetails;
     const complainantMobileNumber = formData?.complainantVerification?.mobileNumber;
     if (respondentData) {
@@ -358,28 +365,21 @@ export const updateProfileData = async ({
             companyDetailsUpload: null,
             supportingDocument: null,
           };
-          if (
-            data?.data?.complainantIDProofDocument?.document &&
-            Array.isArray(data?.data?.complainantIDProofDocument?.document) &&
-            data?.data?.complainantIDProofDocument?.document.length > 0
-          ) {
-            documentData.complainantIDProofDocument = {};
-            documentData.complainantIDProofDocument.document = await Promise.all(
-              data?.data?.complainantIDProofDocument?.document?.map(async (document) => {
-                if (document) {
-                  const documentType = documentsTypeMapping["complainantId"];
-                  const uploadedData = await onDocumentUpload(documentType, document, document.name, tenantId);
-                  const doc = {
-                    documentType,
-                    fileStore: uploadedData.file?.files?.[0]?.fileStoreId || document?.fileStore,
-                    documentName: uploadedData.filename || document?.documentName,
-                    fileName: complainantIdProofFileName,
-                  };
-                  return doc;
-                }
-              })
+          if (data?.data?.complainantId?.complainantId?.ID_Proof?.[0]?.[1]?.file) {
+            const documentType = documentsTypeMapping["complainantId"];
+            const uploadedData = await onDocumentUpload(
+              documentType,
+              data?.data?.complainantId?.complainantId?.ID_Proof?.[0]?.[1]?.file,
+              data?.data?.complainantId?.complainantId?.ID_Proof?.[0]?.[0],
+              tenantId
             );
-            setFormDataValue("complainantIDProofDocument", documentData?.complainantIDProofDocument);
+            const doc = {
+              documentType,
+              fileStore: uploadedData.file?.files?.[0]?.fileStoreId || uploadedData?.fileStore,
+              documentName: uploadedData.filename || uploadedData?.documentName,
+            };
+
+            documentData.complainantIDProofDocument = { document: [doc] };
           }
           if (
             data?.data?.companyDetailsUpload?.document &&
@@ -430,7 +430,8 @@ export const updateProfileData = async ({
             setFormDataValue("supportingDocument", documentData?.supportingDocument);
           }
           const updatedComplainantVerification = structuredClone(data?.data?.complainantVerification);
-          updatedComplainantVerification.individualDetails.document = documentData?.complainantIDProofDocument?.document || [];
+          updatedComplainantVerification.individualDetails.document =
+            documentData?.complainantIDProofDocument?.document || updatedComplainantVerification?.individualDetails?.document || [];
           return {
             ...data,
             isFormCompleted: true,


### PR DESCRIPTION
Issue: #3543

## Summary
enabled id proof, name and address fields editing in efiling for complainant details page, even if user is already registered one.
## Requirements



- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/<issue-number>-workflow.json`





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined the verification process with consistent status updates and improved document handling.
	- Enabled editing of fields that were previously restricted, enhancing profile management.
	- Refined the display of verification documents and conditional action buttons.
	- Strengthened validation to ensure mandatory identification files are provided.

- **Style**
	- Updated error message styling for clearer and more consistent user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->