### PR TITLE
[BUG #3575]: BoTD for litigant edit 

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/ReviewLitigantDetails.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/ReviewLitigantDetails.js
@@ -231,6 +231,7 @@ const ReviewLitigantDetails = ({ path }) => {
             dateOfApplication: location?.state?.dateOfApplication,
             uniqueId: location?.state?.uniqueId,
             applicantPartyUuid: profileRequest?.editorDetails?.uuid,
+            applicantType: profileRequest?.editorDetails?.isAdvocate ? "ADVOCATE" : "COMPLAINANT",
             pendingTaskRefId: referenceId,
           },
         },


### PR DESCRIPTION
Issue: #3575
## Summary
added default value of BOTD for order type accept/reject profile edit request.

## Requirements



- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/<issue-number>-workflow.json`




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the case review process by clearly distinguishing between Advocate and Complainant applicants.
	- Improved order generation by dynamically retrieving and displaying the profile editor’s full name in context-based notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->