### PR TITLE
[hotfix-3485-toDev] Benchclerk/Magistrate: Have Summons and warrants show in a row banner just like notice

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/NoticeAccordion.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/NoticeAccordion.js
@@ -1,0 +1,63 @@
+import React, { useState } from "react";
+
+function NoticeAccordion({ title, children }) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggleAccordion = () => {
+    setIsOpen((prev) => !prev);
+  };
+
+  const styles = {
+    container: {
+      border: "1px solid #ddd",
+      borderRadius: "4px",
+      overflow: "hidden",
+      fontFamily: "sans-serif", // Optional: choose your font
+    },
+    header: {
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "space-between",
+      cursor: "pointer",
+      padding: "0.5rem 1rem",
+      backgroundColor: "#fce8e8",
+    },
+    title: {
+      margin: 0,
+      fontSize: "1rem",
+      flex: 1,
+    },
+    icon: {
+      fontWeight: "bold",
+      marginLeft: "1rem",
+      fontSize: "1.2rem",
+    },
+    divider: {
+      margin: 0,
+      border: "none",
+      borderBottom: "1px solid #ddd",
+    },
+    body: {
+      padding: "1rem",
+      backgroundColor: "#fff",
+    },
+  };
+
+  return (
+    <div style={styles.container}>
+      {/* Accordion Header */}
+      <div style={styles.header} onClick={toggleAccordion}>
+        <h3 style={styles.title}>{title}</h3>
+        <span style={styles.icon}>{isOpen ? "−" : "+"}</span>
+      </div>
+
+      {/* Divider (optional) */}
+      <hr style={styles.divider} />
+
+      {/* Accordion Body (visible only if isOpen is true) */}
+      {isOpen && <div style={styles.body}>{children}</div>}
+    </div>
+  );
+}
+
+export default NoticeAccordion;

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCase.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCase.js
@@ -41,6 +41,7 @@ import DocumentModal from "@egovernments/digit-ui-module-orders/src/components/D
 import { getFullName } from "../../../../../cases/src/utils/joinCaseUtils";
 import PublishedNotificationModal from "./publishedNotificationModal";
 import ConfirmEvidenceAction from "../../../components/ConfirmEvidenceAction";
+import NoticeAccordion from "../../../components/NoticeAccordion";
 
 const defaultSearchValues = {};
 
@@ -2503,69 +2504,77 @@ const AdmittedCases = () => {
             </div>
           )}
         </div>
