### PR TITLE
[BUG]: Seperate out reason for change from litigant details #3573

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/css/src/dristi/editProfile.scss
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/css/src/dristi/editProfile.scss
@@ -1,6 +1,5 @@
-.respondent,
-.complainant {
-  width: 80% !important;
+.respondent-edit,
+.complainant-edit {
   .card-section-header:first-child {
     margin-bottom: 8px;
   }

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/view-case/Config/editComplainantDetailsConfig.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/view-case/Config/editComplainantDetailsConfig.js
@@ -641,5 +641,5 @@ export const editComplainantDetailsConfig = {
   isOptional: false,
   // addFormText: "ADD_COMPLAINANT",
   // formItemName: "CS_COMPLAINANT",
-  className: "complainant",
+  className: "complainant-edit",
 };

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/view-case/Config/editComplainantDetailsConfig.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/view-case/Config/editComplainantDetailsConfig.js
@@ -572,6 +572,19 @@ const editComplainantDetailsFormConfig = [
   {
     body: [
       {
+        key: "reasonDetailsSeparator",
+        type: "component",
+        sublabel: "REQUEST_DETAILS",
+        component: "OrSeparator",
+        populators: {
+          inputs: [],
+        },
+      },
+    ],
+  },
+  {
+    body: [
+      {
         type: "component",
         component: "SelectCustomTextArea",
         key: "reasonForChange",

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/view-case/Config/editRespondentConfig.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/view-case/Config/editRespondentConfig.js
@@ -572,5 +572,5 @@ export const editRespondentConfig = {
   isOptional: false,
   addFormText: "ADD_RESPONDENT",
   formItemName: "CS_RESPONDENT",
-  className: "respondent",
+  className: "respondent-edit",
 };

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/view-case/Config/editRespondentConfig.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/view-case/Config/editRespondentConfig.js
@@ -497,6 +497,19 @@ const editRespondentFormconfig = [
   {
     body: [
       {
+        key: "reasonDetailsSeparator",
+        type: "component",
+        sublabel: "REQUEST_DETAILS",
+        component: "OrSeparator",
+        populators: {
+          inputs: [],
+        },
+      },
+    ],
+  },
+  {
+    body: [
+      {
         type: "component",
         component: "SelectCustomTextArea",
         key: "reasonForChange",

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/view-case/editProfileValidationUtils.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/view-case/editProfileValidationUtils.js
@@ -445,7 +445,8 @@ export const updateProfileData = async ({
         })
     );
 
-    const { complainantIDProofDocument, reasonForChange, supportingDocument, ...remainingFormData } = newFormData?.[0]?.data || {};
+    const { complainantIDProofDocument, reasonDetailsSeparator, reasonForChange, supportingDocument, ...remainingFormData } =
+      newFormData?.[0]?.data || {};
     profilePayload = {
       tenantId,
       caseId,
@@ -579,7 +580,7 @@ export const updateProfileData = async ({
         obj.data.emails.textfieldValue = "";
       }
     }
-    const { reasonForChange, supportingDocument, ...remainingFormData } = newFormDataCopy?.[0]?.data || {};
+    const { reasonDetailsSeparator, reasonForChange, supportingDocument, ...remainingFormData } = newFormDataCopy?.[0]?.data || {};
     const currentRespondent = caseDetails?.additionalDetails?.[selected]?.formdata?.find(
       (item, index) => item?.data?.respondentVerification?.individualDetails?.individualId === uniqueId || item?.uniqueId === uniqueId
     );


### PR DESCRIPTION
Issue: #3573

## Summary
Separated reason for editing and supporting documents with a horizontal line,
efiling complainant page width css issue fixed in 2nd commit.
## Requirements



- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/<issue-number>-workflow.json`




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined the layout for profile editing views by updating element styling for a more adaptive display.
  
- **New Features**
  - Enhanced form interactions by adding visual separators to distinguish request detail sections for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->