### PR TITLE
[3978 cherry-pick to develop]: [Order for admit case id getting published 2 times, if we have a dca filed.] 

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrders.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrders.js
@@ -346,9 +346,7 @@ const GenerateOrders = () => {
     {},
     `case-details-${filingNumber}`,
     filingNumber,
-    Boolean(filingNumber),
-    true,
-    6 * 1000
+    Boolean(filingNumber)
   );
   const userInfo = Digit.UserService.getUser()?.info;
   const userInfoType = useMemo(() => (userInfo?.type === "CITIZEN" ? "citizen" : "employee"), [userInfo]);
@@ -387,16 +385,19 @@ const GenerateOrders = () => {
   const applicationTypeConfigUpdated = useMemo(() => {
     const updatedConfig = structuredClone(applicationTypeConfig);
     // Showing admit case/Dismiss case order type in the dropdown list depending on the case status.
-    if (
-      ["PENDING_NOTICE"].includes(caseDetails?.status) ||
-      // case admit can not be allowed if there are pending review/approval of some Delay condonation application.
-      (["PENDING_RESPONSE", "PENDING_ADMISSION"].includes(caseDetails?.status) && isDelayApplicationPending)
-    ) {
+    if (["PENDING_NOTICE"].includes(caseDetails?.status)) {
       updatedConfig[0].body[0].populators.mdmsConfig.select =
         "(data) => {return data['Order'].OrderType?.filter((item)=>[`DISMISS_CASE`, `SUMMONS`, `NOTICE`, `SECTION_202_CRPC`, `MANDATORY_SUBMISSIONS_RESPONSES`, `REFERRAL_CASE_TO_ADR`, `SCHEDULE_OF_HEARING_DATE`, `WARRANT`, `OTHERS`, `JUDGEMENT`].includes(item.type)).map((item) => {return { ...item, name: 'ORDER_TYPE_'+item.code };});}";
     } else if (["PENDING_RESPONSE", "PENDING_ADMISSION"].includes(caseDetails?.status)) {
-      updatedConfig[0].body[0].populators.mdmsConfig.select =
-        "(data) => {return data['Order'].OrderType?.filter((item)=>[`ADMIT_CASE`, `DISMISS_CASE`, `SUMMONS`, `NOTICE`, `SECTION_202_CRPC`, `MANDATORY_SUBMISSIONS_RESPONSES`, `REFERRAL_CASE_TO_ADR`, `SCHEDULE_OF_HEARING_DATE`, `WARRANT`, `OTHERS`, `JUDGEMENT`].includes(item.type)).map((item) => {return { ...item, name: 'ORDER_TYPE_'+item.code };});}";
+      // case admit can not be allowed if there are pending review/approval of some Delay condonation application.
+
+      if (isDelayApplicationPending) {
+        updatedConfig[0].body[0].populators.mdmsConfig.select =
+          "(data) => {return data['Order'].OrderType?.filter((item)=>[`DISMISS_CASE`, `SUMMONS`, `NOTICE`, `SECTION_202_CRPC`, `MANDATORY_SUBMISSIONS_RESPONSES`, `REFERRAL_CASE_TO_ADR`, `SCHEDULE_OF_HEARING_DATE`, `WARRANT`, `OTHERS`, `JUDGEMENT`].includes(item.type)).map((item) => {return { ...item, name: 'ORDER_TYPE_'+item.code };});}";
+      } else {
+        updatedConfig[0].body[0].populators.mdmsConfig.select =
+          "(data) => {return data['Order'].OrderType?.filter((item)=>[`ADMIT_CASE`, `DISMISS_CASE`, `SUMMONS`, `NOTICE`, `SECTION_202_CRPC`, `MANDATORY_SUBMISSIONS_RESPONSES`, `REFERRAL_CASE_TO_ADR`, `SCHEDULE_OF_HEARING_DATE`, `WARRANT`, `OTHERS`, `JUDGEMENT`].includes(item.type)).map((item) => {return { ...item, name: 'ORDER_TYPE_'+item.code };});}";
+      }
     }
     return updatedConfig;
   }, [caseDetails, isDelayApplicationPending]);
@@ -1401,7 +1402,7 @@ const GenerateOrders = () => {
       });
       return [updatedConfig];
     }
-  }, [caseDetails, complainants, currentOrder, respondents, t, unJoinedLitigant, witnesses, selectedOrder]);
+  }, [caseDetails, applicationTypeConfigUpdated, complainants, currentOrder, respondents, t, unJoinedLitigant, witnesses, selectedOrder]);
 
   const multiSelectDropdownKeys = useMemo(() => {
     const foundKeys = [];


### PR DESCRIPTION
Issue: #3978

## Summary
removed caching from case search.

## Requirements



- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the logic for selecting order types, ensuring "ADMIT_CASE" cannot be chosen when a delay condonation application is pending.
  - Disabled repeated polling when fetching case service data, resulting in more efficient data loading.
- **Refactor**
  - Updated internal dependencies to ensure form configurations refresh correctly when order type options change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->