### PR TITLE
[#4124 develop]: made delivery channel mandatory validation for publishing notice and …

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/index.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/index.js
@@ -32,7 +32,7 @@ const EmployeeApp = ({ path, url, userType, tenants, parentRoute, result, fileSt
   const eSignWindowObject = sessionStorage.getItem("eSignWindowObject");
   const retrievedObject = JSON.parse(eSignWindowObject);
 
-  const isJudgeView = roles?.some((role) => ["CASE_APPROVER", "BENCH_CLERK", "COURT_ROOM_MANAGER", "TYPIST_ROLE"].includes(role.code));
+  const isJudgeView = roles?.some((role) => ["JUDGE_ROLE", "BENCH_CLERK", "TYPIST_ROLE"].includes(role.code));
 
   const employeeCrumbs = [
     {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrders.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrders.js
@@ -3684,6 +3684,34 @@ const GenerateOrders = () => {
           }
         }
 
+        if (orderType === "NOTICE") {
+          if(formData?.noticeOrder?.selectedChannels?.length === 0){
+            setShowErrorToast({ label: t("PLESE_SELECT_A_DELIVERY_CHANNEL_FOR_NOTICE_ORDER"), error: true });
+            hasError = true;
+            break;
+          }
+        }
+
+        if (orderType === "SUMMONS") {
+          if(formData?.SummonsOrder?.selectedChannels?.length === 0){
+            setShowErrorToast({ label: t("PLESE_SELECT_A_DELIVERY_CHANNEL_FOR_SUMMONS_ORDER"), error: true });
+            hasError = true;
+            break;
+          }
+
+          else if (
+            formData?.SummonsOrder?.selectedChannels?.some(
+              (channel) =>
+                (channel?.code === "POLICE") &&
+                (!channel?.value?.geoLocationDetails || !channel?.value?.geoLocationDetails?.policeStation)
+            )
+          ) {
+            setShowErrorToast({ label: t("CS_POLICE_STATION_ERROR"), error: true });
+            hasError = true;
+            break;
+          }
+        }
+
         if (orderType === "WARRANT") {
           if (!formData?.bailInfo?.noOfSureties && formData?.bailInfo?.isBailable?.code === true) {
             setFormErrors?.current?.[index]?.("noOfSureties", { message: t("CORE_REQUIRED_FIELD_ERROR") });


### PR DESCRIPTION
Issue: #4124

## Summary
At least one delivery channel selection should be mandatory before publishing order for notice or summons.
 
## Requirements



- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Added validation to ensure "NOTICE" and "SUMMONS" orders cannot be submitted without selecting at least one channel.
	- For "SUMMONS" orders, additional validation ensures that if the "POLICE" channel is selected, a valid police station must be provided.
	- Users will now see clear error messages if these conditions are not met during order review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->