### PR TITLE
(1)bug 3747, (2) showing pay online button for epost payments in warrant

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/PaymentForSummonModalSMSAndEmail.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/PaymentForSummonModalSMSAndEmail.js
@@ -438,6 +438,19 @@ const PaymentForSummonModalSMSAndEmail = ({ path }) => {
           onClick: onPayOnline,
         },
       ],
+      EPOST: [
+        {
+          label: "Fee Type",
+          amount: "Amount",
+          action: "Actions",
+        },
+        {
+          label: "Court Fees",
+          amount: courtFeeAmount,
+          action: "Pay Online",
+          onClick: onPayOnline,
+        },
+      ],
       RPAD: [
         {
           label: "Fee Type",
@@ -504,6 +517,10 @@ const PaymentForSummonModalSMSAndEmail = ({ path }) => {
     } else if (deliveryChannel === "SMS") {
       contactDetail = taskDetails?.respondentDetails?.phone || "Not provided";
     } else if (deliveryChannel === "Police") {
+      contactDetail = taskDetails?.respondentDetails?.phone || "Not provided";
+    } else if (deliveryChannel === "RPAD") {
+      contactDetail = taskDetails?.respondentDetails?.phone || "Not provided";
+    } else if (deliveryChannel === "Post") {
       contactDetail = taskDetails?.respondentDetails?.phone || "Not provided";
     }
 

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/ReviewSummonsNoticeAndWarrant.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/ReviewSummonsNoticeAndWarrant.js
@@ -499,7 +499,8 @@ const ReviewSummonsNoticeAndWarrant = () => {
         },
         {
           heading: { label: t("ADD_SIGNATURE") },
-          actionSaveLabel: deliveryChannel === "Email" ? t("SEND_EMAIL_TEXT") : t("PROCEED_TO_SENT"),
+          actionSaveLabel:
+            deliveryChannel === "Email" ? t("SEND_EMAIL_TEXT") : deliveryChannel === "Police" ? t("CORE_COMMON_SEND") : t("PROCEED_TO_SENT"),
           actionCancelLabel: t("BACK"),
           modalBody: (
             <div>


### PR DESCRIPTION
Issue : #3747
## Requirements



- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
added configuration for epost  to show button in online payment, changed button text in sign document while review police delivery channel.






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the "EPOST" delivery channel in payment fee options and contact details within the payment modal.
- **Enhancements**
  - Updated the save button label in the "Add Signature" step to display context-specific text based on the selected delivery channel, including a new label for the "Police" channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->