### PR TITLE
[bug 4088]: hold config update till latest orders data is not available

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/WitnessDrawer.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/WitnessDrawer.js
@@ -65,24 +65,24 @@ const WitnessDrawer = ({ isOpen, onClose, tenantId, onSubmit, attendees, caseDet
       const selectedWitnessDefault = caseDetails?.additionalDetails?.witnessDetails?.formdata?.[0]?.data || {};
       setSelectedWitness(selectedWitnessDefault);
       setWitnessDepositionText(
-        hearing?.additionalDetails?.witnessDepositions?.find((witness) => witness.uuid === selectedWitnessDefault?.uuid)?.deposition
+        hearingData?.additionalDetails?.witnessDepositions?.find((witness) => witness.uuid === selectedWitnessDefault?.uuid)?.deposition
       );
     }
-  }, [caseDetails, hearing?.additionalDetails?.witnessDepositions]);
+  }, [caseDetails, hearingData?.additionalDetails?.witnessDepositions]);
 
   const isDepositionSaved = useMemo(() => {
     return (
-      hearing?.additionalDetails?.witnessDepositions?.find((witness) => witness.uuid === selectedWitness?.uuid)?.isDepositionSaved === true ||
+      hearingData?.additionalDetails?.witnessDepositions?.find((witness) => witness.uuid === selectedWitness?.uuid)?.isDepositionSaved === true ||
       hearingData?.additionalDetails?.witnessDepositions?.find((witness) => witness.uuid === selectedWitness?.uuid)?.isDepositionSaved === true
     );
-  }, [selectedWitness, hearing, hearingData]);
+  }, [selectedWitness, hearingData]);
 
   const handleDropdownChange = (selectedWitnessOption) => {
     const selectedUUID = selectedWitnessOption.value;
     const selectedWitnessDeposition = caseDetails?.additionalDetails?.witnessDetails?.formdata?.find((w) => w.data.uuid === selectedUUID)?.data || {};
     setSelectedWitness(selectedWitnessDeposition);
     setWitnessDepositionText(
-      hearing?.additionalDetails?.witnessDepositions?.find((witness) => witness.uuid === selectedWitnessDeposition.uuid)?.deposition || ""
+      hearingData?.additionalDetails?.witnessDepositions?.find((witness) => witness.uuid === selectedWitnessDeposition.uuid)?.deposition || ""
     );
   };
 
@@ -91,11 +91,11 @@ const WitnessDrawer = ({ isOpen, onClose, tenantId, onSubmit, attendees, caseDet
   }, [selectedWitness]);
 
   const saveWitnessDeposition = async () => {
-    if (!hearing) return;
+    if (!hearingData) return;
 
     setWitnessModalOpen(true);
 
-    const updatedHearing = structuredClone(hearing || {});
+    const updatedHearing = structuredClone(hearingData || {});
     updatedHearing.additionalDetails = updatedHearing.additionalDetails || {};
     updatedHearing.additionalDetails.witnessDepositions = updatedHearing.additionalDetails.witnessDepositions || [];
     // Find the index of the selected witness in witnessDepositions
@@ -154,7 +154,7 @@ const WitnessDrawer = ({ isOpen, onClose, tenantId, onSubmit, attendees, caseDet
           }
         });
       }
-      const documents = Array.isArray(hearing?.documents) ? hearing.documents : [];
+      const documents = Array.isArray(hearingData?.documents) ? hearingData.documents : [];
       const documentsFile =
         signedDocumentUploadID !== ""
           ? {
@@ -165,7 +165,7 @@ const WitnessDrawer = ({ isOpen, onClose, tenantId, onSubmit, attendees, caseDet
 
       const reqBody = {
         hearing: {
-          ...hearing,
+          ...hearingData,
           documents: documentsFile ? [...documents, documentsFile] : documents,
         },
       };

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrders.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrders.js
@@ -612,6 +612,9 @@ const GenerateOrders = () => {
     return `${year}-${month}-${day}`;
   };
   useEffect(() => {
+    if (isOrdersLoading || isOrdersFetching) {
+      return;
+    }
     if (!ordersData?.list || ordersData?.list.length < 1) {
       setFormList([defaultOrderData]);
     } else {
@@ -967,6 +970,7 @@ const GenerateOrders = () => {
   );
 
   const modifiedFormConfig = useMemo(() => {
+    if (!currentOrder) return null;
     if (currentOrder?.orderCategory === "COMPOSITE") {
       return currentOrder?.compositeItems?.map((item) => {
         // We will disable the order type dropdown as a quick fix to handle formcomposer issue
@@ -3900,7 +3904,8 @@ const GenerateOrders = () => {
     !ordersData?.list ||
     isHearingLoading ||
     isCourtIdsLoading ||
-    isPublishedOrdersLoading
+    isPublishedOrdersLoading ||
+    !modifiedFormConfig
   ) {
     return <Loader />;
   }


### PR DESCRIPTION
Issue: #4088

## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability of witness deposition handling in admitted cases by ensuring the most current hearing data is used throughout the WitnessDrawer interface.
	- Enhanced stability in the Generate Orders page by adding additional checks to prevent errors when order data is still loading or incomplete, ensuring the form only loads when data is ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->