### PR TITLE
[#3901]: removed unnecessary api calls from generate orders screen

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/hooks/dristi/useSearchCaseService.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/hooks/dristi/useSearchCaseService.js
@@ -1,7 +1,7 @@
 import { useQuery, useQueryClient } from "react-query";
 import { DRISTIService } from "../../services";
 
-function useSearchCaseService(reqData, params, moduleCode, caseId, enabled, isCacheTimeEnabled = true) {
+function useSearchCaseService(reqData, params, moduleCode, caseId, enabled, isCacheTimeEnabled = true, cacheTime = 0) {
   const client = useQueryClient();
   const { isLoading, data, isFetching, refetch, error } = useQuery(
     `GET_CASE_DETAILS_${moduleCode}_${caseId}`,
@@ -10,7 +10,7 @@ function useSearchCaseService(reqData, params, moduleCode, caseId, enabled, isCa
         .then((data) => data)
         .catch(() => ({})),
     {
-      ...(isCacheTimeEnabled && { cacheTime: 0 }),
+      ...(isCacheTimeEnabled && { cacheTime }),
       enabled: Boolean(enabled),
     }
   );


### PR DESCRIPTION
Issue: #3901

## Summary
removed unnecessary api calls from generate orders screen

## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for specifying a custom cache duration when searching cases, allowing for more flexible data caching.
- **Refactor**
	- Improved order fetching in the Generate Orders page to only retrieve relevant published orders based on the selected order type, resulting in more efficient data loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->