### PR TITLE
[#3778]: reducing count tab call in home page

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/HomeView.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/HomeView.js
@@ -42,7 +42,7 @@ const HomeView = () => {
   const token = window.localStorage.getItem("token");
   const isUserLoggedIn = Boolean(token);
   const [defaultValues, setDefaultValues] = useState(defaultSearchValues);
-  const [config, setConfig] = useState(TabLitigantSearchConfig?.TabSearchConfig?.[0]);
+
   const [caseDetails, setCaseDetails] = useState(null);
   const [isFetchCaseLoading, setIsFetchCaseLoading] = useState(false);
   const [tabData, setTabData] = useState(
@@ -70,6 +70,11 @@ const HomeView = () => {
   const tenantId = useMemo(() => window?.Digit.ULBService.getCurrentTenantId(), []);
   const userInfo = Digit?.UserService?.getUser()?.info;
   const userInfoType = useMemo(() => (userInfo?.type === "CITIZEN" ? "citizen" : "employee"), [userInfo]);
+  const setInitialConfig = () => {
+    if (userInfoType !== "employee") return TabLitigantSearchConfig?.TabSearchConfig?.[0];
+    else return null;
+  };
+  const [config, setConfig] = useState(() => setInitialConfig());
   const { data: individualData, isLoading, isFetching } = window?.Digit.Hooks.dristi.useGetIndividualUser(
     {
       Individual: {
@@ -257,11 +262,18 @@ const HomeView = () => {
     const isAnyLoading = isLoading || isFetching || isSearchLoading || isFetchCaseLoading || isOutcomeLoading;
     if (!isAnyLoading || (rolesToConfigMappingData && rowClickData && tabConfigs)) {
       setOnRowClickData(rowClickData);
-      if(tabConfigs && !isEqual(tabConfigs, tabConfig)) {
+      if (userInfoType === "employee") {
+      if (tabConfigs && !isEqual(tabConfigs, tabConfig)) {
         setConfig(tabConfigs?.TabSearchConfig?.[0]);
         setTabConfig(tabConfigs);
         getTotalCountForTab(tabConfigs);
       }
+    }
+    else {
+      setConfig(tabConfigs?.TabSearchConfig?.[0]);
+        setTabConfig(tabConfigs);
+        getTotalCountForTab(tabConfigs);
+    }
     }
   }, [
     isLoading,
@@ -453,27 +465,31 @@ const HomeView = () => {
                 )}
               </div>
               <div className="inbox-search-wrapper pucar-home home-view">
-                <InboxSearchComposer
-                  key={`InboxSearchComposer-${callRefetch}`}
-                  configs={{
-                    ...config,
-                    ...{
-                      additionalDetails: {
-                        ...config?.additionalDetails,
-                        ...additionalDetails,
+                {config ? (
+                  <InboxSearchComposer
+                    key={`InboxSearchComposer-${callRefetch}`}
+                    configs={{
+                      ...config,
+                      ...{
+                        additionalDetails: {
+                          ...config?.additionalDetails,
+                          ...additionalDetails,
+                        },
                       },
-                    },
-                  }}
-                  defaultValues={defaultValues}
-                  showTab={true}
-                  tabData={tabData}
-                  onTabChange={onTabChange}
-                  additionalConfig={{
-                    resultsTable: {
-                      onClickRow: onRowClick,
-                    },
-                  }}
-                />
+                    }}
+                    defaultValues={defaultValues}
+                    showTab={true}
+                    tabData={tabData}
+                    onTabChange={onTabChange}
+                    additionalConfig={{
+                      resultsTable: {
+                        onClickRow: onRowClick,
+                      },
+                    }}
+                  />
+                ) : (
+                  <Loader />
+                )}
               </div>
             </div>
           </div>


### PR DESCRIPTION
Issue: #3778

## Summary
reducing count tab call in home page

## Requirements



- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of configuration and search component rendering for "employee" users, ensuring the interface displays correctly based on user type.
  - Added a loading indicator when configuration data is not yet available, enhancing the user experience during data initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->