### PR TITLE
disabled otp  btn on failing multiple otps

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/Login/index.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/Login/index.js
@@ -212,8 +212,9 @@ const Login = ({ stateCode }) => {
         }));
       }
     } catch (err) {
-      setCanSubmitOtp(true);
+      // setCanSubmitOtp(true);
       setOtpError(err?.response?.data?.error_description === "Account locked" ? t("MAX_RETRIES_EXCEEDED") : t("CS_INVALID_OTP"));
+      setCanSubmitOtp(err?.response?.data?.error_description === "Account locked" ? false : true);
       setParmas((prev) => ({
         ...prev,
         otp: "",


### PR DESCRIPTION
## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OTP submission handling by preventing further OTP attempts when an account is locked, providing clearer feedback to users in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->