### PR TITLE
[bug 4049]: pick courtId from globalConfig instead of localStorage

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/scrutiny/ViewCaseFile.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/scrutiny/ViewCaseFile.js
@@ -19,7 +19,7 @@ import downloadPdfWithLink from "../../../Utils/downloadPdfWithLink";
 import WorkflowTimeline from "../../../components/WorkflowTimeline";
 import { use } from "react";
 const judgeId = window?.globalConfigs?.getConfig("JUDGE_ID") || "JUDGE_ID";
-const courtId = localStorage.getItem("courtId");
+const courtId = window?.globalConfigs?.getConfig("COURT_ID") || "COURT_ID";
 const benchId = window?.globalConfigs?.getConfig("BENCH_ID") || "BENCH_ID";
 
 const downloadButtonStyle = {


### PR DESCRIPTION
Issue: #4049

## Summary
picked courtId from globalConfig instead of localStorage

## Requirements



- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the method for retrieving the court identifier to use a global configuration instead of local storage. This change does not affect user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->