### PR TITLE
Spell correction in Proclamation doc sub type

### DIFF
--- a/backend/icops_integration-kerala/src/main/java/com/egov/icops_integrationkerala/enrichment/IcopsEnrichment.java
+++ b/backend/icops_integration-kerala/src/main/java/com/egov/icops_integrationkerala/enrichment/IcopsEnrichment.java
@@ -78,7 +78,7 @@ public class IcopsEnrichment {
                     break;
                 case "PROCLAMATION":
                     docSubType = Optional.ofNullable(taskDetails.getProclamationDetails().getDocSubType())
-                            .orElse("Proclamation requiring the apperance of a person accused");
+                            .orElse("Proclamation requiring the appearance of a person accused");
                     issueDate = taskDetails.getProclamationDetails().getIssueDate();
                     break;
                 case "ATTACHMENT":

--- a/backend/summons-svc/src/main/java/digit/config/ServiceConstants.java
+++ b/backend/summons-svc/src/main/java/digit/config/ServiceConstants.java
@@ -84,7 +84,7 @@ public class ServiceConstants {
     public static final String SUMMON_TO_ACCUSED="Summons to an accused 138";
     public static final String SUMMON_TO_WITNESS="Summons to witness";
     public static final String WARRANT_TO_ACCUSED="Warrant of arrest of accused 138";
-    public static final String PROCLAMATION_DOC_SUB_TYPE="Proclamation requiring the apperance of a person accused";
+    public static final String PROCLAMATION_DOC_SUB_TYPE="Proclamation requiring the appearance of a person accused";
     public static final String ATTACHMENT_DOC_SUB_TYPE="Order authorising an attachment by the district magistrate or collector";
     public static final String POLICE_REPORT = "POLICE_REPORT";
     public static final String DIRECT = "DIRECT";

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrders.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrders.js
@@ -3132,7 +3132,7 @@ const GenerateOrders = () => {
           proclamationDetails: {
             issueDate: orderData?.auditDetails?.lastModifiedTime,
             caseFilingDate: caseDetails?.filingDate,
-            docSubType: "Proclamation requiring the apperance of a person accused",
+            docSubType: "Proclamation requiring the appearance of a person accused",
             templateType: "GENERIC",
             proclamationText: orderFormValue?.proclamationText?.proclamationText || "",
             partyType: respondentNameData?.partyType?.toLowerCase() || "accused",


### PR DESCRIPTION
## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a spelling error in the document subtype label: “Proclamation requiring the appearance of a person accused” now displays correctly (previously “apperance”).
  * Updated default label used when the subtype is unspecified to match the corrected wording.
  * Ensures consistent wording across UI screens, forms, and generated documents with no functional changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->