### PR TITLE
updated view in bulk mark as evidence

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/EvidenceModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/EvidenceModal.js
@@ -127,6 +127,17 @@ const EvidenceModal = ({
   const showSubmit = useMemo(() => {
     if (userType === "employee") {
       if (!isJudge) {
+        if (
+          modalType === "Documents" &&
+          !(
+            documentSubmission?.[0]?.artifactList?.isEvidence ||
+            documentSubmission?.[0]?.artifactList?.isVoid ||
+            documentSubmission?.[0]?.artifactList?.evidenceMarkedStatus !== null
+          )
+        ) {
+          return true;
+        }
+
         return false;
       }
       if (modalType === "Documents") {
@@ -156,7 +167,7 @@ const EvidenceModal = ({
       }
       return false;
     }
-  }, [userType, modalType, userRoles, applicationStatus, userInfo?.uuid, createdBy, isLitigent, allAdvocates]);
+  }, [userType, isJudge, modalType, userRoles, applicationStatus, isBail, documentSubmission, userInfo?.uuid, createdBy, isLitigent, allAdvocates]);
 
   const actionSaveLabel = useMemo(() => {
     let label = "";
@@ -1381,36 +1392,41 @@ const EvidenceModal = ({
           //     : {}
           // }
         >
-          {documentSubmission?.[0]?.artifactList?.evidenceMarkedStatus && userType === "employee" && (
-            <div style={{ margin: "16px 24px" }}>
-              <div className="custom-note-main-div" style={{ padding: "8px 16px", flexDirection: "row", justifyContent: "space-between" }}>
-                <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-                  <CustomErrorTooltip message={t("CS_EVIDENCE_MARKED_INFO_TEXT")} showTooltip={true} />
-                  <div className="custom-note-heading-div">
-                    <h2>{t("CS_PLEASE_COMMON_NOTE")}</h2>
+          {(documentSubmission?.[0]?.artifactList?.evidenceMarkedStatus || documentSubmission?.[0]?.artifactList?.isEvidence) &&
+            userType === "employee" && (
+              <div style={{ margin: "16px 24px" }}>
+                <div className="custom-note-main-div" style={{ padding: "8px 16px", flexDirection: "row", justifyContent: "space-between" }}>
+                  <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                    <CustomErrorTooltip message={t("CS_EVIDENCE_MARKED_INFO_TEXT")} showTooltip={true} />
+                    <div className="custom-note-heading-div">
+                      <h2>{t("CS_PLEASE_COMMON_NOTE")}</h2>
+                    </div>
+                    <div className="custom-note-info-div" style={{ display: "flex", alignItems: "center" }}>
+                      {<p>{t("CS_EVIDENCE_MARKED_INFO_TEXT")}</p>}
+                    </div>
                   </div>
-                  <div className="custom-note-info-div" style={{ display: "flex", alignItems: "center" }}>
-                    {<p>{t("CS_EVIDENCE_MARKED_INFO_TEXT")}</p>}
+                  <div>
+                    <button
+                      className="custom-note-close-button"
+                      style={{ fontWeight: "700", fontSize: "18px", fontStyle: "large", backgroundColor: "transparent", color: "#0F3B8C" }}
+                      onClick={() => {
+                        setShow(false);
+                        setShowMakeAsEvidenceModal(true);
+                      }}
+                    >
+                      {t("VIEW_DETAILS")}
+                    </button>
                   </div>
-                </div>
-                <div>
-                  <button
-                    className="custom-note-close-button"
-                    style={{ fontWeight: "700", fontSize: "18px", fontStyle: "large", backgroundColor: "transparent", color: "#0F3B8C" }}
-                    onClick={() => {
-                      setShow(false);
-                      setShowMakeAsEvidenceModal(true);
-                    }}
-                  >
-                    {t("VIEW_DETAILS")}
-                  </button>
                 </div>
               </div>
-            </div>
-          )}
+            )}
           <div
             className="evidence-modal-main "
-            style={documentSubmission?.[0]?.artifactList?.evidenceMarkedStatus ? { height: "calc(100% - 140px)" } : {}}
+            style={
+              documentSubmission?.[0]?.artifactList?.evidenceMarkedStatus || documentSubmission?.[0]?.artifactList?.isEvidence
+                ? { height: "calc(100% - 140px)" }
+                : {}
+            }
           >
             <div className={"application-details"}>
               <div style={{ display: "flex", flexDirection: "column", overflowY: "auto", height: "fit-content" }}>

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/configs/UICustomizations.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/configs/UICustomizations.js
@@ -827,7 +827,7 @@ export const UICustomizations = {
         case "CASE_TITLE":
           return <OrderName rowData={row} colData={column} value={value} />;
         case "DOCUMENT_HEADING":
-          return t(value) || "";
+          return row?.businessObject?.artifactDetails?.additionalDetails?.formdata?.documentTitle || t(value) || "";
         case "SELECT":
           return <BulkCheckBox rowData={row} colData={column} isBailBond={true} />;
         case "EVIDENCE_NUMBER":


### PR DESCRIPTION
## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Employees can now submit in the Documents view when no evidence exists and nothing is marked.
  * Evidence note now appears when evidence exists or is marked, with a refreshed header that includes a View Details button and additional guidance text.
  * Evidence modal dynamically adjusts height based on evidence presence/marking for better readability.
  * Bulk “Mark as Evidence” list now displays the saved document title when available, falling back to the translated label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->