### PR TITLE
[bug 3598]: greying out date of accrual field in demand notice

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/css/src/dristi/eFiling.scss
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/css/src/dristi/eFiling.scss
@@ -697,6 +697,11 @@
     margin: 0px !important;
     max-width: 100%;
   }
+  .date-of-accrual {
+    color: #bbbbbd !important;
+    border: solid 1px #bbbbbd !important;
+    pointer-events: none !important;
+  }
 }
 
 .delay-application {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/Config/demandNoticeConfig.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/Config/demandNoticeConfig.js
@@ -2,159 +2,108 @@ const demandNoticeFormConfig = [
   {
     body: [
       {
-        type: "component",
-        component: "SelectUserTypeComponent",
-        key: "modeOfDispatchType",
-        isMandatory: true,
-        withoutLabel: true,
-        populators: {
-          inputs: [
-            {
-              label: "CS_MODE_OF_DISPATCH_TYPE",
-              type: "dropdown",
-              name: "modeOfDispatchType",
-              optionsKey: "name",
-              error: "CORE_REQUIRED_FIELD_ERROR",
-              required: false,
-              isMandatory: true,
-              mdmsConfig: {
-                masterName: "DispatchMode",
-                moduleName: "case",
-                select: "(data) => {return data['case'].DispatchMode?.map((item) => {return item;});}",
-              },
-            },
-          ],
-        },
-      },
-    ],
-  },
-  {
-    body: [
-      {
-        type: "date",
-        label: "CS_DATE_OF_ISSUANCE_LDN",
-        labelChildren: "OutlinedInfoIcon",
-        isMandatory: true,
-        populators: {
-          name: "dateOfIssuance",
-          validation: {
-            max: {
-              patternType: "date",
-              masterName: "commonUiConfig",
-              moduleName: "maxDateValidation",
-            },
-          },
-        },
-      },
-    ],
-  },
-  {
-    body: [
-      {
         type: "date",
         label: "CS_DATE_OF_DISPATCH_LDN",
-        labelChildren: "OutlinedInfoIcon",
-        isMandatory: true,
         populators: {
           name: "dateOfDispatch",
           validation: {
             max: {
-              patternType: "date",
               masterName: "commonUiConfig",
               moduleName: "maxDateValidation",
+              patternType: "date",
             },
           },
         },
-      },
-    ],
-  },
-  {
-    body: [
-      {
-        type: "component",
-        component: "SelectCustomDragDrop",
-        key: "legalDemandNoticeFileUpload",
-        withoutLabel: true,
-        populators: {
-          inputs: [
-            {
-              name: "document",
-              documentHeader: "LEGAL_DEMAND_NOTICE",
-              type: "DragDropComponent",
-              uploadGuidelines: "UPLOAD_DOC_50",
-              maxFileSize: 50,
-              maxFileErrorMessage: "CS_FILE_LIMIT_50_MB",
-              fileTypes: ["JPG", "PDF", "PNG"],
-              isMultipleUpload: true,
-            },
-          ],
-        },
-      },
-    ],
-  },
-  {
-    body: [
-      {
-        type: "component",
-        component: "SelectCustomDragDrop",
-        key: "proofOfDispatchFileUpload",
-        withoutLabel: true,
-        populators: {
-          inputs: [
-            {
-              name: "document",
-              documentHeader: "PROOF_OF_DISPATCH_LDN",
-              type: "DragDropComponent",
-              uploadGuidelines: "UPLOAD_DOC_50",
-              maxFileSize: 50,
-              maxFileErrorMessage: "CS_FILE_LIMIT_50_MB",
-              fileTypes: ["JPG", "PDF", "PNG"],
-              isMultipleUpload: true,
-            },
-          ],
-        },
-      },
-    ],
-  },
-  {
-    body: [
-      {
-        type: "radio",
-        key: "proofOfService",
-        label: "CS_DELAY_APPLICATION_TYPE",
         isMandatory: true,
+        labelChildren: "OutlinedInfoIcon",
+      },
+    ],
+  },
+  {
+    body: [
+      {
+        key: "legalDemandNoticeFileUpload",
+        type: "component",
+        label: "LEGAL_DEMAND_NOTICE",
+        component: "SelectCustomDragDrop",
+        populators: {
+          inputs: [
+            {
+              name: "document",
+              type: "DragDropComponent",
+              fileTypes: ["JPG", "JPEG", "PDF", "PNG"],
+              maxFileSize: 50,
+              documentHeader: "LEGAL_DEMAND_NOTICE",
+              isMultipleUpload: true,
+              uploadGuidelines: "UPLOAD_DOC_50",
+              maxFileErrorMessage: "CS_FILE_LIMIT_50_MB",
+            },
+          ],
+        },
+        isMandatory: true,
+        withoutLabel: true,
+      },
+    ],
+  },
+  {
+    body: [
+      {
+        key: "proofOfDispatchFileUpload",
+        type: "component",
+        label: "PROOF_OF_DISPATCH_LDN",
+        component: "SelectCustomDragDrop",
+        populators: {
+          inputs: [
+            {
+              name: "document",
+              type: "DragDropComponent",
+              fileTypes: ["JPG", "JPEG", "PDF", "PNG"],
+              maxFileSize: 50,
+              documentHeader: "PROOF_OF_DISPATCH_LDN",
+              isMultipleUpload: true,
+              uploadGuidelines: "UPLOAD_DOC_50",
+              maxFileErrorMessage: "CS_FILE_LIMIT_50_MB",
+            },
+          ],
+        },
+        isMandatory: true,
+        withoutLabel: true,
+      },
+    ],
+  },
+  {
+    body: [
+      {
+        key: "proofOfService",
+        type: "radio",
+        label: "CS_DELAY_APPLICATION_TYPE",
         populators: {
           name: "proofOfService",
-          label: "CS_DELAY_APPLICATION_TYPE",
           type: "radioButton",
-          optionsKey: "name",
           error: "CORE_REQUIRED_FIELD_ERROR",
-          required: false,
-          isMandatory: true,
-          isDependent: true,
-          clearFields: {
-            stateOfRegistration: "",
-            barRegistrationNumber: "",
-            barCouncilId: [],
-            stateRegnNumber: "",
-          },
+          label: "CS_DELAY_APPLICATION_TYPE",
           options: [
             {
               code: "YES",
               name: "YES",
-              showProofOfAcknowledgment: true,
               isEnabled: true,
+              showProofOfAcknowledgment: true,
             },
             {
               code: "NO",
               name: "NO",
-              showProofOfAcknowledgment: false,
+              isEnabled: true,
               isVerified: true,
               hasBarRegistrationNo: true,
-              isEnabled: true,
+              showProofOfAcknowledgment: false,
             },
           ],
+          required: false,
+          optionsKey: "name",
+          isDependent: true,
+          isMandatory: true,
         },
+        isMandatory: true,
       },
     ],
   },
@@ -163,129 +112,151 @@ const demandNoticeFormConfig = [
       {
         type: "date",
         label: "CS_DATE_OF_SERVICE_LDN",
-        isMandatory: true,
         populators: {
           name: "dateOfService",
           validation: {
             max: {
-              patternType: "date",
               masterName: "commonUiConfig",
               moduleName: "maxDateValidation",
+              patternType: "date",
             },
           },
         },
+        isMandatory: true,
       },
     ],
   },
   {
     body: [
       {
-        type: "component",
-        component: "SelectCustomDragDrop",
         key: "proofOfAcknowledgmentFileUpload",
-        isDocDependentOn: "proofOfService",
-        isDocDependentKey: "showProofOfAcknowledgment",
+        type: "component",
+        label: "PROOF_LEGAL_DEMAND_NOTICE",
+        component: "SelectCustomDragDrop",
         populators: {
           inputs: [
             {
               name: "document",
-              documentHeader: "PROOF_LEGAL_DEMAND_NOTICE",
               type: "DragDropComponent",
-              uploadGuidelines: "UPLOAD_DOC_50",
+              fileTypes: ["JPG", "JPEG", "PDF", "PNG"],
               maxFileSize: 50,
-              maxFileErrorMessage: "CS_FILE_LIMIT_50_MB",
-              fileTypes: ["JPG", "PDF", "PNG"],
+              documentHeader: "PROOF_LEGAL_DEMAND_NOTICE",
               isMultipleUpload: true,
-              documentHeaderStyle: { textAlign: "left" },
+              uploadGuidelines: "UPLOAD_DOC_50",
+              documentHeaderStyle: {
+                textAlign: "left",
+              },
+              maxFileErrorMessage: "CS_FILE_LIMIT_50_MB",
             },
           ],
         },
+        isMandatory: true,
+        withoutLabel: true,
+        isDocDependentOn: "proofOfService",
+        isDocDependentKey: "showProofOfAcknowledgment",
       },
     ],
   },
   {
     body: [
       {
-        type: "radio",
         key: "proofOfReply",
+        type: "radio",
         label: "CS_REPLY_NOTICE",
-        isMandatory: true,
         populators: {
           name: "proofOfReply",
-          label: "CS_REPLY_NOTICE",
           type: "radioButton",
-          optionsKey: "name",
           error: "CORE_REQUIRED_FIELD_ERROR",
-          required: false,
-          isMandatory: true,
-          isDependent: true,
-          clearFields: {
-            stateOfRegistration: "",
-            barRegistrationNumber: "",
-            barCouncilId: [],
-            stateRegnNumber: "",
-          },
+          label: "CS_REPLY_NOTICE",
           options: [
             {
               code: "YES",
               name: "YES",
-              showProofOfReply: true,
               isEnabled: true,
+              showProofOfReply: true,
             },
             {
               code: "NO",
               name: "NO",
-              showProofOfReply: false,
-              isVerified: true,
-              hasBarRegistrationNo: true,
               isEnabled: true,
+              isVerified: true,
+              showProofOfReply: false,
+              hasBarRegistrationNo: true,
             },
           ],
+          required: false,
+          optionsKey: "name",
+          isDependent: true,
+          isMandatory: true,
         },
+        isMandatory: true,
       },
     ],
   },
   {
-    dependentKey: {
-      proofOfReply: ["showProofOfReply"],
-    },
     body: [
       {
         type: "date",
         label: "CS_DATE_OF_REPLY_LDN",
-        isMandatory: true,
         populators: {
           name: "dateOfReply",
           validation: {
             max: {
-              patternType: "date",
               masterName: "commonUiConfig",
               moduleName: "maxDateValidation",
+              patternType: "date",
             },
           },
         },
+        isMandatory: true,
+      },
+    ],
+    dependentKey: {
+      proofOfReply: ["showProofOfReply"],
+    },
+  },
+  {
+    body: [
+      {
+        key: "proofOfReplyFileUpload",
+        type: "component",
+        label: "CS_PROOF_TO_REPLY_DEMAND_NOTICE",
+        component: "SelectCustomDragDrop",
+        populators: {
+          inputs: [
+            {
+              name: "document",
+              type: "DragDropComponent",
+              fileTypes: ["JPG", "JPEG", "PDF", "PNG"],
+              isOptional: "CS_IS_OPTIONAL",
+              maxFileSize: 50,
+              documentHeader: "CS_PROOF_TO_REPLY_DEMAND_NOTICE",
+              isMultipleUpload: true,
+              uploadGuidelines: "UPLOAD_DOC_50",
+              maxFileErrorMessage: "CS_FILE_LIMIT_50_MB",
+            },
+          ],
+        },
+        isMandatory: false,
+        withoutLabel: true,
+        isDocDependentOn: "proofOfReply",
+        isDocDependentKey: "showProofOfReply",
       },
     ],
   },
   {
     body: [
       {
+        key: "causeOfActionNote",
         type: "component",
-        component: "SelectCustomDragDrop",
-        key: "proofOfReplyFileUpload",
-        isDocDependentOn: "proofOfReply",
-        isDocDependentKey: "showProofOfReply",
+        component: "SelectCustomNote",
         populators: {
           inputs: [
             {
-              name: "document",
-              documentHeader: "CS_PROOF_TO_REPLY_DEMAND_NOTICE",
-              type: "DragDropComponent",
-              uploadGuidelines: "UPLOAD_DOC_50",
-              maxFileSize: 50,
-              maxFileErrorMessage: "CS_FILE_LIMIT_50_MB",
-              fileTypes: ["JPG", "PDF", "PNG"],
-              isMultipleUpload: true,
+              type: "InfoComponent",
+              infoText: "CAUSE_OF_ACTION_FROM_DELIVERY",
+              infoHeader: "CS_COMMON_NOTE",
+              infoTooltipMessage: "CAUSE_OF_ACTION_FROM_DELIVERY",
             },
           ],
         },
@@ -297,60 +268,19 @@ const demandNoticeFormConfig = [
       {
         type: "date",
         label: "CS_DATE_OF_ACCRUAL_LDN",
-        labelChildren: "OutlinedInfoIcon",
-        isMandatory: true,
         populators: {
           name: "dateOfAccrual",
+          customClass: "date-of-accrual",
           validation: {
             max: {
-              patternType: "date",
               masterName: "commonUiConfig",
               moduleName: "maxDateValidation",
+              patternType: "date",
             },
           },
         },
-      },
-    ],
-  },
-  {
-    body: [
-      {
-        type: "radio",
-        key: "delayApplicationType",
-        label: "CS_PAYER_FAIL_TO_PAY",
         isMandatory: true,
-        populators: {
-          name: "delayApplicationType",
-          label: "CS_PAYER_FAIL_TO_PAY",
-          type: "radioButton",
-          optionsKey: "name",
-          error: "CORE_REQUIRED_FIELD_ERROR",
-          required: false,
-          isMandatory: true,
-          isDependent: true,
-          clearFields: {
-            stateOfRegistration: "",
-            barRegistrationNumber: "",
-            barCouncilId: [],
-            stateRegnNumber: "",
-          },
-          options: [
-            {
-              code: "YES",
-              name: "YES",
-              showForm: false,
-              isEnabled: true,
-            },
-            {
-              code: "NO",
-              name: "NO",
-              showForm: true,
-              isVerified: true,
-              hasBarRegistrationNo: true,
-              isEnabled: true,
-            },
-          ],
-        },
+        labelChildren: "OutlinedInfoIcon",
       },
     ],
   },
@@ -359,14 +289,15 @@ const demandNoticeFormConfig = [
 export const demandNoticeConfig = {
   formconfig: demandNoticeFormConfig,
   header: "CS_DEMAND_NOTICE_HEADING",
-  subtext: "CS_DEMAND_NOTICE_SUBTEXT",
+  subtext: "CS_COMPLAINT_DATA_ENTRY_INFO",
   isOptional: false,
   addFormText: "ADD_DEMAND_NOTICE",
   formItemName: "CS_DEMAND_NOTICE",
   className: "demand-notice",
   selectDocumentName: {
-    proofOfDispatchFileUpload: "PROOF_OF_DISPATCH_LDN",
-    proofOfAcknowledgmentFileUpload: "PROOF_LEGAL_DEMAND_NOTICE",
-    proofOfReplyFileUpload: "CS_PROOF_TO_REPLY_DEMAND_NOTICE",
+    proofOfReplyFileUpload: "CS_PROOF_TO_REPLY_DEMAND_NOTICE_FILE_NAME",
+    proofOfDispatchFileUpload: "PROOF_OF_DISPATCH_FILE_NAME",
+    legalDemandNoticeFileUpload: "LEGAL_DEMAND_NOTICE",
+    proofOfAcknowledgmentFileUpload: "PROOF_LEGAL_DEMAND_NOTICE_FILE_NAME",
   },
 };

--- a/support/3598-mdms-data.json
+++ b/support/3598-mdms-data.json
@@ -1,0 +1,316 @@
+{
+  "tenantId": "kl",
+  "masterName": "commonUiConfig",
+  "moduleName": "demandNoticeConfig",
+  "mdmsPayload": [
+    {
+      "id": "9decf574-885c-48ba-8cd4-b9fe1695ec1c",
+      "tenantId": "kl",
+      "schemaCode": "commonUiConfig.demandNoticeConfig",
+      "uniqueIdentifier": "1",
+      "data": {
+        "id": 1,
+        "header": "CS_DEMAND_NOTICE_HEADING",
+        "subtext": "CS_COMPLAINT_DATA_ENTRY_INFO",
+        "className": "demand-notice",
+        "formconfig": [
+          {
+            "body": [
+              {
+                "type": "date",
+                "label": "CS_DATE_OF_DISPATCH_LDN",
+                "populators": {
+                  "name": "dateOfDispatch",
+                  "validation": {
+                    "max": {
+                      "masterName": "commonUiConfig",
+                      "moduleName": "maxDateValidation",
+                      "patternType": "date"
+                    }
+                  }
+                },
+                "isMandatory": true,
+                "labelChildren": "OutlinedInfoIcon"
+              }
+            ]
+          },
+          {
+            "body": [
+              {
+                "key": "legalDemandNoticeFileUpload",
+                "type": "component",
+                "label": "LEGAL_DEMAND_NOTICE",
+                "component": "SelectCustomDragDrop",
+                "populators": {
+                  "inputs": [
+                    {
+                      "name": "document",
+                      "type": "DragDropComponent",
+                      "fileTypes": ["JPG", "JPEG", "PDF", "PNG"],
+                      "maxFileSize": 50,
+                      "documentHeader": "LEGAL_DEMAND_NOTICE",
+                      "isMultipleUpload": true,
+                      "uploadGuidelines": "UPLOAD_DOC_50",
+                      "maxFileErrorMessage": "CS_FILE_LIMIT_50_MB"
+                    }
+                  ]
+                },
+                "isMandatory": true,
+                "withoutLabel": true
+              }
+            ]
+          },
+          {
+            "body": [
+              {
+                "key": "proofOfDispatchFileUpload",
+                "type": "component",
+                "label": "PROOF_OF_DISPATCH_LDN",
+                "component": "SelectCustomDragDrop",
+                "populators": {
+                  "inputs": [
+                    {
+                      "name": "document",
+                      "type": "DragDropComponent",
+                      "fileTypes": ["JPG", "JPEG", "PDF", "PNG"],
+                      "maxFileSize": 50,
+                      "documentHeader": "PROOF_OF_DISPATCH_LDN",
+                      "isMultipleUpload": true,
+                      "uploadGuidelines": "UPLOAD_DOC_50",
+                      "maxFileErrorMessage": "CS_FILE_LIMIT_50_MB"
+                    }
+                  ]
+                },
+                "isMandatory": true,
+                "withoutLabel": true
+              }
+            ]
+          },
+          {
+            "body": [
+              {
+                "key": "proofOfService",
+                "type": "radio",
+                "label": "CS_DELAY_APPLICATION_TYPE",
+                "populators": {
+                  "name": "proofOfService",
+                  "type": "radioButton",
+                  "error": "CORE_REQUIRED_FIELD_ERROR",
+                  "label": "CS_DELAY_APPLICATION_TYPE",
+                  "options": [
+                    {
+                      "code": "YES",
+                      "name": "YES",
+                      "isEnabled": true,
+                      "showProofOfAcknowledgment": true
+                    },
+                    {
+                      "code": "NO",
+                      "name": "NO",
+                      "isEnabled": true,
+                      "isVerified": true,
+                      "hasBarRegistrationNo": true,
+                      "showProofOfAcknowledgment": false
+                    }
+                  ],
+                  "required": false,
+                  "optionsKey": "name",
+                  "isDependent": true,
+                  "isMandatory": true
+                },
+                "isMandatory": true
+              }
+            ]
+          },
+          {
+            "body": [
+              {
+                "type": "date",
+                "label": "CS_DATE_OF_SERVICE_LDN",
+                "populators": {
+                  "name": "dateOfService",
+                  "validation": {
+                    "max": {
+                      "masterName": "commonUiConfig",
+                      "moduleName": "maxDateValidation",
+                      "patternType": "date"
+                    }
+                  }
+                },
+                "isMandatory": true
+              }
+            ]
+          },
+          {
+            "body": [
+              {
+                "key": "proofOfAcknowledgmentFileUpload",
+                "type": "component",
+                "label": "PROOF_LEGAL_DEMAND_NOTICE",
+                "component": "SelectCustomDragDrop",
+                "populators": {
+                  "inputs": [
+                    {
+                      "name": "document",
+                      "type": "DragDropComponent",
+                      "fileTypes": ["JPG", "JPEG", "PDF", "PNG"],
+                      "maxFileSize": 50,
+                      "documentHeader": "PROOF_LEGAL_DEMAND_NOTICE",
+                      "isMultipleUpload": true,
+                      "uploadGuidelines": "UPLOAD_DOC_50",
+                      "documentHeaderStyle": {
+                        "textAlign": "left"
+                      },
+                      "maxFileErrorMessage": "CS_FILE_LIMIT_50_MB"
+                    }
+                  ]
+                },
+                "isMandatory": true,
+                "withoutLabel": true,
+                "isDocDependentOn": "proofOfService",
+                "isDocDependentKey": "showProofOfAcknowledgment"
+              }
+            ]
+          },
+          {
+            "body": [
+              {
+                "key": "proofOfReply",
+                "type": "radio",
+                "label": "CS_REPLY_NOTICE",
+                "populators": {
+                  "name": "proofOfReply",
+                  "type": "radioButton",
+                  "error": "CORE_REQUIRED_FIELD_ERROR",
+                  "label": "CS_REPLY_NOTICE",
+                  "options": [
+                    {
+                      "code": "YES",
+                      "name": "YES",
+                      "isEnabled": true,
+                      "showProofOfReply": true
+                    },
+                    {
+                      "code": "NO",
+                      "name": "NO",
+                      "isEnabled": true,
+                      "isVerified": true,
+                      "showProofOfReply": false,
+                      "hasBarRegistrationNo": true
+                    }
+                  ],
+                  "required": false,
+                  "optionsKey": "name",
+                  "isDependent": true,
+                  "isMandatory": true
+                },
+                "isMandatory": true
+              }
+            ]
+          },
+          {
+            "body": [
+              {
+                "type": "date",
+                "label": "CS_DATE_OF_REPLY_LDN",
+                "populators": {
+                  "name": "dateOfReply",
+                  "validation": {
+                    "max": {
+                      "masterName": "commonUiConfig",
+                      "moduleName": "maxDateValidation",
+                      "patternType": "date"
+                    }
+                  }
+                },
+                "isMandatory": true
+              }
+            ],
+            "dependentKey": {
+              "proofOfReply": ["showProofOfReply"]
+            }
+          },
+          {
+            "body": [
+              {
+                "key": "proofOfReplyFileUpload",
+                "type": "component",
+                "label": "CS_PROOF_TO_REPLY_DEMAND_NOTICE",
+                "component": "SelectCustomDragDrop",
+                "populators": {
+                  "inputs": [
+                    {
+                      "name": "document",
+                      "type": "DragDropComponent",
+                      "fileTypes": ["JPG", "JPEG", "PDF", "PNG"],
+                      "isOptional": "CS_IS_OPTIONAL",
+                      "maxFileSize": 50,
+                      "documentHeader": "CS_PROOF_TO_REPLY_DEMAND_NOTICE",
+                      "isMultipleUpload": true,
+                      "uploadGuidelines": "UPLOAD_DOC_50",
+                      "maxFileErrorMessage": "CS_FILE_LIMIT_50_MB"
+                    }
+                  ]
+                },
+                "isMandatory": false,
+                "withoutLabel": true,
+                "isDocDependentOn": "proofOfReply",
+                "isDocDependentKey": "showProofOfReply"
+              }
+            ]
+          },
+          {
+            "body": [
+              {
+                "key": "causeOfActionNote",
+                "type": "component",
+                "component": "SelectCustomNote",
+                "populators": {
+                  "inputs": [
+                    {
+                      "type": "InfoComponent",
+                      "infoText": "CAUSE_OF_ACTION_FROM_DELIVERY",
+                      "infoHeader": "CS_COMMON_NOTE",
+                      "infoTooltipMessage": "CAUSE_OF_ACTION_FROM_DELIVERY"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "body": [
+              {
+                "type": "date",
+                "label": "CS_DATE_OF_ACCRUAL_LDN",
+                "populators": {
+                  "name": "dateOfAccrual",
+                  "customClass": "date-of-accrual",
+                  "validation": {
+                    "max": {
+                      "masterName": "commonUiConfig",
+                      "moduleName": "maxDateValidation",
+                      "patternType": "date"
+                    }
+                  }
+                },
+                "isMandatory": true,
+                "labelChildren": "OutlinedInfoIcon"
+              }
+            ]
+          }
+        ],
+        "isOptional": false,
+        "addFormText": "ADD_DEMAND_NOTICE",
+        "formItemName": "CS_DEMAND_NOTICE",
+        "selectDocumentName": {
+          "proofOfReplyFileUpload": "CS_PROOF_TO_REPLY_DEMAND_NOTICE_FILE_NAME",
+          "proofOfDispatchFileUpload": "PROOF_OF_DISPATCH_FILE_NAME",
+          "legalDemandNoticeFileUpload": "LEGAL_DEMAND_NOTICE",
+          "proofOfAcknowledgmentFileUpload": "PROOF_LEGAL_DEMAND_NOTICE_FILE_NAME"
+        }
+      },
+      "isActive": true
+    }
+  ]
+}


### PR DESCRIPTION
Issue: #3598

## Summary
greying out, disabling date of accrual field in demand notice.
## Requirements



- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [x] I have added MDMS data changes to `support/<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/<issue-number>-workflow.json`











## Data Changes

For MDMS or workflow changes, list the following:
- [x] Files modified: `3598-mdms-data.json`
- [ ] Migration steps (if any):





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Introduced a new visual style for specific date fields, ensuring a subtle color, bordered appearance, and non-interactive behavior.

- **New Features**
  - Streamlined the demand notice form by updating validation rules, removing outdated input options, and adding enhanced file upload components with clear guidelines and improved naming conventions.
  - Integrated comprehensive configuration data to support dynamic form layouts and dependencies, enhancing overall usability for document submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->