### PR TITLE
Fix for validation for same mobile number of different surities

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/pages/employee/GenerateBailBond.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/pages/employee/GenerateBailBond.js
@@ -615,6 +615,30 @@ const GenerateBailBond = () => {
     return true;
   };
 
+  const validateAdvocateSuretyContactNumber = (sureties) => {
+    const advocateMobileNumber = userInfo?.mobileNumber;
+    const mobileNumbers = new Set();
+    
+    for (let i = 0; i < sureties?.length; i++) {
+      const currentMobile = sureties[i]?.mobileNumber;
+      if (!currentMobile) continue;
+      
+      if (advocateMobileNumber && currentMobile === advocateMobileNumber) {
+        setShowErrorToast({ label: "SURETY_ADVOCATE_MOBILE_NUMBER_SAME", error: true });
+        return true;
+      }
+    
+      if (mobileNumbers.has(currentMobile)) {
+        setShowErrorToast({ label: "SAME_MOBILE_NUMBER_SURETY", error: true });
+        return true;
+      }
+      
+      mobileNumbers.add(currentMobile);
+    }
+    
+    return false;
+  };
+
   const validateSurities = (sureties) => {
     let error = false;
     if (!sureties && !Object.keys(setFormState?.current?.errors).includes("sureties")) {
@@ -671,6 +695,10 @@ const GenerateBailBond = () => {
           setShowErrorToast({ label: "CS_PLEASE_CHECK_ADDRESS_DETAILS_BEFORE_SUBMIT", error: true });
           return;
         }
+      }
+
+      if(validateAdvocateSuretyContactNumber(formdata?.sureties)){
+        return;
       }
     }
 


### PR DESCRIPTION
## Requirements



- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to prevent sureties' mobile numbers from matching the advocate's mobile number or being duplicated among sureties during bail bond generation.
  * Users will now see specific error messages if these mobile number issues are detected, ensuring more accurate data entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->