### PR TITLE
order pending task | On first access, any order with a pending task redirects to the home screen fixed

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/index.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/index.js
@@ -69,41 +69,45 @@ const App = ({ path, stateCode, userType, tenants }) => {
         <PrivateRoute path={`${path}/hearings-response`} component={() => <HearingsResponse></HearingsResponse>} />
         <PrivateRoute path={`${path}/inside-hearing`} component={() => <InsideHearingMainPage />} />
         <PrivateRoute path={`${path}/home-pending-task/e-filing-payment-response`} component={() => <EFilingPaymentRes></EFilingPaymentRes>} />
-        <PrivateRoute path={`${path}/home-pending-task`} component={() => <HomeView></HomeView>} />
-        <PrivateRoute path={`${path}/bulk-esign-order`} component={() => <BulkESignView></BulkESignView>} />
-
-        <PrivateRoute path={`${path}/dashboard/adiary`} component={() => <ADiaryPage></ADiaryPage>} />
-        <PrivateRoute exact path={`${path}/dashboard`} component={() => <DashboardPage></DashboardPage>} />
         <PrivateRoute
+          exact
           path={`${path}/home-pending-task/e-filing-payment-breakdown`}
           component={() => <EfilingPaymentBreakdown></EfilingPaymentBreakdown>}
         />
         <PrivateRoute
+          exact
           path={`${path}/home-pending-task/summons-warrants-modal`}
           component={() => <SummonsAndWarrantsModal></SummonsAndWarrantsModal>}
         />
-        <PrivateRoute path={`${path}/home-pending-task/reissue-summons-modal`} component={() => <ReIssueSummonsModal></ReIssueSummonsModal>} />
-        <PrivateRoute path={`${path}/home-pending-task/post-payment-modal`} component={() => <PaymentForSummonModal></PaymentForSummonModal>} />
-        <PrivateRoute path={`${path}/home-pending-task/rpad-payment-modal`} component={() => <PaymentForRPADModal></PaymentForRPADModal>} />
+        <PrivateRoute exact path={`${path}/home-pending-task/reissue-summons-modal`} component={() => <ReIssueSummonsModal></ReIssueSummonsModal>} />
+        <PrivateRoute exact path={`${path}/home-pending-task/post-payment-modal`} component={() => <PaymentForSummonModal></PaymentForSummonModal>} />
+        <PrivateRoute exact path={`${path}/home-pending-task/rpad-payment-modal`} component={() => <PaymentForRPADModal></PaymentForRPADModal>} />
         <PrivateRoute
+          exact
           path={`${path}/home-pending-task/icops-payment-modal`}
           component={() => <PaymentForSummonModalSMSAndEmail></PaymentForSummonModalSMSAndEmail>}
         />
         <PrivateRoute
+          exact
           path={`${path}/home-pending-task/sms-payment-modal`}
           component={() => <PaymentForSummonModalSMSAndEmail></PaymentForSummonModalSMSAndEmail>}
         />
         <PrivateRoute
+          exact
           path={`${path}/home-pending-task/email-payment-modal`}
           component={() => <PaymentForSummonModalSMSAndEmail></PaymentForSummonModalSMSAndEmail>}
         />
+        <PrivateRoute exact path={`${path}/home-pending-task/home-schedule-hearing`} component={() => <ScheduleHearing />} />
+        <PrivateRoute exact path={`${path}/home-pending-task/home-set-next-hearing`} component={() => <ScheduleNextHearing />} />
+        <PrivateRoute exact path={`${path}/home-pending-task`} component={() => <HomeView></HomeView>} />
+        <PrivateRoute path={`${path}/bulk-esign-order`} component={() => <BulkESignView></BulkESignView>} />
+        <PrivateRoute path={`${path}/dashboard/adiary`} component={() => <ADiaryPage></ADiaryPage>} />
+        <PrivateRoute exact path={`${path}/dashboard`} component={() => <DashboardPage></DashboardPage>} />
         <PrivateRoute path={`${path}/sbi-epost-payment`} component={() => <SBIEpostPayment></SBIEpostPayment>} />
         <PrivateRoute path={`${path}/post-payment-screen`} component={() => <PaymentStatus></PaymentStatus>} />
         <PrivateRoute path={`${path}/sbi-payment-screen`} component={() => <SBIPaymentStatus />} />
         <PrivateRoute path={`${path}/view-hearing`} component={() => <ViewHearing></ViewHearing>} />
         <PrivateRoute path={`${path}/home-popup`} component={() => <HomePopUp></HomePopUp>} />
-        <PrivateRoute path={`${path}/home-pending-task/home-schedule-hearing`} component={() => <ScheduleHearing />} />
-        <PrivateRoute path={`${path}/home-pending-task/home-set-next-hearing`} component={() => <ScheduleNextHearing />} />
       </AppContainer>
     </Switch>
   );

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/PaymentForSummonModalSMSAndEmail.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/PaymentForSummonModalSMSAndEmail.js
@@ -1,5 +1,5 @@
-import React, { useCallback, useMemo, useState } from "react";
-import { Button, Loader } from "@egovernments/digit-ui-react-components";
+import React, { useCallback, useMemo, useState, useEffect } from "react";
+import { Loader } from "@egovernments/digit-ui-react-components";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom/cjs/react-router-dom.min";
 import ApplicationInfoComponent from "../../components/ApplicationInfoComponent";
