### PR TITLE
Remove fields showing "OutlinedInfoIcon" once a case is sent back

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingCases.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingCases.js
@@ -950,7 +950,7 @@ function EFilingCases({ path }) {
                 body.labelChildren = <span style={{ color: "#77787B" }}>&nbsp;{`${t("CS_IS_OPTIONAL")}`}</span>;
               }
 
-              if (body?.labelChildren === "OutlinedInfoIcon" && Object.keys(caseDetails?.additionalDetails?.scrutiny?.data || {}).length === 0) {
+              if (body?.labelChildren === "OutlinedInfoIcon") {
                 body.labelChildren = (
                   <React.Fragment>
                     <span style={{ color: "#77787B", position: "relative" }} data-tip data-for={`${body.label}-tooltip`}>
@@ -1130,7 +1130,7 @@ function EFilingCases({ path }) {
                 body.labelChildren = <span style={{ color: "#77787B" }}>&nbsp;{`${t("CS_IS_OPTIONAL")}`}</span>;
               }
 
-              if (body?.labelChildren === "OutlinedInfoIcon" && Object.keys(caseDetails?.additionalDetails?.scrutiny?.data || {}).length === 0) {
+              if (body?.labelChildren === "OutlinedInfoIcon") {
                 body.labelChildren = (
                   <React.Fragment>
                     <span style={{ color: "#77787B", position: "relative" }} data-tip data-for={`${body.label}-tooltip`}>
@@ -1361,8 +1361,7 @@ function EFilingCases({ path }) {
                 }
                 modifiedFormComponent.state = state;
                 if (
-                  modifiedFormComponent?.labelChildren === "OutlinedInfoIcon" &&
-                  Object.keys(caseDetails?.additionalDetails?.scrutiny?.data || {}).length === 0
+                  modifiedFormComponent?.labelChildren === "OutlinedInfoIcon"
                 ) {
                   modifiedFormComponent.labelChildren = (
                     <React.Fragment>


### PR DESCRIPTION
## Requirements
#3869


- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the display logic for icons and tooltips in the e-filing cases interface, ensuring that the OutlinedInfoIcon and its tooltip are shown consistently regardless of scrutiny data content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->