### PR TITLE
[#3749] : Complainant Details page validations with POA details.

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/VerifyPhoneNumber.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/VerifyPhoneNumber.js
@@ -290,8 +290,7 @@ function VerifyPhoneNumber({ t, config, onSelect, formData = {}, errors, setErro
                   : {
                       "addressDetails-select": data["addressDetails-select"],
                       addressDetails: data["addressDetails-select"],
-                    }
-                ),
+                    }),
               },
               isUserVerified: true,
             },
@@ -432,7 +431,7 @@ function VerifyPhoneNumber({ t, config, onSelect, formData = {}, errors, setErro
         )}
       </div>
       {errors[config.key]?.type === "required" && <CardLabelError className="error-text">{t("CORE_REQUIRED_FIELD_ERROR")}</CardLabelError>}
-      {errors?.[config?.key]?.[config.name] && !formData?.complainantVerification?.isUserVerified && (
+      {errors?.[config?.key]?.[config.name] && (!formData?.complainantVerification?.isUserVerified || !formData?.poaVerification?.isUserVerified) && (
         <CardLabelError className={errors?.[config?.key]?.[config.name] ? "error-text" : "default-text"}>
           {t(errors?.[config?.key]?.[config.name] ? errors?.[config?.key]?.[config.name] || "VERIFY_PHONE_ERROR_TEXT" : "VERIFY_PHONE_DEFAULT_TEXT")}
         </CardLabelError>

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingCases.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingCases.js
@@ -1787,6 +1787,25 @@ function EFilingCases({ path }) {
     if (!Array.isArray(formdata)) {
       return;
     }
+    if (selected === "complainantDetails" && userType === "LITIGANT") {
+      if (
+        !formdata
+          ?.filter((data) => data.isenabled)
+          ?.find(
+            (fData) =>
+              (fData?.data?.complainantVerification?.mobileNumber &&
+                fData?.data?.complainantVerification?.otpNumber &&
+                fData?.data?.complainantVerification?.mobileNumber === userInfo?.mobileNumber) ||
+              (fData?.data?.poaVerification?.mobileNumber &&
+                fData?.data?.poaVerification?.otpNumber &&
+                fData?.data?.poaVerification?.mobileNumber === userInfo?.mobileNumber)
+          )
+      ) {
+        setShowErrorToast(true);
+        setErrorMsg("LOGGED_IN_USER_MUST_BE_EITHER_COMPLAINANT_OR_POA");
+        return;
+      }
+    }
     if (
       formdata
         .filter((data) => data.isenabled)
@@ -2729,20 +2748,17 @@ function EFilingCases({ path }) {
                 {pageConfig?.addFormText && (
                   <div className="form-item-name">
                     <h1>{`${t(pageConfig?.formItemName)} ${formdata[index]?.displayindex + 1}`}</h1>
-                    {(activeForms > 1 || t(pageConfig?.formItemName) === "Witness" || pageConfig?.isOptional) &&
-                      isDraftInProgress &&
-                      // check- TODO: instedd of comparison from mobile number, compare with individualId
-                      completedComplainants?.[index]?.data?.complainantVerification?.mobileNumber !== userInfo?.mobileNumber && (
-                        <span
-                          style={{ cursor: "pointer" }}
-                          onClick={() => {
-                            setConfirmDeleteModal(true);
-                            setDeleteFormIndex(index);
-                          }}
-                        >
-                          <CustomDeleteIcon />
-                        </span>
-                      )}
+                    {(activeForms > 1 || t(pageConfig?.formItemName) === "Witness" || pageConfig?.isOptional) && isDraftInProgress && (
+                      <span
+                        style={{ cursor: "pointer" }}
+                        onClick={() => {
+                          setConfirmDeleteModal(true);
+                          setDeleteFormIndex(index);
+                        }}
+                      >
+                        <CustomDeleteIcon />
+                      </span>
+                    )}
                   </div>
                 )}
                 <FormComposerV2

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EfilingValidationUtils.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EfilingValidationUtils.js
@@ -576,8 +576,15 @@ export const checkDuplicateMobileEmailValidation = ({
   }
   if (selected === "complainantDetails") {
     const currentMobileNumber = formData?.complainantVerification?.mobileNumber;
-
-    if (currentMobileNumber && respondentMobileNumbersArray.some((number) => number === currentMobileNumber)) {
+    const currentPOAMobileNumber = formData?.poaVerification?.mobileNumber;
+    if (currentMobileNumber && currentPOAMobileNumber && currentMobileNumber === currentPOAMobileNumber) {
+      if (formData?.complainantVerification?.otpNumber && !formData?.poaVerification?.otpNumber) {
+        setError("poaVerification", { mobileNumber: "POA_MOB_NUM_CAN_NOT_BE_SAME_AS_COMPLAINANT_MOB_NUM", isDuplicateNumber: true });
+      }
+      if (formData?.poaVerification?.otpNumber && !formData?.complainantVerification?.otpNumber) {
+        setError("complainantVerification", { mobileNumber: "COMPLAINANT_MOB_NUM_CAN_NOT_BE_SAME_AS_POA_MOB_NUM", isDuplicateNumber: true });
+      }
+    } else if (currentMobileNumber && respondentMobileNumbersArray.some((number) => number === currentMobileNumber)) {
       setError("complainantVerification", { mobileNumber: "COMPLAINANT_MOB_NUM_CAN_NOT_BE_SAME_AS_RESPONDENT_MOB_NUM", isDuplicateNumber: true });
     } else if (
       formdata &&
@@ -592,6 +599,7 @@ export const checkDuplicateMobileEmailValidation = ({
       setError("complainantVerification", { mobileNumber: "DUPLICATE_MOBILE_NUMBER_FOR_COMPLAINANT", isDuplicateNumber: true });
     } else {
       clearErrors("complainantVerification");
+      clearErrors("poaVerification");
     }
   }
 };


### PR DESCRIPTION
Issue: #3749

## Summary
1. Complainant Details page -> POA and Complainant numbers can not have same mobile number entered in same form.
2. If a litigant user type has logged in and filing the form, it's mobile number has to be present in at least on of the forms in Complainant details page as either a complainant or POA.  

## Requirements



- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced validation to ensure that, for litigant users, at least one complainant or power of attorney mobile number matches the logged-in user's number before submitting a case.
- **Bug Fixes**
	- Improved error message display logic during phone verification to cover more scenarios.
	- Refined duplicate mobile number checks and error handling between complainant and power of attorney entries.
- **User Interface**
	- Simplified conditions for displaying the delete icon in the complainant details section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->