### PR TITLE
Fix for Make "Other Documents" field non-mandatory

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/configs/generateBailBondConfig.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/configs/generateBailBondConfig.js
@@ -321,7 +321,7 @@ export const bailBondConfig = [
                 inputs: [
                   {
                     name: "document",
-                    isMandatory: true,
+                    isMandatory: false,
                     documentHeader: "OTHER_DOCUMENTS_HEADING",
                     fileTypes: ["JPG", "PDF", "PNG", "JPEG"],
                     uploadGuidelines: "UPLOAD_DOC_50",

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/pages/employee/GenerateBailBond.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/pages/employee/GenerateBailBond.js
@@ -343,9 +343,6 @@ const GenerateBailBond = () => {
             clearErrors(`proofOfSolvency_${index}`);
           }
 
-          if (docs?.otherDocuments && Object.keys(formState?.errors).includes(`otherDocuments_${index}`)) {
-            clearErrors(`otherDocuments_${index}`);
-          }
         });
       } else if (formData?.sureties?.length > 0 && Object.keys(formState?.errors).includes("sureties")) {
         clearErrors("sureties");
@@ -690,10 +687,6 @@ const GenerateBailBond = () => {
           setFormErrors.current(`proofOfSolvency_${index}`, { message: t("CORE_REQUIRED_FIELD_ERROR") });
         }
 
-        if (!docs?.otherDocuments && !Object.keys(setFormState?.current?.errors).includes(`otherDocuments_${index}`)) {
-          error = true;
-          setFormErrors.current(`otherDocuments_${index}`, { message: t("CORE_REQUIRED_FIELD_ERROR") });
-        }
       });
     }
     return error;


### PR DESCRIPTION
## Requirements

#4402

- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Uploading documents in the "Other Documents" section of the bail bond form is no longer mandatory.
  * Validation and error messages related to missing "Other Documents" have been removed, streamlining the form submission process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->