### PR TITLE
Fix isActive null behaviour while searching

### DIFF
--- a/backend/evidence/src/main/java/org/pucar/dristi/repository/querybuilder/EvidenceQueryBuilder.java
+++ b/backend/evidence/src/main/java/org/pucar/dristi/repository/querybuilder/EvidenceQueryBuilder.java
@@ -56,7 +56,7 @@ public class EvidenceQueryBuilder {
             List<String> status = criteria.getStatus();
             List<String> workflowStatus = criteria.getWorkflowStatus();
             String evidenceNumber = criteria.getEvidenceNumber();
-            boolean isActive = criteria.getIsActive();
+            Boolean isActive = criteria.getIsActive();
 
             // Build the query using the extracted fields
             firstCriteria = addArtifactCriteria(id, query, preparedStmtList, firstCriteria, "art.id = ?",preparedStmtArgList);

--- a/backend/evidence/src/main/java/org/pucar/dristi/web/models/EvidenceSearchCriteria.java
+++ b/backend/evidence/src/main/java/org/pucar/dristi/web/models/EvidenceSearchCriteria.java
@@ -41,7 +41,7 @@ public class EvidenceSearchCriteria {
     private Boolean fuzzySearch = true;
     private List<String> workflowStatus = new ArrayList<>();
     private String evidenceNumber;
-    private boolean isActive = true;
+    private Boolean isActive = true;
 
     @JsonIgnore
     private String userUuid;
@@ -157,7 +157,11 @@ public class EvidenceSearchCriteria {
         return fuzzySearch;
     }
 
-    public boolean getIsActive() {
+    public Boolean getIsActive() {
+        if(isActive == null) {
+            isActive = true;
+        }
+
         return isActive;
     }
 }


### PR DESCRIPTION
## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of the “Active” status in evidence search to better support optional filtering and null-safe defaults. Default behavior remains to show active items; explicitly setting the filter still narrows results accordingly. No changes required to existing workflows, with more predictable behavior when the Active filter is omitted. No other user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->