@@ -9,7 +9,6 @@ import usePaymentProcess from "../../../../home/src/hooks/usePaymentProcess";
 import { DRISTIService } from "@egovernments/digit-ui-module-dristi/src/services";
 import { ordersService } from "../../hooks/services";
 import { Urls } from "../../hooks/services/Urls";
-import { useEffect } from "react";
 import { paymentType } from "../../utils/paymentType";
 import { extractFeeMedium, getTaskType } from "@egovernments/digit-ui-module-dristi/src/Utils";
 import { getSuffixByDeliveryChannel } from "../../utils";
@@ -117,9 +116,15 @@ const PaymentForSummonModalSMSAndEmail = ({ path }) => {
   const { filingNumber, taskNumber } = Digit.Hooks.useQueryParams();
   const tenantId = Digit.ULBService.getCurrentTenantId();
   const [caseId, setCaseId] = useState();
-  const { t } = useTranslation();
   const [isCaseLocked, setIsCaseLocked] = useState(false);
   const [payOnlineButtonTitle, setPayOnlineButtonTitle] = useState("CS_BUTTON_PAY_ONLINE_SOMEONE_PAYING");
+
+  useEffect(() => {
+    // If we don't have query params, redirect to home
+    if (!filingNumber || !taskNumber) {
+      history.replace(`/${window.contextPath}/citizen/home/home-pending-task`);
+    }
+  }, [filingNumber, history, taskNumber]);
 
   const { data: caseData } = Digit.Hooks.dristi.useSearchCaseService(
     {
@@ -569,10 +574,12 @@ const PaymentForSummonModalSMSAndEmail = ({ path }) => {
     };
   }, [
     courtFeeAmount,
+    courtBillResponse?.Bill,
+    deliveryPartnerFeeAmount,
+    ePostBillResponse,
     refetchBill,
     billResponse,
-    caseDetails?.filingNumber,
-    caseDetails?.caseTitle,
+    caseDetails,
     tenantId,
     openPaymentPortal,
     mockSubmitModalInfo,
@@ -583,6 +590,9 @@ const PaymentForSummonModalSMSAndEmail = ({ path }) => {
     status,
     filteredTasks,
     filingNumber,
+    service,
+    orderData,
+    partyIndex,
   ]);
 
   const infos = useMemo(() => {
@@ -673,7 +683,21 @@ const PaymentForSummonModalSMSAndEmail = ({ path }) => {
         />
       ),
     };
-  }, [channelId, feeOptions, history, infos, isCaseAdmitted, links, orderDate, orderType, paymentLoader, isUserAdv]);
+  }, [
+    channelId,
+    orderType,
+    isCaseLocked,
+    payOnlineButtonTitle,
+    infos,
+    links,
+    feeOptions,
+    orderDate,
+    paymentLoader,
+    isCaseAdmitted,
+    isUserAdv,
+    history,
+  ]);
+
   if (isOrdersLoading || isPaymentTypeLoading || isSummonsBreakUpLoading || isBillLoading) {
     return <Loader />;
   }


### PR DESCRIPTION
Add exact prop to routes and reorganize route order in employee homepage

## Requirements
#3866


- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved route matching for several pages to ensure correct navigation and prevent unintended route overlaps.
	- Enhanced dependency tracking in payment-related modals for more reliable updates.
	- Added automatic redirection to the pending tasks page if required query parameters are missing in the payment modal.

- **Refactor**
	- Updated and cleaned up imports and memo dependencies for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->