### PR TITLE
[#3901 - main]: removed unnecessary api calls from generate orders screen

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/hooks/dristi/useSearchCaseService.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/hooks/dristi/useSearchCaseService.js
@@ -1,7 +1,7 @@
 import { useQuery, useQueryClient } from "react-query";
 import { DRISTIService } from "../../services";
 
-function useSearchCaseService(reqData, params, moduleCode, caseId, enabled, isCacheTimeEnabled = true) {
+function useSearchCaseService(reqData, params, moduleCode, caseId, enabled, isCacheTimeEnabled = true, cacheTime = 0) {
   const client = useQueryClient();
   const { isLoading, data, isFetching, refetch, error } = useQuery(
     `GET_CASE_DETAILS_${moduleCode}_${caseId}`,
@@ -10,7 +10,7 @@ function useSearchCaseService(reqData, params, moduleCode, caseId, enabled, isCa
         .then((data) => data)
         .catch(() => ({})),
     {
-      ...(isCacheTimeEnabled && { cacheTime: 0 }),
+      ...(isCacheTimeEnabled && { cacheTime }),
       enabled: Boolean(enabled),
     }
   );

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrders.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrders.js
@@ -303,7 +303,9 @@ const GenerateOrders = () => {
     {},
     `case-details-${filingNumber}`,
     filingNumber,
-    Boolean(filingNumber)
+    Boolean(filingNumber),
+    true,
+    6 * 1000
   );
   const userInfo = Digit.UserService.getUser()?.info;
   const userInfoType = useMemo(() => (userInfo?.type === "CITIZEN" ? "citizen" : "employee"), [userInfo]);
@@ -465,77 +467,6 @@ const GenerateOrders = () => {
     Boolean(filingNumber)
   );
 
-  const { data: noticeOrdersData } = useSearchOrdersService(
-    {
-      tenantId,
-      criteria: { filingNumber, applicationNumber: "", cnrNumber, orderType: "NOTICE", status: "PUBLISHED" },
-      pagination: { limit: 1000, offset: 0 },
-    },
-    { tenantId },
-    filingNumber,
-    Boolean(filingNumber)
-  );
-
-  // Get all the published orders corresponding to approval/rejection of litigants profile change request.
-  const { data: approveRejectLitigantDetailsChangeOrderData } = useSearchOrdersService(
-    {
-      tenantId,
-      criteria: {
-        filingNumber,
-        applicationNumber: "",
-        cnrNumber,
-        orderType: "APPROVAL_REJECTION_LITIGANT_DETAILS_CHANGE",
-        status: OrderWorkflowState.PUBLISHED,
-      },
-      pagination: { limit: 1000, offset: 0 },
-    },
-    { tenantId },
-    filingNumber + OrderWorkflowState.PUBLISHED,
-    Boolean(filingNumber && cnrNumber)
-  );
-
-  const publishedLitigantDetailsChangeOrders = useMemo(() => approveRejectLitigantDetailsChangeOrderData?.list || [], [
-    approveRejectLitigantDetailsChangeOrderData,
-  ]);
-
-  const isDCANoticeGenerated = useMemo(
-    () =>
-      noticeOrdersData?.list?.some((notice) => {
-        if (notice?.orderCategory === "COMPOSITE") {
-          return notice?.compositeItems?.some((item) => item?.orderSchema?.additionalDetails?.formdata?.noticeType?.code === "DCA Notice");
-        }
-        return notice?.additionalDetails?.formdata?.noticeType?.code === "DCA Notice";
-      }),
-    [noticeOrdersData]
-  );
-
-  const { data: publishedOrdersData, isLoading: isPublishedOrdersLoading } = useSearchOrdersService(
-    {
-      tenantId,
-      criteria: { filingNumber, applicationNumber: "", cnrNumber, status: OrderWorkflowState.PUBLISHED, orderType: "ACCEPT_BAIL" },
-      pagination: { limit: 1000, offset: 0 },
-    },
-    { tenantId },
-    filingNumber + OrderWorkflowState.PUBLISHED,
-    Boolean(filingNumber && cnrNumber)
-  );
-  const publishedBailOrder = useMemo(() => publishedOrdersData?.list?.[0] || {}, [publishedOrdersData]);
-  const advocateIds = caseDetails.representatives?.map((representative) => {
-    return {
-      id: representative.advocateId,
-    };
-  });
-
-  const { data: advocateDetails } = Digit.Hooks.dristi.useGetIndividualAdvocate(
-    {
-      criteria: advocateIds,
-    },
-    { tenantId: tenantId },
-    "DRISTI",
-    cnrNumber + filingNumber,
-    true
-  );
-
   const defaultIndex = useMemo(() => {
     return formList.findIndex((order) => order?.orderNumber === orderNumber);
   }, [formList, orderNumber]);
@@ -664,6 +595,96 @@ const GenerateOrders = () => {
   }, [currentDiaryEntry, filingNumber, orderNumber, tenantId]);
 
   const currentOrder = useMemo(() => formList?.[selectedOrder], [formList, selectedOrder]);
+
+  // Checking if the current order type is NOTICE.
+  const isNoticeOrder = useMemo(() => {
+    if (currentOrder?.orderCategory === "COMPOSITE") {
+      if (currentOrder?.compositeItems?.find((item) => item?.orderType === "NOTICE")) {
+        return true;
+      } else return false;
+    } else if (currentOrder?.orderType === "NOTICE") {
+      return true;
+    } else return false;
+  }, [currentOrder]);
+
+  const { data: publishedNoticeOrdersData } = useSearchOrdersService(
+    {
+      tenantId,
+      criteria: { filingNumber, applicationNumber: "", cnrNumber, orderType: "NOTICE", status: "PUBLISHED" },
+      pagination: { limit: 1000, offset: 0 },
+    },
+    { tenantId },
+    filingNumber + OrderWorkflowState.PUBLISHED + "NOTICE",
+    Boolean(filingNumber && isNoticeOrder)
+  );
+
+  const isDCANoticeGenerated = useMemo(
+    () =>
+      publishedNoticeOrdersData?.list?.some((notice) => {
+        if (notice?.orderCategory === "COMPOSITE") {
+          return notice?.compositeItems?.some((item) => item?.orderSchema?.additionalDetails?.formdata?.noticeType?.code === "DCA Notice");
+        }
+        return notice?.additionalDetails?.formdata?.noticeType?.code === "DCA Notice";
+      }),
+    [publishedNoticeOrdersData]
+  );
+
+  // Checking if the current order is for approving/rejecting the litigant's profile edit request.
+  const isApproveRejectLitigantDetailsChange = useMemo(() => {
+    if (currentOrder?.orderCategory === "COMPOSITE") {
+      if (currentOrder?.compositeItems?.find((item) => item?.orderType === "APPROVAL_REJECTION_LITIGANT_DETAILS_CHANGE")) {
+        return true;
+      } else return false;
+    } else if (currentOrder?.orderType === "APPROVAL_REJECTION_LITIGANT_DETAILS_CHANGE") {
+      return true;
+    } else return false;
+  }, [currentOrder]);
+
+  // Get all the published orders corresponding to approval/rejection of litigants profile change request.
+  const { data: approveRejectLitigantDetailsChangeOrderData } = useSearchOrdersService(
+    {
+      tenantId,
+      criteria: {
+        filingNumber,
+        applicationNumber: "",
+        cnrNumber,
+        orderType: "APPROVAL_REJECTION_LITIGANT_DETAILS_CHANGE",
+        status: OrderWorkflowState.PUBLISHED,
+      },
+      pagination: { limit: 1000, offset: 0 },
+    },
+    { tenantId },
+    filingNumber + OrderWorkflowState.PUBLISHED + "APPROVAL_REJECTION_LITIGANT_DETAILS_CHANGE",
+    Boolean(filingNumber && cnrNumber && isApproveRejectLitigantDetailsChange)
+  );
+
+  const publishedLitigantDetailsChangeOrders = useMemo(() => approveRejectLitigantDetailsChangeOrderData?.list || [], [
+    approveRejectLitigantDetailsChangeOrderData,
+  ]);
+
+  // If current order is Judgement type, then we require published bail orders list.
+  const isJudgementOrder = useMemo(() => {
+    if (currentOrder?.orderCategory === "COMPOSITE") {
+      if (currentOrder?.compositeItems?.find((item) => item?.orderType === "JUDGEMENT")) {
+        return true;
+      } else return false;
+    } else if (currentOrder?.orderType === "JUDGEMENT") {
+      return true;
+    } else return false;
+  }, [currentOrder]);
+
+  const { data: publishedBailOrdersData, isLoading: isPublishedOrdersLoading } = useSearchOrdersService(
+    {
+      tenantId,
+      criteria: { filingNumber, applicationNumber: "", cnrNumber, status: OrderWorkflowState.PUBLISHED, orderType: "ACCEPT_BAIL" },
+      pagination: { limit: 1000, offset: 0 },
+    },
+    { tenantId },
+    filingNumber + OrderWorkflowState.PUBLISHED + "ACCEPT_BAIL",
+    Boolean(filingNumber && cnrNumber && isJudgementOrder)
+  );
+  const publishedBailOrder = useMemo(() => publishedBailOrdersData?.list?.[0] || {}, [publishedBailOrdersData]);
+
   const hearingNumber = useMemo(() => currentOrder?.hearingNumber || currentOrder?.additionalDetails?.hearingId || "", [currentOrder]);
   useEffect(() => {
     const formListNew = structuredClone([...(ordersData?.list || [])].reverse());


### PR DESCRIPTION
Issue: #3901

## Summary
removed unnecessary api calls from generate orders screen

## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for specifying a custom cache duration when searching cases, allowing for more flexible data caching.
- **Refactor**
	- Improved order fetching in the Generate Orders page to only retrieve relevant published orders based on the selected order type, resulting in more efficient data loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->