### PR TITLE
[#3576]: Affidavit field not needed for accused details editing 

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/view-case/Config/editRespondentConfig.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/view-case/Config/editRespondentConfig.js
@@ -497,36 +497,6 @@ const editRespondentFormconfig = [
   {
     body: [
       {
-        key: "inquiryAffidavitFileUpload",
-        type: "component",
-        label: "AFFIDAVIT_UNDER_SECTION_225_BNSS",
-        component: "SelectCustomDragDrop",
-        populators: {
-          inputs: [
-            {
-              name: "document",
-              type: "DragDropComponent",
-              fileTypes: ["JPG", "JPEG", "PDF", "PNG"],
-              isOptional: "",
-              maxFileSize: 50,
-              documentHeader: "AFFIDAVIT_UNDER_SECTION_225_BNSS",
-              isMultipleUpload: true,
-              uploadGuidelines: "UPLOAD_DOC_50",
-              infoTooltipMessage: "AFFIDAVIT_UNDER_SECTION_225_BNSS_TOOLTIP_MSG",
-              maxFileErrorMessage: "CS_FILE_LIMIT_50_MB",
-            },
-          ],
-        },
-        withoutLabel: true,
-      },
-    ],
-    dependentKey: {
-      respondentType: ["commonFields"],
-    },
-  },
-  {
-    body: [
-      {
         type: "component",
         component: "SelectCustomTextArea",
         key: "reasonForChange",

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/view-case/EditProfile.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/view-case/EditProfile.js
@@ -606,7 +606,7 @@ const EditProfile = ({ path }) => {
         (item, index) => item?.data?.respondentVerification?.individualDetails?.individualId === uniqueId || item?.uniqueId === uniqueId
       );
       if (currentRespondent?.data) {
-        const updatedData = structuredClone(currentRespondent?.data);
+        const { inquiryAffidavitFileUpload, ...updatedData } = structuredClone(currentRespondent?.data);
         return updatedData;
       } else return {};
     }

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/view-case/editProfileValidationUtils.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/view-case/editProfileValidationUtils.js
@@ -587,6 +587,12 @@ export const updateProfileData = async ({
     if (respVerification) {
       remainingFormData.respondentVerification = { ...respVerification };
     }
+    if (currentRespondent?.data) {
+      const { inquiryAffidavitFileUpload, ...restData } = currentRespondent?.data || {};
+      if (inquiryAffidavitFileUpload) {
+        remainingFormData.inquiryAffidavitFileUpload = { ...inquiryAffidavitFileUpload };
+      }
+    }
     profilePayload = {
       tenantId,
       caseId,

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrders.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrders.js
@@ -3531,12 +3531,18 @@ const GenerateOrders = () => {
         }
 
         try {
-          await Promise.all(updatedOrders?.map((item) => createTask(item?.order?.orderType, item)));
+          await Promise.all(
+            updatedOrders
+              ?.filter((item) => ["SUMMONS", "WARRANT", "NOTICE"].includes(item?.order?.orderType))
+              ?.map((item) => createTask(item?.order?.orderType, item))
+          );
         } catch (error) {
           console.error("Error in creating tasks:", error);
         }
       } else {
-        createTask(currentOrder?.orderType, orderResponse);
+        if (["SUMMONS", "WARRANT", "NOTICE"].includes(currentOrder?.orderType)) {
+          createTask(currentOrder?.orderType, orderResponse);
+        }
       }
 
       setShowSuccessModal(true);


### PR DESCRIPTION
Issue: #3576

## Summary
hide affidavit edit of accused during profile editing

## Requirements

- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/<issue-number>-workflow.json`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the affidavit file upload option from the respondent editing form, streamlining the profile update process.
- **Bug Fixes**
  - Updated the order task generation flow to process only orders of types "SUMMONS," "WARRANT," and "NOTICE," ensuring that only relevant tasks are created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->