### PR TITLE
pass uniqueId for warrant orders, removed uniqueId filter in warran, sumon, notice modal temporarily till migration of orders

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/configs/ordersCreateConfig.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/configs/ordersCreateConfig.js
@@ -3386,10 +3386,12 @@ export const configsCreateOrderWarrant = [
         type: "dropdown",
         label: "WARRANT_FOR_PARTY",
         schemaKeyPath: "orderDetails.respondentName",
-        disable: true,
         populators: {
           name: "warrantFor",
+          optionsKey: "name",
           error: "CORE_REQUIRED_FIELD_ERROR",
+          required: true,
+          isMandatory: true,
           styles: { maxWidth: "100%" },
         },
       },

--- a/utilities/dristi-pdf/src/orderHandlers/orderWarrant.js
+++ b/utilities/dristi-pdf/src/orderHandlers/orderWarrant.js
@@ -91,7 +91,10 @@ async function orderWarrant(req, res, qrCode, order, compositeOrder) {
     // }
 
     const reasonForWarrant = order.orderDetails.warrantType;
-    const personName = order?.orderDetails?.respondentName;
+    const personName =
+      order?.orderDetails?.respondentName?.name ||
+      order?.orderDetails?.respondentName ||
+      "";
     const additionalComments = order.comments || "";
 
     // Handle QR code if enabled


### PR DESCRIPTION

## Summary
1. pass uniqueId for warrant orders in warrantFor object,
2. Removed uniqueId filter in warrant, summons, notice modal temporarily till migration of orders is done because in old orders therer is no uniqueId attached with the data of parties in order details/additional Details, so currently filtering accused on the basis of names only.
TODO:  Will have to again place uniqueId filter when the old orders are enriched with uniqueId using migration script.(uniqueId filter is required because with profile editing feature, same accused will show in different tabs depending on its different names till now depending on how many times its name has been changed using profile editing.)

## Requirements



- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/<issue-number>-workflow.json`



