### PR TITLE
[bug 3755]: default search filters should be set only on page refresh(for judge)

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/ReviewSummonsNoticeAndWarrant.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/ReviewSummonsNoticeAndWarrant.js
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Header, InboxSearchComposer } from "@egovernments/digit-ui-react-components";
-import { SummonsTabsConfig, SummonsTabsConfigJudge } from "../../configs/SuumonsConfig";
+import { defaultSearchValuesForJudgePending, SummonsTabsConfig, SummonsTabsConfigJudge } from "../../configs/SuumonsConfig";
 import { useTranslation } from "react-i18next";
 import DocumentModal from "../../components/DocumentModal";
 import PrintAndSendDocumentComponent from "../../components/Print&SendDocuments";
@@ -37,13 +37,31 @@ const handleTaskDetails = (taskDetails) => {
   }
 };
 
+export const getJudgeDefaultConfig = () => {
+  return SummonsTabsConfig?.SummonsTabsConfig?.map((item, index) => {
+    return {
+      ...item,
+      sections: {
+        ...item?.sections,
+        search: {
+          ...item?.sections?.search,
+          uiConfig: {
+            ...item?.sections?.search?.uiConfig,
+            defaultValues: index === 0 ? defaultSearchValuesForJudgePending : defaultSearchValues,
+          },
+        },
+      },
+    };
+  });
+};
+
 const ReviewSummonsNoticeAndWarrant = () => {
   const { t } = useTranslation();
   const tenantId = window?.Digit.ULBService.getCurrentTenantId();
   const [defaultValues, setDefaultValues] = useState(defaultSearchValues);
   const roles = Digit.UserService.getUser()?.info?.roles;
   const isJudge = roles.some((role) => role.code === "JUDGE_ROLE");
-  const [config, setConfig] = useState(isJudge ? SummonsTabsConfigJudge?.SummonsTabsConfig?.[0] : SummonsTabsConfig?.SummonsTabsConfig?.[0]);
+  const [config, setConfig] = useState(isJudge ? getJudgeDefaultConfig()?.[0] : SummonsTabsConfig?.SummonsTabsConfig?.[0]);
   const [showActionModal, setShowActionModal] = useState(false);
   const [showNoticeModal, setshowNoticeModal] = useState(false);
   const [isSigned, setIsSigned] = useState(false);
@@ -69,11 +87,7 @@ const ReviewSummonsNoticeAndWarrant = () => {
 
   const [tabData, setTabData] = useState(
     isJudge
-      ? SummonsTabsConfigJudge?.SummonsTabsConfig?.map((configItem, index) => ({
-          key: index,
-          label: configItem.label,
-          active: index === 0 ? true : false,
-        }))
+      ? getJudgeDefaultConfig()?.map((configItem, index) => ({ key: index, label: configItem.label, active: index === 0 ? true : false }))
       : SummonsTabsConfig?.SummonsTabsConfig?.map((configItem, index) => ({
           key: index,
           label: configItem.label,
@@ -310,7 +324,7 @@ const ReviewSummonsNoticeAndWarrant = () => {
 
   const onTabChange = (n) => {
     setTabData((prev) => prev.map((i, c) => ({ ...i, active: c === n ? true : false }))); //setting tab enable which is being clicked
-    setConfig(isJudge ? SummonsTabsConfigJudge?.SummonsTabsConfig?.[n] : SummonsTabsConfig?.SummonsTabsConfig?.[n]); // as per tab number filtering the config
+    setConfig(SummonsTabsConfig?.SummonsTabsConfig?.[n]);
     setReload(!reload);
   };
 


### PR DESCRIPTION
Issue: #3755

## Requirements



- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->
