### PR TITLE
updated evidence number format

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/Utils/index.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/Utils/index.js
@@ -112,10 +112,16 @@ export const removeInvalidNameParts = (name) => {
     .join(" ");
 };
 
-export const modifiedEvidenceNumber = (value) => {
-  return value && typeof value === "string" ? value.split("-").pop() : value;
+export const modifiedEvidenceNumber = (value, filingNumber = null) => {
+  if (value && typeof value === "string") {
+    if (filingNumber && typeof filingNumber === "string" && value.startsWith(filingNumber)) {
+      return value.slice(filingNumber.length + 1).trim();
+    } else {
+      return value.split("-").pop();
+    }
+  }
+  return value;
 };
-
 export const getFilteredPaymentData = (paymentType, paymentData, bill) => {
   const processedPaymentType = paymentType?.toLowerCase()?.includes("application");
   return processedPaymentType ? [{ key: "Total Amount", value: bill?.totalAmount }] : paymentData;

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/configs/UICustomizations.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/configs/UICustomizations.js
@@ -1222,7 +1222,7 @@ export const UICustomizations = {
         case "CS_ACTIONS":
           return <OverlayDropdown style={{ position: "relative" }} column={column} row={row} master="commonUiConfig" module="FilingsConfig" />;
         case "EVIDENCE_NUMBER":
-          return (row?.isEvidence || isEmployee) && modifiedEvidenceNumber(value);
+          return (row?.isEvidence || isEmployee) && modifiedEvidenceNumber(value, row?.filingNumber);
         case "EVIDENCE_STATUS":
           return row?.evidenceMarkedStatus && (row?.evidenceMarkedStatus === "COMPLETED" || isEmployee) ? (
             <CustomChip

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/MarkAsEvidence.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/MarkAsEvidence.js
@@ -33,7 +33,8 @@ const getButtonLabels = (isJudge, evidenceDetails, currentDiaryEntry = false, t)
 
     // Cancel/back button label
     cancelLabel:
-      evidenceDetails?.evidenceMarkedStatus === "DRAFT_IN_PROGRESS" || evidenceDetails?.evidenceMarkedStatus === null
+      evidenceDetails?.evidenceMarkedStatus === "DRAFT_IN_PROGRESS" ||
+      (evidenceDetails?.evidenceMarkedStatus === null && !evidenceDetails?.isEvidence)
         ? t("CS_BULK_BACK")
         : evidenceDetails?.isEvidence || evidenceDetails?.evidenceMarkedStatus === "COMPLETED"
         ? currentDiaryEntry && t("CS_BULK_CANCEL")
@@ -199,7 +200,7 @@ const MarkAsEvidence = ({
 
   const memoEvidenceValues = useMemo(() => {
     return {
-      title: evidenceDetails?.artifactType,
+      title: evidenceDetails?.additionalDetails?.formdata?.documentTitle || evidenceDetails?.artifactType,
       artifactNumber: evidenceDetails?.artifactNumber,
       sourceType: evidenceDetails?.sourceType,
       owner: evidenceDetails?.owner,
@@ -302,6 +303,27 @@ const MarkAsEvidence = ({
     };
   }, [name]);
 
+  const getCustomEvidenceNumber = (evidenceNumber, filingNumber) => {
+    try {
+      if (typeof evidenceNumber !== "string" || typeof filingNumber !== "string") {
+        throw new Error("Both evidenceNumber and filingNumber must be strings");
+      }
+
+      if (evidenceNumber.length > 1) {
+        if (filingNumber && evidenceNumber.startsWith(filingNumber) && evidenceNumber.length > filingNumber.length + 2) {
+          return evidenceNumber.slice(filingNumber.length + 2).trim();
+        } else {
+          return evidenceNumber.slice(1);
+        }
+      }
+
+      return evidenceNumber;
+    } catch (error) {
+      console.error("Error getting custom evidence number:", error);
+      return null;
+    }
+  };
+
   const getEvidenceDetails = async () => {
     try {
       setLoader(true);
@@ -318,10 +340,11 @@ const MarkAsEvidence = ({
         },
         {}
       );
-      const customEvidenceNumber =
-        response?.artifacts?.[0]?.evidenceNumber?.length > 1
-          ? response?.artifacts?.[0]?.evidenceNumber?.slice(1)
-          : response?.artifacts?.[0]?.evidenceNumber;
+      // const customEvidenceNumber =
+      //   response?.artifacts?.[0]?.evidenceNumber?.length > 1
+      //     ? response?.artifacts?.[0]?.evidenceNumber?.slice(1)
+      //     : response?.artifacts?.[0]?.evidenceNumber;
+      const customEvidenceNumber = getCustomEvidenceNumber(response?.artifacts?.[0]?.evidenceNumber, response?.artifacts?.[0]?.filingNumber);
       setStepper(response?.artifacts?.[0]?.evidenceMarkedStatus === null ? 0 : 1);
       setEvidenceNumber(customEvidenceNumber);
       setEvidenceDetails(response?.artifacts?.[0]);
@@ -416,6 +439,9 @@ const MarkAsEvidence = ({
       if (evidenceTag) {
         setWitnessTag(combined?.find((user) => user?.code === evidenceTag));
       }
+      if (evidenceDetails?.isEvidence && !evidenceDetails?.additionalDetails?.botd) {
+        getAdiaryEntries(response?.criteria[0]?.responseList[0]?.cmpNumber || filingNumber);
+      }
       setWitnessTagValues(combined?.filter(Boolean));
       setCaseDetails(response?.criteria[0]?.responseList[0]);
     } catch (error) {
@@ -459,7 +485,33 @@ const MarkAsEvidence = ({
       setLoader(false);
     }
   };
-
+  const getAdiaryEntries = async (caseNumber) => {
+    try {
+      setLoader(true);
+      const adiaryResponse = await DRISTIService.aDiaryEntrySearch(
+        {
+          criteria: {
+            tenantId: tenantId,
+            courtId: courtId,
+            caseId: caseNumber || caseDetails?.cmpNumber || filingNumber,
+            referenceId: artifactNumber,
+          },
+          pagination: {
+            limit: 10,
+            offSet: 0,
+          },
+        },
+        { tenantId }
+      );
+      if (!businessOfDay || businessOfDay === "" || businessOfDay === null) {
+        setBusinessOfDay(adiaryResponse?.entries?.[0]?.businessOfDay);
+      }
+    } catch (error) {
+      console.error("Error fetching adiary entries:", error);
+    } finally {
+      setLoader(false);
+    }
+  };
   useEffect(() => {
     if (!evidenceDetailsObj && !sessionStorage.getItem("markAsEvidenceSelectedItem")) {
       getEvidenceDetails();
@@ -469,7 +521,9 @@ const MarkAsEvidence = ({
 
       // Set evidence details from session storage
       if (sessionData?.evidenceNumber) {
-        const customEvidenceNumber = sessionData.evidenceNumber.length > 1 ? sessionData.evidenceNumber.slice(1) : sessionData.evidenceNumber;
+        // const customEvidenceNumber = sessionData.evidenceNumber.length > 1 ? sessionData.evidenceNumber.slice(1) : sessionData.evidenceNumber;
+        const customEvidenceNumber = getCustomEvidenceNumber(sessionData.evidenceNumber, sessionData?.filingNumber);
+
         setEvidenceNumber(customEvidenceNumber);
       }
 
@@ -507,8 +561,10 @@ const MarkAsEvidence = ({
         setStepper(evidenceDetailsObj?.evidenceNumber === null ? 0 : 1);
 
         // Set evidence number
-        const customEvidenceNumber =
-          evidenceDetailsObj?.evidenceNumber?.length > 1 ? evidenceDetailsObj.evidenceNumber.slice(1) : evidenceDetailsObj.evidenceNumber;
+        // const customEvidenceNumber =
+        //   evidenceDetailsObj?.evidenceNumber?.length > 1 ? evidenceDetailsObj.evidenceNumber.slice(1) : evidenceDetailsObj.evidenceNumber;
+        const customEvidenceNumber = getCustomEvidenceNumber(evidenceDetailsObj?.evidenceNumber, evidenceDetailsObj?.filingNumber);
+
         setEvidenceNumber(customEvidenceNumber);
 
         // Set business of day from props
@@ -528,13 +584,13 @@ const MarkAsEvidence = ({
     try {
       const payload = {
         ...evidenceDetails,
-        evidenceNumber: `${evidenceTag}${evidenceNumber}`,
+        evidenceNumber: `${filingNumber}-${evidenceTag}${evidenceNumber}`,
         isEvidenceMarkedFlow: action ? true : false,
         tag: witnessTag?.code,
         isEvidence: isEvidence,
         additionalDetails: {
           ...evidenceDetails?.additionalDetails,
-          botd: businessOfDay,
+          botd: businessOfDay || `Document marked as evidence exhibit number ${evidenceTag}${evidenceNumber}`,
           ownerName: ownerName,
         },
         ...(seal !== null && { seal }),
@@ -561,7 +617,7 @@ const MarkAsEvidence = ({
       setLoader(true);
       if (stepper === 0) {
         clearEvidenceSessionData();
-        if (businessOfDay === null || businessOfDay === "") {
+        if (businessOfDay === null || businessOfDay === "" || !businessOfDay) {
           setBusinessOfDay(`Document marked as evidence exhibit number ${evidenceTag}${evidenceNumber}`);
         }
         await handleMarkEvidence(


### PR DESCRIPTION
## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Evidence numbers auto-prefix with the filing number and display without duplicate prefixes.
  - Automatically fetches diary entries to populate Business of the Day when missing, with a sensible fallback message.

- Bug Fixes
  - Back button now appears only during draft/in-progress states as intended.
  - Document titles in the Evidence view prefer the entered document title when available.
  - Consistent evidence number formatting across views and session restores, including list customizations that respect the filing number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->