### PR TITLE
warrant payment modal -> issuedTo:  is showing object object instead of name

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/PaymentForSummonModalSMSAndEmail.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/PaymentForSummonModalSMSAndEmail.js
@@ -475,7 +475,11 @@ const PaymentForSummonModalSMSAndEmail = ({ path }) => {
       orderDetails?.orderCategory === "COMPOSITE" ? compositeItem?.additionalDetails?.formdata : orderDetails?.additionalDetails?.formdata;
     const orderKey = orderType === "SUMMONS" ? "SummonsOrder" : "noticeOrder";
     const partyData = formdata?.[orderKey]?.party?.data;
-    const name = [partyData?.firstName, partyData?.lastName]?.filter(Boolean)?.join(" ") || (orderType === "WARRANT" && formdata?.warrantFor);
+    const name =
+      [partyData?.firstName, partyData?.lastName]?.filter(Boolean)?.join(" ") ||
+      (orderType === "WARRANT" && formdata?.warrantFor?.name) ||
+      formdata?.warrantFor ||
+      "";
 
     const task = filteredTasks?.[0];
     const taskDetails = task?.taskDetails;


### PR DESCRIPTION
## Summary
warrant payment modal -> issuedTo:  is showing object object instead of name - handled object as well as string


## Requirements



- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/<issue-number>-workflow.json`







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced how recipient names are determined for payment notifications to ensure that a valid name is always displayed, even when some information might be missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->