### PR TITLE
[UAT bugs 3577, 3587]:

### DIFF
--- a/utilities/dristi-pdf/src/orderHandlers/acceptReschedulingRequest.js
+++ b/utilities/dristi-pdf/src/orderHandlers/acceptReschedulingRequest.js
@@ -171,7 +171,8 @@ async function acceptReschedulingRequest(
           applicationId: order.orderDetails?.refApplicationId || "",
           reasonForRescheduling,
           originalHearingDate,
-          additionalComments: order.comments,
+          additionalComments:
+            order?.additionalDetails?.formdata?.comments?.text || "",
           judgeSignature: judgeDetails.judgeSignature,
           judgeName: judgeDetails.name,
           courtSeal: judgeDetails.courtSeal,

--- a/utilities/dristi-pdf/src/orderHandlers/adrCaseReferral.js
+++ b/utilities/dristi-pdf/src/orderHandlers/adrCaseReferral.js
@@ -142,7 +142,8 @@ async function adrCaseReferral(req, res, qrCode, order, compositeOrder) {
 
     const currentDate = new Date();
     const formattedToday = formatDate(currentDate, "DD-MM-YYYY");
-    const additionalComments = order?.comments || "";
+    const additionalComments =
+      order?.additionalDetails?.formdata?.comments?.text || "";
     const modeOfAdr = adr?.name || "";
     const caseNumber = courtCase?.courtCaseNumber || courtCase?.cmpNumber || "";
     const data = {

--- a/utilities/dristi-pdf/src/orderHandlers/caseSettlementAcceptance.js
+++ b/utilities/dristi-pdf/src/orderHandlers/caseSettlementAcceptance.js
@@ -172,7 +172,8 @@ async function caseSettlementAcceptance(
     const formattedToday = formatDate(currentDate, "DD-MM-YYYY");
 
     const specifyMechanism = order.orderDetails.settlementMechanism;
-    const additionalComments = order?.comments || "";
+    const additionalComments =
+      order?.additionalDetails?.formdata?.comments?.text || "";
     const settlementStatus =
       order.orderDetails.isSettlementImplemented === "ES_COMMON_YES"
         ? "Yes"

--- a/utilities/dristi-pdf/src/orderHandlers/caseSettlementRejection.js
+++ b/utilities/dristi-pdf/src/orderHandlers/caseSettlementRejection.js
@@ -173,8 +173,10 @@ async function caseSettlementRejection(
     const formattedToday = formatDate(currentDate, "DD-MM-YYYY");
 
     const specifyMechanism = order.orderDetails.settlementMechanism;
-    const rejectionSummary = order?.comments || "";
-    const additionalComments = order?.comments || "";
+    const rejectionSummary =
+      order?.additionalDetails?.formdata?.comments?.text || "";
+    const additionalComments =
+      order?.additionalDetails?.formdata?.comments?.text || "";
     const settlementStatus =
       order.orderDetails.isSettlementImplemented === "ES_COMMON_YES"
         ? "Yes"

--- a/utilities/dristi-pdf/src/orderHandlers/caseTransfer.js
+++ b/utilities/dristi-pdf/src/orderHandlers/caseTransfer.js
@@ -152,7 +152,8 @@ async function caseTransfer(req, res, qrCode, order, compositeOrder) {
 
     const currentDate = new Date();
     const formattedToday = formatDate(currentDate, "DD-MM-YYYY");
-    const additionalComments = order?.comments || "";
+    const additionalComments =
+      order?.additionalDetails?.formdata?.comments?.text || "";
     const specifyCourtOrJurisdiction =
       order?.additionalDetails?.formdata?.caseTransferredTo || "";
     const groundsForTransfer = order?.orderDetails?.grounds || "";

--- a/utilities/dristi-pdf/src/orderHandlers/mandatoryAsyncSubmissionsResponses.js
+++ b/utilities/dristi-pdf/src/orderHandlers/mandatoryAsyncSubmissionsResponses.js
@@ -183,7 +183,8 @@ async function mandatoryAsyncSubmissionsResponses(
           evidenceSubmissionDeadline,
           ifResponse,
           responseSubmissionDeadline,
-          additionalComments: order?.comments || "",
+          additionalComments:
+            order?.additionalDetails?.formdata?.additionalComments?.text || "",
           Date: formattedToday,
           day: day,
           Month: month,

--- a/utilities/dristi-pdf/src/orderHandlers/newHearingDateAfterReschedule.js
+++ b/utilities/dristi-pdf/src/orderHandlers/newHearingDateAfterReschedule.js
@@ -148,7 +148,8 @@ async function newHearingDateAfterReschedule(
           originalHearingDate,
           date: formattedToday,
           newHearingDate,
-          additionalComments: order.comments,
+          additionalComments:
+            order?.additionalDetails?.formdata?.comments?.text || "",
           judgeSignature: judgeDetails.name,
           judgeName: judgeDetails.name,
           courtSeal: judgeDetails.courtSeal,

--- a/utilities/dristi-pdf/src/orderHandlers/orderAcceptCheckout.js
+++ b/utilities/dristi-pdf/src/orderHandlers/orderAcceptCheckout.js
@@ -163,9 +163,11 @@ async function orderAcceptCheckout(req, res, qrCode, order, compositeOrder) {
           reasonForRescheduling,
           originalHearingDate,
           applicationId: application?.applicationNumber,
-          content: order?.comments || "",
-          additionalDetails: order?.comments || "",
-          additionalComments: order?.comments || "",
+          content: order?.additionalDetails?.formdata?.comments?.text || "",
+          additionalDetails:
+            order?.additionalDetails?.formdata?.comments?.text || "",
+          additionalComments:
+            order?.additionalDetails?.formdata?.comments?.text || "",
           judgeSignature: judgeDetails.judgeSignature,
           judgeName: judgeDetails.name,
           courtSeal: judgeDetails.courtSeal,

--- a/utilities/dristi-pdf/src/orderHandlers/orderAcceptExtension.js
+++ b/utilities/dristi-pdf/src/orderHandlers/orderAcceptExtension.js
@@ -171,7 +171,8 @@ async function orderAcceptExtension(req, res, qrCode, order, compositeOrder) {
 
     const currentDate = new Date();
     const formattedToday = formatDate(currentDate, "DD-MM-YYYY");
-    const additionalComments = order?.comments || "";
+    const additionalComments =
+      order?.additionalDetails?.formdata?.comments?.text || "";
     const originalSubmissionName = originalOrder.orderDetails.documentName;
     const partyName = [
       onbehalfOfIndividual.name.givenName,

--- a/utilities/dristi-pdf/src/orderHandlers/orderAcceptVoluntary.js
+++ b/utilities/dristi-pdf/src/orderHandlers/orderAcceptVoluntary.js
@@ -149,7 +149,8 @@ async function orderAcceptVoluntary(req, res, qrCode, order, compositeOrder) {
     } else {
       return renderError(res, "Invalid filingDate format", 500);
     }
-    const additionalComments = order.comments || "";
+    const additionalComments =
+      order?.additionalDetails?.formdata?.comments?.text || "";
     const caseNumber = courtCase?.courtCaseNumber || courtCase?.cmpNumber || "";
     const data = {
       Data: [
@@ -168,9 +169,10 @@ async function orderAcceptVoluntary(req, res, qrCode, order, compositeOrder) {
           caseYear,
           partyName: partyName,
           additionalComments: additionalComments,
-          content: order?.comments || "",
+          content: order?.additionalDetails?.formdata?.comments?.text || "",
           applicationNumber: application?.applicationNumber,
-          additionalDetails: order?.comments || "",
+          additionalDetails:
+            order?.additionalDetails?.formdata?.comments?.text || "",
           judgeSignature: judgeDetails.judgeSignature,
           judgeName: judgeDetails.name,
           courtSeal: judgeDetails.courtSeal,

--- a/utilities/dristi-pdf/src/orderHandlers/orderForRejectionReschedulingRequest.js
+++ b/utilities/dristi-pdf/src/orderHandlers/orderForRejectionReschedulingRequest.js
@@ -139,7 +139,8 @@ const orderForRejectionReschedulingRequest = async (
           reasonForRescheduling,
           originalHearingDate,
           date: formattedToday,
-          additionalComments: order.comments,
+          additionalComments:
+            order?.additionalDetails?.formdata?.comments?.text || "",
           judgeSignature: judgeDetails.judgeSignature,
           designation: judgeDetails.designation,
           courtSeal: judgeDetails.courtSeal,

--- a/utilities/dristi-pdf/src/orderHandlers/orderGeneric.js
+++ b/utilities/dristi-pdf/src/orderHandlers/orderGeneric.js
@@ -129,7 +129,11 @@ async function orderGeneric(req, res, qrCode, order, compositeOrder) {
           caseNumber: caseNumber,
           orderName: order.orderNumber,
           date: formattedToday,
-          orderContent: order.comments,
+          orderContent:
+            order?.additionalDetails?.formdata?.comments?.text ||
+            order?.additionalDetails?.formdata?.otherDetails?.text ||
+            order?.additionalDetails?.formdata?.sentence?.text ||
+            "",
           judgeSignature: judgeDetails.judgeSignature,
           judgeName: judgeDetails.name,
           courtSeal: judgeDetails.courtSeal,

--- a/utilities/dristi-pdf/src/orderHandlers/orderNotice.js
+++ b/utilities/dristi-pdf/src/orderHandlers/orderNotice.js
@@ -114,7 +114,8 @@ async function orderNotice(req, res, qrCode, order, compositeOrder) {
     } else {
       return renderError(res, "Invalid filingDate format", 500);
     }
-    const additionalComments = order?.comments || "";
+    const additionalComments =
+      order?.additionalDetails?.formdata?.comments?.text || "";
     const typeOfNotice = order?.orderDetails?.noticeType || "";
     const hearingDate = order?.orderDetails?.hearingDate
       ? formatDate(new Date(order?.orderDetails?.hearingDate), "DD-MM-YYYY")

--- a/utilities/dristi-pdf/src/orderHandlers/orderRejectCheckout.js
+++ b/utilities/dristi-pdf/src/orderHandlers/orderRejectCheckout.js
@@ -164,9 +164,11 @@ async function orderRejectCheckout(req, res, qrCode, order, compositeOrder) {
           reasonForRescheduling,
           originalHearingDate,
           applicationId: application?.applicationNumber,
-          content: order?.comments || "",
-          additionalDetails: order?.comments || "",
-          additionalComments: order?.comments || "",
+          content: order?.additionalDetails?.formdata?.comments?.text || "",
+          additionalDetails:
+            order?.additionalDetails?.formdata?.comments?.text || "",
+          additionalComments:
+            order?.additionalDetails?.formdata?.comments?.text || "",
           judgeSignature: judgeDetails.judgeSignature,
           judgeName: judgeDetails.name,
           courtSeal: judgeDetails.courtSeal,

--- a/utilities/dristi-pdf/src/orderHandlers/orderRejectExtension.js
+++ b/utilities/dristi-pdf/src/orderHandlers/orderRejectExtension.js
@@ -171,7 +171,8 @@ async function orderRejectExtension(req, res, qrCode, order, compositeOrder) {
 
     const currentDate = new Date();
     const formattedToday = formatDate(currentDate, "DD-MM-YYYY");
-    const additionalComments = order?.comments || "";
+    const additionalComments =
+      order?.additionalDetails?.formdata?.comments?.text || "";
     const originalSubmissionName = originalOrder.orderDetails.documentName;
     const partyName = [
       onbehalfOfIndividual.name.givenName,

--- a/utilities/dristi-pdf/src/orderHandlers/orderRejectVoluntary.js
+++ b/utilities/dristi-pdf/src/orderHandlers/orderRejectVoluntary.js
@@ -150,7 +150,8 @@ async function orderRejectVoluntary(req, res, qrCode, order, compositeOrder) {
       return renderError(res, "Invalid filingDate format", 500);
     }
     const additionalComments = "";
-    const reasonForRejection = order?.comments || "";
+    const reasonForRejection =
+      order?.additionalDetails?.formdata?.comments?.text || "";
     const caseNumber = courtCase?.courtCaseNumber || courtCase?.cmpNumber || "";
     const data = {
       Data: [
@@ -171,7 +172,7 @@ async function orderRejectVoluntary(req, res, qrCode, order, compositeOrder) {
           partyName: partyName,
           additionalComments: additionalComments,
           applicationNumber: application?.applicationNumber,
-          content: order?.comments || "",
+          content: order?.additionalDetails?.formdata?.comments?.text || "",
           judgeSignature: judgeDetails.judgeSignature,
           judgeName: judgeDetails.name,
           courtSeal: judgeDetails.courtSeal,

--- a/utilities/dristi-pdf/src/orderHandlers/orderSection202crpc.js
+++ b/utilities/dristi-pdf/src/orderHandlers/orderSection202crpc.js
@@ -148,7 +148,8 @@ async function orderSection202crpc(req, res, qrCode, order, compositeOrder) {
     const day = currentDate.getDate();
     const month = months[currentDate.getMonth()];
     const year = currentDate.getFullYear();
-    const additionalComments = order?.comments || "";
+    const additionalComments =
+      order?.additionalDetails?.formdata?.comments?.text || "";
     // Prepare data for PDF generation
     const complainantName =
       order?.additionalDetails?.formdata?.applicationFilledBy?.name || "";

--- a/utilities/dristi-pdf/src/orderHandlers/scheduleHearingDate.js
+++ b/utilities/dristi-pdf/src/orderHandlers/scheduleHearingDate.js
@@ -173,7 +173,8 @@ async function scheduleHearingDate(req, res, qrCode, order, compositeOrder) {
             order.orderDetails.hearingDate
           ).toLocaleDateString("en-IN"),
           partyNames: order.orderDetails.partyName.join(", "),
-          additionalComments: order.comments,
+          additionalComments:
+            order?.additionalDetails?.formdata?.comments?.text || "",
           purposeOfHearing: purposeOfHearing,
           judgeSignature: judgeDetails.judgeSignature,
           judgeName: judgeDetails.name,

--- a/utilities/dristi-pdf/src/orderHandlers/summonsIssue.js
+++ b/utilities/dristi-pdf/src/orderHandlers/summonsIssue.js
@@ -9,6 +9,7 @@ const {
 } = require("../api");
 const { renderError } = require("../utils/renderError");
 const { handleApiCall } = require("../utils/handleApiCall");
+const { formatDate } = require("./formatDate");
 
 async function summonsIssue(req, res, qrCode, order, compositeOrder) {
   const cnrNumber = req.query.cnrNumber;
@@ -84,14 +85,10 @@ async function summonsIssue(req, res, qrCode, order, compositeOrder) {
     //     renderError(res, "Court establishment MDMS master not found", 404);
     // }
 
-    // Search for hearing details
-    const resHearing = await handleApiCall(
-      res,
-      () => search_hearing(tenantId, cnrNumber, requestInfo),
-      "Failed to query hearing service"
-    );
-    const hearing = resHearing?.data?.HearingList[0];
-    if (!hearing) {
+    const hearingDate = order?.orderDetails?.hearingDate
+      ? formatDate(new Date(order?.orderDetails?.hearingDate))
+      : "";
+    if (!hearingDate) {
       renderError(res, "Hearing not found", 404);
     }
 
@@ -144,8 +141,9 @@ async function summonsIssue(req, res, qrCode, order, compositeOrder) {
           caseName: courtCase.caseTitle,
           respondentName: order.orderDetails.respondentName,
           date: Date.now(),
-          hearingDate: hearing.startTime,
-          additionalComments: order.comments,
+          hearingDate: hearingDate,
+          additionalComments:
+            order?.additionalDetails?.formdata?.comments?.text || "",
           judgeName: judgeDetails.name,
           judgeSignature: judgeDetails.judgeSignature,
           courtSeal: judgeDetails.courtSeal,


### PR DESCRIPTION
Issue: #3577 
#3587


## Summary
For 3587-Instead of picking comments from order object, pick it from formdata in additionalDetails object.
For 3577- search hearing api removed, instead take gearing date from orderdetails.
## Requirements



- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/<issue-number>-workflow.json`







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved how additional comments are sourced for generated documents to ensure consistent, reliable display even when certain data is missing.
  - Updated the hearing date formatting for summons documents to use the direct order details, offering clearer error feedback when a hearing date is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->