### PR TITLE
feat: add vakalatnama document viewer to advocate replacement component

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/components/AdvocateReplacementComponent.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/components/AdvocateReplacementComponent.js
@@ -204,6 +204,12 @@ const AdvocateReplacementComponent = ({ filingNumber, taskNumber, setPendingTask
         { label: "MOBILE_NUMBER", value: taskDetails?.advocateDetails?.mobileNumber },
         { label: "REQUEST_DATE", value: formatDate(new Date(taskDetails?.advocateDetails?.requestedDate)) },
       ],
+      vakalatnama: {
+        label: "VAKALATNAMA",
+        value: taskDetails?.replacementDetails
+          ?.filter((item) => item?.document?.fileStore)
+          ?.map((item) => ({ name: `Vakalatnama (${item?.litigantDetails?.name})`, fileStoreId: item?.document?.fileStore })),
+      },
       reasonForReplacement: [
         { label: "REASON_FOR_REPLACEMENT", value: taskDetails?.reason },
         ...(taskDetails?.reasonDocument?.fileStore
@@ -235,6 +241,19 @@ const AdvocateReplacementComponent = ({ filingNumber, taskNumber, setPendingTask
               <p className="value">{item.value}</p>
             </div>
           ))}
+        </div>
+        <div className="advocate-replacement-request-body">
+          <div className="info-row" style={{ justifyContent: "space-between" }}>
+            <p className="label">{t(advocateReplacementData?.vakalatnama?.label)}</p>
+            <div
+              className="reason-document-wrapper"
+              style={{ width: "fit-content", maxWidth: "60%", overflowX: "auto", gap: "20px", justifyContent: "flex-start" }}
+            >
+              {advocateReplacementData?.vakalatnama?.value?.map((vakalatnama) => (
+                <DocViewerWrapper fileStoreId={vakalatnama.fileStoreId} tenantId={tenantId} displayFilename={vakalatnama.name} />
+              ))}
+            </div>
+          </div>
         </div>
         <div className="advocate-replacement-request-body">
           {advocateReplacementData?.reasonForReplacement?.map((item) => (

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/components/AdvocateReplacementComponent.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/components/AdvocateReplacementComponent.js
@@ -219,7 +219,7 @@ const AdvocateReplacementComponent = ({ filingNumber, taskNumber, setPendingTask
       litigants: isCitizen
         ? [
             { type: "head", data: ["LITIGANTS_FOR_WHOM_REPLACEMENT_IS_REQUESTED"] },
-            ...taskDetails?.replacementDetails?.map((item) => ({ type: "body", data: [item?.litigantDetails?.name || "Maruthi"] })),
+            ...taskDetails?.replacementDetails?.map((item) => ({ type: "body", data: [item?.litigantDetails?.name] })),
           ]
         : [
             { type: "head", data: ["ADVOCATES_TO_BE_REPLACED", "LITIGANTS_FOR_WHOM_REPLACEMENT_IS_REQUESTED", "BAR_REGISTRATION_NO"] },
@@ -242,19 +242,21 @@ const AdvocateReplacementComponent = ({ filingNumber, taskNumber, setPendingTask
             </div>
           ))}
         </div>
-        <div className="advocate-replacement-request-body">
-          <div className="info-row" style={{ justifyContent: "space-between" }}>
-            <p className="label">{t(advocateReplacementData?.vakalatnama?.label)}</p>
-            <div
-              className="reason-document-wrapper"
-              style={{ width: "fit-content", maxWidth: "60%", overflowX: "auto", gap: "20px", justifyContent: "flex-start" }}
-            >
-              {advocateReplacementData?.vakalatnama?.value?.map((vakalatnama) => (
-                <DocViewerWrapper fileStoreId={vakalatnama.fileStoreId} tenantId={tenantId} displayFilename={vakalatnama.name} />
-              ))}
+        {advocateReplacementData?.vakalatnama?.value?.length > 0 && (
+          <div className="advocate-replacement-request-body">
+            <div className="info-row" style={{ justifyContent: "space-between" }}>
+              <p className="label">{t(advocateReplacementData?.vakalatnama?.label)}</p>
+              <div
+                className="reason-document-wrapper"
+                style={{ width: "fit-content", maxWidth: "60%", overflowX: "auto", gap: "20px", justifyContent: "flex-start" }}
+              >
+                {advocateReplacementData?.vakalatnama?.value?.map((vakalatnama) => (
+                  <DocViewerWrapper fileStoreId={vakalatnama.fileStoreId} tenantId={tenantId} displayFilename={vakalatnama.name} />
+                ))}
+              </div>
             </div>
           </div>
-        </div>
+        )}
         <div className="advocate-replacement-request-body">
           {advocateReplacementData?.reasonForReplacement?.map((item) => (
             <div className="info-row" key={item.label}>


### PR DESCRIPTION
## Requirements
https://github.com/pucardotorg/dristi/issues/3929


- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new section to display "Vakalatnama" documents related to advocate replacement tasks within the advocate replacement details view. Users can now view and scroll through associated Vakalatnama documents for each replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->