-        <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
-          {groupNoticeOrderByHearingNumber?.map((orders, index) => (
-            <React.Fragment>
-              {userType === "employee" && orders?.cases?.length > 0 && (
-                <div key={orders?.hearingNumber} className="notice-failed-notification" style={styles.container}>
-                  <div className="notice-failed-icon" style={styles.icon}>
-                    <InfoIconRed style={styles.icon} />
-                  </div>
-                  <p className="notice-failed-text" style={styles.text}>
-                    {`${t("NOTICE_GENERATED_FOR")} ${
-                      index === 0
-                        ? t("CURRENT_HEARING") + " (" + orders?.hearingNumber + ")"
-                        : t("PREVIOUS_HEARING") + " (" + orders?.hearingNumber + ")"
-                    }, `}
-                    <span onClick={() => handleAllNoticeGeneratedForHearing(orders?.hearingNumber)} className="click-here" style={styles.link}>
-                      {t("NOTICE_CLICK_HERE")}
-                    </span>
-                  </p>
-                </div>
-              )}
-            </React.Fragment>
-          ))}
+        {(groupSummonWarrantOrderByHearingNumber?.length > 0 || groupNoticeOrderByHearingNumber?.length > 0) && (
+          <NoticeAccordion title={t("PROCESS_STATUS")}>
+            <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+              {groupSummonWarrantOrderByHearingNumber?.map((orders, index) => (
+                <React.Fragment>
+                  {userType === "employee" && orders?.cases?.length > 0 && (
+                    <div key={orders?.hearingNumber} className="notice-failed-notification" style={styles.container}>
+                      <div className="notice-failed-icon" style={styles.icon}>
+                        <InfoIconRed style={styles.icon} />
+                      </div>
+                      <p className="notice-failed-text" style={styles.text}>
+                        {`${t("SUMMON_WARRANT_FOR")} ${
+                          currentHearingId === orders?.hearingNumber
+                            ? t("CURRENT_HEARING") + " (" + orders?.hearingNumber + ")"
+                            : t("PREVIOUS_HEARING") + " (" + orders?.hearingNumber + ")"
+                        }, `}
+                        <span
+                          onClick={() => handleAllSummonWarrantGeneratedForHearing(orders?.hearingNumber)}
+                          className="click-here"
+                          style={styles.link}
+                        >
+                          {t("NOTICE_CLICK_HERE")}
+                        </span>
+                      </p>
+                    </div>
+                  )}
+                </React.Fragment>
+              ))}
 
-          {groupSummonWarrantOrderByHearingNumber?.map((orders, index) => (
-            <React.Fragment>
-              {userType === "employee" && orders?.cases?.length > 0 && (
-                <div key={orders?.hearingNumber} className="notice-failed-notification" style={styles.container}>
-                  <div className="notice-failed-icon" style={styles.icon}>
-                    <InfoIconRed style={styles.icon} />
-                  </div>
-                  <p className="notice-failed-text" style={styles.text}>
-                    {`${t("SUMMON_WARRANT_FOR")} ${
-                      index === 0
-                        ? t("CURRENT_HEARING") + " (" + orders?.hearingNumber + ")"
-                        : t("PREVIOUS_HEARING") + " (" + orders?.hearingNumber + ")"
-                    }, `}
-                    <span onClick={() => handleAllSummonWarrantGeneratedForHearing(orders?.hearingNumber)} className="click-here" style={styles.link}>
-                      {t("NOTICE_CLICK_HERE")}
-                    </span>
-                  </p>
-                </div>
-              )}
-            </React.Fragment>
-          ))}
-          {/* {noticeFailureCount?.map(
-            ({ partyIndex, partyName, failureCount }, index) =>
-              failureCount > 0 &&
-              !isCaseAdmitted &&
-              isJudge && (
-                <div key={partyIndex} className="notice-failed-notification" style={styles.container}>
-                  <div className="notice-failed-icon" style={styles.icon}>
-                    <InfoIconRed style={styles.icon} />
-                  </div>
-                  <p className="notice-failed-text" style={styles.text}>
-                    {`${t("NOTICE_FAILED")} ${failureCount} ${t("TIMES_VIEW_STATUS")} ${partyName}. ${t("VIEW_STATUS")}, `}
-                    <span onClick={() => handleOpenSummonNoticeModal(partyIndex)} className="click-here" style={styles.link}>
-                      {t("NOTICE_CLICK_HERE")}
-                    </span>
-                  </p>
-                </div>
-              )
-          )} */}
-        </div>
+              {groupNoticeOrderByHearingNumber?.map((orders, index) => (
+                <React.Fragment>
+                  {userType === "employee" && orders?.cases?.length > 0 && (
+                    <div key={orders?.hearingNumber} className="notice-failed-notification" style={styles.container}>
+                      <div className="notice-failed-icon" style={styles.icon}>
+                        <InfoIconRed style={styles.icon} />
+                      </div>
+                      <p className="notice-failed-text" style={styles.text}>
+                        {`${t("NOTICE_GENERATED_FOR")} ${
+                          currentHearingId === orders?.hearingNumber
+                            ? t("CURRENT_HEARING") + " (" + orders?.hearingNumber + ")"
+                            : t("PREVIOUS_HEARING") + " (" + orders?.hearingNumber + ")"
+                        }, `}
+                        <span onClick={() => handleAllNoticeGeneratedForHearing(orders?.hearingNumber)} className="click-here" style={styles.link}>
+                          {t("NOTICE_CLICK_HERE")}
+                        </span>
+                      </p>
+                    </div>
+                  )}
+                </React.Fragment>
+              ))}
+              {/* {noticeFailureCount?.map(
+                ({ partyIndex, partyName, failureCount }, index) =>
+                  failureCount > 0 &&
+                  !isCaseAdmitted &&
+                  isJudge && (
+                    <div key={partyIndex} className="notice-failed-notification" style={styles.container}>
+                      <div className="notice-failed-icon" style={styles.icon}>
+                        <InfoIconRed style={styles.icon} />
+                      </div>
+                      <p className="notice-failed-text" style={styles.text}>
+                        {`${t("NOTICE_FAILED")} ${failureCount} ${t("TIMES_VIEW_STATUS")} ${partyName}. ${t("VIEW_STATUS")}, `}
+                        <span onClick={() => handleOpenSummonNoticeModal(partyIndex)} className="click-here" style={styles.link}>
+                          {t("NOTICE_CLICK_HERE")}
+                        </span>
+                      </p>
+                    </div>
+                  )
+              )} */}
+            </div>
+          </NoticeAccordion>
+        )}
 
         <CustomCaseInfoDiv t={t} data={caseBasicDetails} column={6} />
         <div className="search-tabs-container">


### PR DESCRIPTION
## Requirements
#3485


- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a collapsible panel that allows users to expand or collapse hearing-related notices and summons for easier reading.

- **Refactor**
  - Updated the layout for displaying hearing statuses and details, resulting in a clearer and more organized user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->