### PR TITLE
delete deposition drafts - 4462

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCaseV2.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCaseV2.js
@@ -4046,6 +4046,7 @@ const AdmittedCaseV2 = () => {
             setShowWitnessModal(false);
             setEditWitnessDepositionArtifact(null);
             refetchHearing();
+            refetchCaseData();
             onTabChange(0, {}, "Documents");
           }}
           onSubmit={(action) => {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/ConfirmDepositionDeleteModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/ConfirmDepositionDeleteModal.js
@@ -2,7 +2,7 @@ import React from "react";
 import Modal from "@egovernments/digit-ui-module-dristi/src/components/Modal";
 import { CloseSvg } from "@egovernments/digit-ui-react-components";
 
-function ConfirmDepositionDeleteModal({ t, selectedWitness, allParties, onCancel, onSubmit }) {
+function ConfirmDepositionDeleteModal({ t, selectedWitness, selectedTab, allParties, onCancel, onSubmit }) {
   const CloseBtn = (props) => {
     return (
       <div onClick={props?.onClick} style={{ height: "100%", display: "flex", alignItems: "center", paddingRight: "20px", cursor: "pointer" }}>
@@ -14,7 +14,7 @@ function ConfirmDepositionDeleteModal({ t, selectedWitness, allParties, onCancel
     return <h1 className="heading-m">{props.label}</h1>;
   };
 
-  const sourceName = allParties?.find((p) => p?.uuid === selectedWitness?.value || p?.uniqueId === selectedWitness?.value)?.sourceName;
+  const witnessName = selectedTab?.sourceName;
 
   return (
     <React.Fragment>
@@ -29,7 +29,7 @@ function ConfirmDepositionDeleteModal({ t, selectedWitness, allParties, onCancel
       >
         <div style={{ padding: "30px 0" }}>
           <span>{t("ARE_YOU_SURE_YOU_WANT_TO_DELETE_DEPOSITION")}</span>
-          <span>{sourceName}</span>
+          <span>{witnessName}</span>
           <span>{t("PLEASE_CONFIRM_DELETE_DEPOSITION")}</span>
         </div>
       </Modal>

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/WitnessDepositionReviewModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/WitnessDepositionReviewModal.js
@@ -39,6 +39,7 @@ const WitnessDepositionReviewModal = ({
 }) => {
   const tenantId = Digit.ULBService.getCurrentTenantId();
   const DocViewerWrapper = window?.Digit?.ComponentRegistryService?.getComponent("DocViewerWrapper");
+
   const [showErrorToast, setShowErrorToast] = useState(null);
 
   const { data: { file: witnessDepositionPreviewPdf, fileName: witnessDepositionPreviewFilename } = {}, isFetching: isLoading } = useQuery({
@@ -132,6 +133,8 @@ const WitnessDepositionReviewModal = ({
             .then(() => {
               setShowsignatureModal(true);
               setShowWitnessDepositionReview(false);
+              localStorage.removeItem("artifactNumber");
+              localStorage.removeItem("showPdfPreview");
             })
             .catch((e) => {
               setShowErrorToast({ label: t("INTERNAL_ERROR_OCCURRED"), error: true });

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/WitnessDrawerV2.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/WitnessDrawerV2.js
@@ -81,11 +81,11 @@ const WitnessDrawerV2 = ({
   const [showErrorToast, setShowErrorToast] = useState(null);
   const userInfo = Digit?.UserService?.getUser?.()?.info;
   const urlParams = new URLSearchParams(window.location.search);
-  const [showWitnessDepositionReview, setShowWitnessDepositionReview] = useState(false);
+  const [showWitnessDepositionReview, setShowWitnessDepositionReview] = useState(localStorage.getItem("showPdfPreview") || false);
   const [witnessDepositionFileStoreId, setWitnessDepositionFileStoreId] = useState("");
   const [showSignatureModal, setShowsignatureModal] = useState(false);
   const [showConfirmWitnessModal, setShowConfirmWitnessModal] = useState(false);
-  const [currentArtifactNumber, setCurrentArtifactNumber] = useState(artifactNumber || null);
+  const [currentArtifactNumber, setCurrentArtifactNumber] = useState(artifactNumber || localStorage.getItem("artifactNumber") || null);
   const [witnessDepositionUploadLoader, setWitnessDepositionUploadLoader] = useState(false);
   const [showWitnessDepositionESign, setShowWitnessDepositionESign] = useState(false);
   const { downloadPdf } = useDownloadCasePdf();
@@ -104,15 +104,6 @@ const WitnessDrawerV2 = ({
   const closeToast = () => {
     setShowErrorToast(null);
   };
-
-  // Sync currentArtifactNumber with artifactNumber prop
-  useEffect(() => {
-    if (localStorage.getItem("artifactNumber")) {
-      setCurrentArtifactNumber(localStorage.getItem("artifactNumber"));
-      setShowWitnessDepositionReview(true);
-      localStorage.removeItem("artifactNumber");
-    }
-  }, []);
 
   useEffect(() => {
     if (showErrorToast) {
@@ -285,7 +276,7 @@ const WitnessDrawerV2 = ({
     Boolean(caseDetails?.filingNumber && caseDetails?.courtId)
   );
 
-  const evidenceList = useMemo(() => evidenceData?.artifacts?.filter((artifact) => artifact?.status === "DRAFT_IN_PROGRESS"), [evidenceData]);
+  const evidenceList = useMemo(() => evidenceData?.artifacts?.filter((artifact) => artifact?.status === "DRAFT_IN_PROGRESS") || [], [evidenceData]);
   const { data: filingTypeData, isLoading: isFilingTypeLoading } = Digit.Hooks.dristi.useGetStatuteSection("common-masters", [
     { name: "FilingType" },
   ]);
@@ -459,7 +450,7 @@ const WitnessDrawerV2 = ({
 
   // Create a new draft
   const createNewDraft = useCallback(
-    async (evidenceList = []) => {
+    async (evidenceList = [], isEvidenceRefetch = false) => {
       try {
         const newTab = {
           artifactNumber: null, // Will be set after saving
@@ -478,8 +469,11 @@ const WitnessDrawerV2 = ({
         const updatedTabs = [...evidenceList, newTab];
         setActiveTabs(updatedTabs);
         setActiveTabIndex(updatedTabs.length - 1);
+        setCurrentArtifactNumber(null);
+        setSelectedWitness({});
+        setSelectedWitnessType({});
         setWitnessDepositionText(""); // Clear the text area for new draft
-
+        isEvidenceRefetch && evidenceRefetch();
         // No need to call API yet - we'll create the evidence when user saves the draft
       } catch (error) {
         console.error("Error creating draft:", error);
@@ -499,17 +493,21 @@ const WitnessDrawerV2 = ({
   }, [caseDetails, hearingData, allParties, activeTabs.length]);
 
   useEffect(() => {
-    createNewDraft([]);
+    if (!(currentArtifactNumber || localStorage.getItem("artifactNumber"))) {
+      createNewDraft([]);
+    }
   }, []);
 
   // Process evidence list when data is loaded
   useEffect(() => {
-    if (!isEvidenceLoading && evidenceList?.length > 0) {
+    if (!isEvidenceLoading) {
       const evidenceWithUnsaved = [...evidenceList];
-      if (currentArtifactNumber) {
-        const artifact = evidenceWithUnsaved?.find((tab) => tab?.artifactNumber === currentArtifactNumber);
+      const artifactNumber = localStorage.getItem("artifactNumber");
+      const artifactNum = currentArtifactNumber || artifactNumber;
+      if (artifactNum) {
+        const artifact = evidenceWithUnsaved?.find((tab) => tab?.artifactNumber === artifactNum);
         if (artifact) {
-          const activeindex = evidenceWithUnsaved?.findIndex((tab) => tab?.artifactNumber === currentArtifactNumber);
+          const activeindex = evidenceWithUnsaved?.findIndex((tab) => tab?.artifactNumber === artifactNum);
           const selectedUUID = artifact?.sourceID;
           const matchingWitness = options.find((opt) => opt?.value === selectedUUID);
           setActiveTabs(evidenceWithUnsaved); // basically we show only that particular tab when editing an evidence(it will have corresponding artifact number)
@@ -598,12 +596,22 @@ const WitnessDrawerV2 = ({
 
   // Handle tab change
   const handleTabChange = async (tab) => {
-    const currentArtifact = activeTabs?.find((t) => t?.artifactNumber === tab?.artifactNumber);
-    if (activeTabs?.find((tab) => tab?.isNew && selectedWitness?.value)) {
-      handleSaveDraft(false, currentArtifact?.artifactNumber);
-    } else {
-      setCurrentArtifactNumber(currentArtifact?.artifactNumber);
+    const currentArtifact = activeTabs?.find((t) => t?.artifactNumber === currentArtifactNumber);
+    const newArtifact = activeTabs?.find((t) => t?.artifactNumber === tab?.artifactNumber);
+
+    if (currentArtifact?.artifactNumber) {
+      if (
+        !isEqual(selectedWitness?.value, currentArtifact?.sourceID) ||
+        !isEqual(selectedWitnessType?.value, currentArtifact?.tag) ||
+        !isEqual(witnessDepositionText, currentArtifact?.description)
+      ) {
+        handleSaveDraft(false, tab?.artifactNumber);
+      }
+      setCurrentArtifactNumber(tab?.artifactNumber);
+    } else if (activeTabs?.find((tab) => tab?.isNew && selectedWitness?.value)) {
+      handleSaveDraft(false, currentArtifactNumber);
     }
+    setCurrentArtifactNumber(tab?.artifactNumber);
   };
 
   const handleDropdownChange = (selectedPartyOption) => {
@@ -656,45 +664,54 @@ const WitnessDrawerV2 = ({
       const artifactNum = artifactNumber || currentArtifactNumber;
       if (artifactNum) {
         const evidence = activeTabs?.find((tab) => tab?.artifactNumber === artifactNum);
-        // Update existing evidence
-        const updateEvidenceReqBody = {
-          artifact: {
-            ...evidence,
-            sourceType: selectedWitnessType.value === "PW" ? "COMPLAINANT" : selectedWitnessType.value === "DW" ? "ACCUSED" : "COURT",
-            tag: selectedWitnessType?.value,
-            sourceID: selectedWitness.value,
-            sourceName: party?.sourceName,
-            description: witnessDepositionText,
-            additionalDetails: {
-              witnessDetails: {
-                address: party?.address || "",
-                designation: party?.designation || "",
-                age: party?.age || "",
-                ownerType: party?.ownerType || "",
+
+        if (
+          !backAction ||
+          (backAction &&
+            (!isEqual(selectedWitness?.value, evidence?.sourceID) ||
+              !isEqual(selectedWitnessType?.value, evidence?.tag) ||
+              !isEqual(witnessDepositionText, evidence?.description)))
+        ) {
+          // Update existing evidence
+          const updateEvidenceReqBody = {
+            artifact: {
+              ...evidence,
+              sourceType: selectedWitnessType.value === "PW" ? "COMPLAINANT" : selectedWitnessType.value === "DW" ? "ACCUSED" : "COURT",
+              tag: selectedWitnessType?.value,
+              sourceID: selectedWitness.value,
+              sourceName: party?.sourceName,
+              description: witnessDepositionText,
+              additionalDetails: {
+                witnessDetails: {
+                  address: party?.address || "",
+                  designation: party?.designation || "",
+                  age: party?.age || "",
+                  ownerType: party?.ownerType || "",
+                },
+              },
+              isEvidenceMarkedFlow: false,
+              workflow: {
+                action: "SAVE_DRAFT",
               },
             },
-            isEvidenceMarkedFlow: false,
-            workflow: {
-              action: "SAVE_DRAFT",
-            },
-          },
-        };
+          };
 
-        const updatedEvidence = await DRISTIService.updateEvidence(updateEvidenceReqBody);
+          const updatedEvidence = await DRISTIService.updateEvidence(updateEvidenceReqBody);
 
-        // Update the tab in activeTabs directly
-        if (updatedEvidence?.artifact) {
-          const updatedTabs = [...activeTabs];
-          if (newCurrentArtifactNumber) {
-            setCurrentArtifactNumber(newCurrentArtifactNumber);
-          } else {
-            setCurrentArtifactNumber(updatedEvidence?.artifact?.artifactNumber);
+          // Update the tab in activeTabs directly
+          if (updatedEvidence?.artifact) {
+            const updatedTabs = [...activeTabs];
+            if (newCurrentArtifactNumber) {
+              setCurrentArtifactNumber(newCurrentArtifactNumber);
+            } else {
+              setCurrentArtifactNumber(updatedEvidence?.artifact?.artifactNumber);
+            }
+            setActiveTabs(updatedTabs);
+            setObtainedTag(updatedEvidence?.artifact?.tag);
           }
-          setActiveTabs(updatedTabs);
-          setObtainedTag(updatedEvidence?.artifact?.tag);
-        }
 
-        setShowErrorToast({ label: "WITNESS_DEPOSITION_UPDATED_SUCCESSFULLY", error: false });
+          setShowErrorToast({ label: t("WITNESS_DEPOSITION_UPDATED_SUCCESSFULLY"), error: false });
+        }
       } else {
         // Create new evidence
         const createEvidenceReqBody = {
@@ -807,6 +824,7 @@ const WitnessDrawerV2 = ({
 
         setShowErrorToast({ label: t("WITNESS_MARKED_SUCCESSFULLY"), error: false });
         localStorage.setItem("artifactNumber", updatedEvidence?.artifact?.artifactNumber);
+        localStorage.setItem("showPdfPreview", true);
         setCurrentEvidence(updatedEvidence?.artifact);
         setCurrentArtifactNumber(updatedEvidence?.artifact?.artifactNumber);
 
@@ -948,10 +966,8 @@ const WitnessDrawerV2 = ({
   const handleConfirmDeleteDeposition = async (selectedTab) => {
     try {
       if (!selectedTab?.artifactNumber) {
-        const updatedActiveTabs = activeTabs?.filter((tab) => !activeTabs?.artifactNumber);
-        setActiveTabs(updatedActiveTabs);
-        setShowErrorToast({ label: t(" WITNESS_DEPOSITION_DELETED_SUCCESSFULLY"), error: false });
-        const deletedEvidenceIndex = activeTabs?.findIndex((tab) => tab?.artifactNumber === selectedTab?.artifactNumber);
+        const deletedEvidenceIndex = activeTabs?.length - 1;
+        const updatedActiveTabs = activeTabs?.filter((tab) => tab?.artifactNumber);
         setActiveTabs(updatedActiveTabs);
         const newCurrentEvidence = updatedActiveTabs?.[deletedEvidenceIndex - 1];
         if (newCurrentEvidence?.artifactNumber) {
@@ -960,22 +976,24 @@ const WitnessDrawerV2 = ({
         } else {
           setCurrentArtifactNumber(null);
         }
-        setShowConfirmDeleteDepositionModal({ show: false, tab: {} });
-        evidenceRefetch();
+        // evidenceRefetch();
         return;
       }
 
       // If the witness deposition has artifact number.
       const evidence = activeTabs?.find((tab) => tab?.artifactNumber === selectedTab?.artifactNumber);
       const party = allParties?.find((p) => p?.uuid === selectedWitness?.value || p?.uniqueId === selectedWitness?.value);
+      const deletedEvidenceIndex = activeTabs?.findIndex((tab) => tab?.artifactNumber === selectedTab?.artifactNumber);
+
       if (evidence?.artifactNumber) {
         // Update existing evidence
+        setLoader(true);
         const updateEvidenceReqBody = {
           artifact: {
             ...evidence,
-            tag: selectedWitnessType?.value,
-            sourceID: selectedWitness?.value,
-            sourceName: party?.sourceName,
+            tag: evidence?.tag,
+            sourceID: evidence?.sourceID,
+            sourceName: evidence?.sourceName,
             isActive: false,
             workflow: {
               action: "DELETE_DRAFT",
@@ -985,7 +1003,6 @@ const WitnessDrawerV2 = ({
 
         const updatedEvidence = await DRISTIService.updateEvidence(updateEvidenceReqBody);
         setShowErrorToast({ label: t(" WITNESS_DEPOSITION_DELETED_SUCCESSFULLY"), error: false });
-        const deletedEvidenceIndex = activeTabs?.findIndex((tab) => tab?.artifactNumber === selectedTab?.artifactNumber);
         const updatedActiveTabs = activeTabs?.filter((tab) => tab?.artifactNumber !== selectedTab?.artifactNumber);
         setActiveTabs(updatedActiveTabs);
         if (deletedEvidenceIndex === activeTabs?.length - 1) {
@@ -1003,6 +1020,7 @@ const WitnessDrawerV2 = ({
             setCurrentArtifactNumber(newCurrentEvidence?.artifactNumber);
           } else {
             setCurrentArtifactNumber(null);
+            setActiveTabs(updatedActiveTabs);
           }
         }
         setShowConfirmDeleteDepositionModal({ show: false, tab: {} });
@@ -1011,6 +1029,133 @@ const WitnessDrawerV2 = ({
     } catch (error) {
       console.error("Error while deleting witness deposition bond:", error);
       setShowErrorToast({ label: t("SOMETHING_WENT_WRONG"), error: true });
+    } finally {
+      setLoader(false);
+    }
+  };
+
+  const handleAddNewDepositionDraft = async () => {
+    if (!selectedWitness?.value) {
+      setShowErrorToast({ label: t("PLEASE_SELECT_WITNESS_FIRST"), error: true });
+
+      return;
+    }
+
+    if (!selectedWitnessType?.value) {
+      setShowErrorToast({ label: t("PLEASE_MARK_WITNESS"), error: true });
+      return;
+    }
+
+    try {
+      setLoader(true);
+
+      const party = allParties?.find((p) => p?.uuid === selectedWitness?.value || p?.uniqueId === selectedWitness?.value);
+      // Check if we need to create or update evidence
+      const artifactNum = artifactNumber || currentArtifactNumber;
+      if (artifactNum) {
+        const currentActiveIndex = activeTabs?.findIndex((tab) => tab?.artifactNumber === artifactNum);
+        const evidence = activeTabs?.find((tab) => tab?.artifactNumber === artifactNum);
+
+        if (
+          !isEqual(selectedWitness?.value, evidence?.sourceID) ||
+          !isEqual(selectedWitnessType?.value, evidence?.tag) ||
+          !isEqual(witnessDepositionText, evidence?.description)
+        ) {
+          // Update existing evidence
+          const updateEvidenceReqBody = {
+            artifact: {
+              ...evidence,
+              sourceType: selectedWitnessType.value === "PW" ? "COMPLAINANT" : selectedWitnessType.value === "DW" ? "ACCUSED" : "COURT",
+              tag: selectedWitnessType?.value,
+              sourceID: selectedWitness.value,
+              sourceName: party?.sourceName,
+              description: witnessDepositionText,
+              additionalDetails: {
+                witnessDetails: {
+                  address: party?.address || "",
+                  designation: party?.designation || "",
+                  age: party?.age || "",
+                  ownerType: party?.ownerType || "",
+                },
+              },
+              isEvidenceMarkedFlow: false,
+              workflow: {
+                action: "SAVE_DRAFT",
+              },
+            },
+          };
+
+          const updatedEvidence = await DRISTIService.updateEvidence(updateEvidenceReqBody);
+
+          if (updatedEvidence?.artifact) {
+            // Update the activeTabs array by replacing the updated evidence object
+            const updatedTabs = [...activeTabs];
+            if (currentActiveIndex !== -1) {
+              updatedTabs[currentActiveIndex] = updatedEvidence.artifact;
+              setActiveTabs(updatedTabs);
+              setCurrentEvidence(updatedEvidence.artifact);
+              setShowErrorToast({ label: t("WITNESS_DEPOSITION_UPDATED_SUCCESSFULLY"), error: false });
+              setCurrentArtifactNumber(null);
+              createNewDraft(updatedTabs, true);
+            }
+          }
+        } else {
+          setCurrentArtifactNumber(null);
+          createNewDraft(activeTabs, true);
+        }
+      } else {
+        // Create new evidence
+        const currentActiveIndex = activeTabs?.findIndex((tab) => !tab?.artifactNumber);
+
+        const createEvidenceReqBody = {
+          artifact: {
+            artifactType: "WITNESS_DEPOSITION",
+            caseId: caseDetails?.id,
+            filingNumber: caseDetails?.filingNumber,
+            tenantId,
+            sourceType: selectedWitnessType?.value === "PW" ? "COMPLAINANT" : selectedWitnessType?.value === "DW" ? "ACCUSED" : "COURT",
+            tag: selectedWitnessType?.value,
+            sourceID: selectedWitness?.value,
+            sourceName: party?.sourceName, // confirm?
+            filingType: filingType,
+            description: witnessDepositionText,
+            additionalDetails: {
+              witnessDetails: {
+                address: party?.address || "",
+                designation: party?.designation || "",
+                age: party?.age || "",
+                ownerType: party?.ownerType || "",
+              },
+            },
+            comments: [],
+            workflow: {
+              action: "SAVE_DRAFT",
+            },
+          },
+        };
+
+        const updatedEvidence = await submissionService.createEvidence(createEvidenceReqBody);
+
+        if (updatedEvidence?.artifact) {
+          // Update the activeTabs array by replacing the updated evidence object
+          const updatedTabs = [...activeTabs];
+          if (currentActiveIndex !== -1) {
+            updatedTabs[currentActiveIndex] = updatedEvidence.artifact;
+            setActiveTabs(updatedTabs);
+            setCurrentEvidence(updatedEvidence.artifact);
+            setShowErrorToast({ label: t("WITNESS_DEPOSITION_UPDATED_SUCCESSFULLY"), error: false });
+            setCurrentArtifactNumber(null);
+            createNewDraft(updatedTabs, true);
+          }
+        }
+      }
+
+      // Also refresh evidence list to ensure server and client are in sync
+    } catch (error) {
+      console.error("Error saving draft:", error);
+      setShowErrorToast({ label: t("SOMETHING_WENT_WRONG"), error: true });
+    } finally {
+      setLoader(false);
     }
   };
 
@@ -1075,7 +1220,7 @@ const WitnessDrawerV2 = ({
                     gap: "8px",
                   }}
                 >
-                  <span>{tab?.isNew ? `${t("CS_DEPOSITION")} (${t("UNSAVED_DRAFT")})` : `${t("CS_DEPOSITION")} (${tab?.sourceName})`}</span>
+                  <span>{tab?.isNew ? `${t("CS_DEPOSITION")} (${t("UNSAVED")})` : `${t("CS_DEPOSITION")} (${tab?.sourceName})`}</span>
                   <span
                     style={{
                       cursor: "pointer",
@@ -1085,8 +1230,11 @@ const WitnessDrawerV2 = ({
                     }}
                     onClick={(e) => {
                       e.stopPropagation(); // Prevent tab change when clicking delete
-                      // Add delete functionality here
-                      setShowConfirmDeleteDepositionModal({ show: true, tab: tab });
+                      if (tab?.artifactNumber) {
+                        setShowConfirmDeleteDepositionModal({ show: true, tab: tab });
+                      } else {
+                        handleConfirmDeleteDeposition(tab);
+                      }
                     }}
                   >
                     <CustomDeleteIcon />
@@ -1097,7 +1245,7 @@ const WitnessDrawerV2 = ({
               {
                 <div
                   className="witness-tab add-tab"
-                  onClick={() => handleAddNewDraft()}
+                  onClick={() => handleAddNewDepositionDraft()}
                   style={{
                     padding: "8px 18px",
                     cursor: "pointer",
@@ -1231,6 +1379,8 @@ const WitnessDrawerV2 = ({
           t={t}
           handleBack={() => {
             setShowWitnessDepositionReview(false);
+            localStorage.removeItem("artifactNumber");
+            localStorage.removeItem("showPdfPreview");
           }}
           setShowWitnessDepositionReview={setShowWitnessDepositionReview}
           setShowsignatureModal={setShowsignatureModal}
@@ -1299,6 +1449,7 @@ const WitnessDrawerV2 = ({
         <ConfirmDepositionDeleteModal
           t={t}
           selectedWitness={selectedWitness}
+          selectedTab={showConfirmDeleteDepositionModal?.tab}
           allParties={allParties}
           onCancel={() => setShowConfirmDeleteDepositionModal({ show: false, tab: {} })}
           onSubmit={() => handleConfirmDeleteDeposition(showConfirmDeleteDepositionModal?.tab)}


### PR DESCRIPTION
#4462
## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Persist witness deposition review state across sessions, including PDF preview readiness.
  - Enhanced tab management: create/update drafts seamlessly, plus-tab adds new draft, and unsaved tabs display as “UNSAVED.”
  - Additional data refresh when closing the witness deposition modal for up-to-date case and hearing info.

- Bug Fixes
  - Prevented errors when evidence lists are absent.
  - More reliable deletion flow for both saved and unsaved drafts.
  - Improved error feedback with toasts during review/sign workflows.
  - Cleans up preview state after closing review to avoid stale UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->