### PR TITLE
update task object for acknowledgement id

### DIFF
--- a/backend/icops_integration-kerala/src/main/java/com/egov/icops_integrationkerala/enrichment/IcopsEnrichment.java
+++ b/backend/icops_integration-kerala/src/main/java/com/egov/icops_integrationkerala/enrichment/IcopsEnrichment.java
@@ -83,6 +83,9 @@ public class IcopsEnrichment {
                     .build();
              processRequest = ProcessRequest.builder()
                     .partyData(partyData)
+                     .processReceiverAddress(taskDetails.getRespondentDetails().getAddress().toString())
+                     .processRespondantType("A")
+                     .processRespondentName(taskDetails.getRespondentDetails().getName())
                     .processCaseno(task.getFilingNumber())
                     .processDoc(docFileString)
                     .processUniqueId(processUniqueId)

--- a/backend/scheduler-svc/src/main/java/digit/web/models/hearing/Hearing.java
+++ b/backend/scheduler-svc/src/main/java/digit/web/models/hearing/Hearing.java
@@ -40,6 +40,15 @@ public class Hearing {
     @Valid
     private String hearingId = null;
 
+    @JsonProperty("courtCaseNumber")
+    private String courtCaseNumber = null;
+
+    @JsonProperty("caseReferenceNumber")
+    private String caseReferenceNumber = null;
+
+    @JsonProperty("cmpNumber")
+    private String cmpNumber = null;
+
     @JsonProperty("filingNumber")
     private List<String> filingNumber = new ArrayList<>();
 

--- a/backend/summons-svc/src/main/java/digit/web/models/DeliveryChannel.java
+++ b/backend/summons-svc/src/main/java/digit/web/models/DeliveryChannel.java
@@ -30,4 +30,7 @@ public class DeliveryChannel {
 
     @JsonProperty("deliveryStatus")
     private String deliveryStatus;
+
+    @JsonProperty("channelAcknowledgementId")
+    private String channelAcknowledgementId;
 }

--- a/backend/task/src/main/java/org/pucar/dristi/service/TaskService.java
+++ b/backend/task/src/main/java/org/pucar/dristi/service/TaskService.java
@@ -143,7 +143,8 @@ public class TaskService {
             String taskType = body.getTask().getTaskType();
             log.info("status , taskType : {} , {} ", status, taskType);
             if (SUMMON_SENT.equalsIgnoreCase(status) || NOTICE_SENT.equalsIgnoreCase(status) || WARRANT_SENT.equalsIgnoreCase(status)){
-                summonUtil.sendSummons(body);
+                String acknowledgementId = summonUtil.sendSummons(body);
+                updateAcknowledgementId(body, acknowledgementId);
             }
 
             // push to join case topic based on status
@@ -175,6 +176,13 @@ public class TaskService {
             throw new CustomException(UPDATE_TASK_ERR, "Error occurred while updating task: " + e.getMessage());
         }
 
+    }
+
+    private void updateAcknowledgementId(TaskRequest body, String acknowledgementId) {
+        JsonNode taskDetails = objectMapper.convertValue(body.getTask().getTaskDetails(), JsonNode.class);
+        ObjectNode deliveryChannels = (ObjectNode) taskDetails.get("deliveryChannels");
+        deliveryChannels.put("channelAcknowledgementId", acknowledgementId);
+        body.getTask().setTaskDetails(taskDetails);
     }
 
     public TaskExists existTask(TaskExistsRequest taskExistsRequest) {

--- a/backend/task/src/main/java/org/pucar/dristi/util/SummonUtil.java
+++ b/backend/task/src/main/java/org/pucar/dristi/util/SummonUtil.java
@@ -4,9 +4,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.egov.tracer.model.CustomException;
 import org.pucar.dristi.config.Configuration;
+import org.pucar.dristi.web.models.SummonsDelivery;
 import org.pucar.dristi.web.models.TaskRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
 
 @Component
 @Slf4j
@@ -14,20 +17,24 @@ public class SummonUtil {
 
     private final Configuration config;
     private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
 
-    public SummonUtil(Configuration config, RestTemplate restTemplate, ObjectMapper objectMapper) {
+    public SummonUtil(Configuration config, RestTemplate restTemplate, ObjectMapper objectMapper, ObjectMapper objectMapper1) {
         this.config = config;
         this.restTemplate = restTemplate;
+        this.objectMapper = objectMapper1;
     }
 
-    public void sendSummons(TaskRequest taskRequest) {
+    public String sendSummons(TaskRequest taskRequest) {
         StringBuilder uri = new StringBuilder();
         uri.append(config.getSummonHost()).append(config.getSummonSendSummonPath());
         log.info("Sending summons for {}", taskRequest.getTask().getTaskType());
         Object response = null;
         try {
-            response = restTemplate.postForEntity(uri.toString(), taskRequest, Object.class);
+            response = restTemplate.postForEntity(uri.toString(), taskRequest, Map.class).getBody().get("SummonsDelivery");
+            SummonsDelivery summonsDelivery = objectMapper.convertValue(response, SummonsDelivery.class);
             log.info("Summon sent for {}", taskRequest.getTask().getTaskType());
+            return summonsDelivery.getChannelAcknowledgementId();
         } catch(Exception e) {
             log.error("Error while sending summons: {}", taskRequest, e);
             throw new CustomException("SUMMONS_SEND_ERROR", "Error occurred while sending summons");

--- a/backend/task/src/main/java/org/pucar/dristi/web/models/SummonsDelivery.java
+++ b/backend/task/src/main/java/org/pucar/dristi/web/models/SummonsDelivery.java
@@ -1,0 +1,69 @@
+package org.pucar.dristi.web.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.egov.common.contract.models.AuditDetails;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@jakarta.annotation.Generated(value = "org.egov.codegen.SpringBootCodegen", date = "2024-05-29T13:38:04.562296+05:30[Asia/Calcutta]")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SummonsDelivery {
+
+    @JsonProperty("summonDeliveryId")
+    private String summonDeliveryId;
+
+    @JsonProperty("taskNumber")
+    private String taskNumber;
+
+    @JsonProperty("caseId")
+    private String caseId;
+
+    @JsonProperty("tenantId")
+    private String tenantId;
+
+    @JsonProperty("docType")
+    private String docType;
+
+    @JsonProperty("docSubType")
+    private String docSubType;
+
+    @JsonProperty("partyType")
+    private String partyType;
+
+    @JsonProperty("channelName")
+    private String channelName;
+
+    @JsonProperty("paymentFees")
+    private String paymentFees;
+
+    @JsonProperty("paymentTransactionId")
+    private String paymentTransactionId;
+
+    @JsonProperty("paymentStatus")
+    private String paymentStatus;
+
+    @JsonProperty("isAcceptedByChannel")
+    private Boolean isAcceptedByChannel;
+
+    @JsonProperty("channelAcknowledgementId")
+    private String channelAcknowledgementId;
+
+    @JsonProperty("deliveryRequestDate")
+    private String deliveryRequestDate;
+
+    @JsonProperty("deliveryStatus")
+    private String deliveryStatus;
+
+    @JsonProperty("auditDetails")
+    private AuditDetails auditDetails;
+
+    @JsonProperty("rowVersion")
+    private int rowVersion;
+}


### PR DESCRIPTION
## Requirements



- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new fields to display additional case and respondent information in relevant process requests and hearing records.
  - Introduced a new field to track channel acknowledgement status in delivery channels.
  - Added a new entity to represent summons delivery details, including acknowledgement and delivery status.

- **Bug Fixes**
  - Improved handling and propagation of acknowledgement IDs for summons deliveries.

- **Tests**
  - Enhanced test coverage to validate correct extraction and handling of acknowledgement IDs in summons delivery responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->