### PR TITLE
added delete option for witness addresses

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/SelectComponentsMulti.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/SelectComponentsMulti.js
@@ -249,10 +249,19 @@ const SelectComponentsMulti = ({ t, config, onSelect, formData, errors, setError
                     : t("CS_COMMON_ADDRESS_DETAIL")
                 } ${index + 1}`}</h1>
               </b>
-              {(config?.state === "DRAFT_IN_PROGRESS" || index >= config?.addressLength || config?.isJudgeSendBack) && (
+              {(config?.state === "DRAFT_IN_PROGRESS" ||
+                index >= config?.addressLength ||
+                config?.isJudgeSendBack ||
+                config?.formType === "Witness") && (
                 <span
                   onClick={() => {
-                    if (!config?.disable && (config?.state === "DRAFT_IN_PROGRESS" || index >= config?.addressLength || config?.isJudgeSendBack)) {
+                    if (
+                      !config?.disable &&
+                      (config?.state === "DRAFT_IN_PROGRESS" ||
+                        index >= config?.addressLength ||
+                        config?.isJudgeSendBack ||
+                        config?.formType === "Witness")
+                    ) {
                       handleDeleteLocation(data.id);
                     }
                   }}

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrders.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrders.js
@@ -3173,7 +3173,7 @@ const GenerateOrders = () => {
           attachmentDetails: {
             issueDate: orderData?.auditDetails?.lastModifiedTime,
             caseFilingDate: caseDetails?.filingDate,
-            docSubType: "Attachment requiring the apperance of a person accused",
+            docSubType: "Order authorising an attachment by the district magistrate or collector",
             templateType: "GENERIC",
             attachmentText: orderFormValue?.attachmentText?.attachmentText || "",
             district: orderFormValue?.district?.district || "",


### PR DESCRIPTION
## Requirements
#4504


- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Delete icon in multi-select now appears and works for Witness forms, aligning behavior with other applicable form states.

* **Chores**
  * Updated attachment subtype text for ATTACHMENT to “Order authorising an attachment by the district magistrate or collector,” improving clarity in attachment details and related displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->