### PR TITLE
setting purposeOfHearing from formData as well in botd of hearing date

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrders.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrders.js
@@ -1931,10 +1931,9 @@ const GenerateOrders = () => {
       case "REFERRAL_CASE_TO_ADR":
         return "Case referred to Alternative Dispute Resolution to seek settlement";
       case "SCHEDULE_OF_HEARING_DATE":
-        return `For ${t(currentOrder?.orderDetails?.purposeOfHearing)} on ${formatDate(
-          new Date(currentOrder?.additionalDetails?.formdata?.hearingDate),
-          "DD-MM-YYYY"
-        )}`;
+        return `For ${t(
+          currentOrder?.orderDetails?.purposeOfHearing || currentOrder?.additionalDetails?.formdata?.hearingPurpose?.code
+        )} on ${formatDate(new Date(currentOrder?.additionalDetails?.formdata?.hearingDate), "DD-MM-YYYY")}`;
       case "SCHEDULING_NEXT_HEARING":
         return `${currentOrder?.additionalDetails?.formdata?.comments?.text || ""}`;
       case "RESCHEDULE_OF_HEARING_DATE":
@@ -1965,10 +1964,9 @@ const GenerateOrders = () => {
           "DD-MM-YYYY"
         )}`;
       case "ASSIGNING_NEW_HEARING_DATE":
-        return `For ${t(currentOrder?.orderDetails?.purposeOfHearing)} on ${formatDate(
-          new Date(currentOrder?.additionalDetails?.formdata?.hearingDate),
-          "DD-MM-YYYY"
-        )}`;
+        return `For ${t(
+          currentOrder?.orderDetails?.purposeOfHearing || currentOrder?.additionalDetails?.formdata?.hearingPurpose?.code
+        )} on ${formatDate(new Date(currentOrder?.additionalDetails?.formdata?.hearingDate), "DD-MM-YYYY")}`;
       case "CASE_TRANSFER":
         return "The case is transferred to another court for further proceedings";
       case "SETTLEMENT":


### PR DESCRIPTION
## Requirements
#3729


- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the default business-of-the-day (BOTD) string for specific order types to ensure the hearing purpose is always displayed, using a fallback value when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->