### PR TITLE
[BUG 3896- cherry pick to main]: Reduce Individual search calls on clicking on Documents tab in view a case screen

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/hooks/dristi/useEvidenceDetails.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/hooks/dristi/useEvidenceDetails.js
@@ -32,26 +32,36 @@ const useEvidenceDetails = ({ url, params, body, config = {}, plainAccessRequest
         plainAccessRequest,
         true
       );
-      if(owner?.Employees?.length > 1) return ""; 
-      return `${owner?.Individual[0]?.name?.givenName} ${owner[0]?.Individual[0]?.name?.familyName || ""}`.trim();
+      if (owner?.Employees?.length > 1) return "";
+      return `${owner?.Individual?.[0]?.name?.givenName} ${owner?.Individual?.[0]?.name?.familyName || ""}`.trim();
     }
   };
 
   const fetchCombinedData = async () => {
     //need to filter this hearing list response based on slot
     const res = await DRISTIService.searchEvidence(body, params, plainAccessRequest, true);
+    const uniqueArtifactsMap = new Map();
+    res?.artifacts?.forEach((artifact) => {
+      if (!uniqueArtifactsMap.has(artifact.sourceID)) {
+        uniqueArtifactsMap.set(artifact.sourceID, artifact);
+      }
+    });
+    const uniqueArtifacts = Array.from(uniqueArtifactsMap.values());
+
+    const ownerNames = await Promise.all(
+      uniqueArtifacts?.map(async (artifact) => {
+        const ownerName = await getOwnerName(artifact);
+        return { owner: ownerName, sourceID: artifact.sourceID };
+      })
+    );
+    const artifacts = res?.artifacts?.map((artifact) => {
+      const ownerName = ownerNames?.find((item) => item.sourceID === artifact.sourceID)?.owner;
+      return { ...artifact, owner: ownerName };
+    });
+
     return {
       ...res,
-      artifacts: await Promise.all(
-        res.artifacts.map(async (artifact) => {
-          const owner = await getOwnerName(artifact);
-
-          return {
-            ...artifact,
-            owner: owner,
-          };
-        })
-      ),
+      artifacts,
     };
   };
 

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCase.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCase.js
@@ -1263,13 +1263,9 @@ const AdmittedCases = () => {
         if (artifact.sourceID === undefined) {
           return "NA";
         }
-        const owner = await DRISTIService.searchEmployeeUser(
-          {
-            authToken: localStorage.getItem("token"),
-          },
-          { tenantId, uuids: artifact?.sourceID, limit: 1000, offset: 0 }
-        );
-        return `${owner?.Employees?.[0]?.user?.name}`.trim();
+        const owner = await Digit.UserService.userSearch(tenantId, { uuid: [artifact?.sourceID] }, {});
+        if (owner?.user?.length > 1) return "";
+        return `${owner?.user?.[0]?.name}`.trim();
       } else {
         if (artifact?.sourceID === undefined) {
           return "NA";


### PR DESCRIPTION
Issue: #3896

## Summary
There were multiple individual calls for same individual Id to get the user's name -> fixed that.

## Requirements



- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



