### PR TITLE
Removed save sign Later from A-Diary

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pageComponents/OrderReviewModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pageComponents/OrderReviewModal.js
@@ -24,7 +24,6 @@ function OrderReviewModal({
   order,
   setShowsignatureModal,
   showActions = true,
-  saveSignLater,
   setOrderPdfFileStoreID,
   setBusinessOfTheDay,
   currentDiaryEntry,
@@ -218,10 +217,11 @@ function OrderReviewModal({
         headerBarEnd={<CloseBtn onClick={handleReviewGoBack} />}
         actionCancelLabel={showActions && t("BULK_EDIT")}
         actionCustomLabel={showActions && t("ADD_SIGNATURE")}
-        actionSaveLabel={(showActions || saveSignLater) && t("SAVE_FINALISE_AND_SIGN_LATER")}
+        actionSaveLabel={showActions && t("SAVE_FINALISE_AND_SIGN_LATER")}
         isBackButtonDisabled={isLoading || isUpdateLoading}
         isCustomButtonDisabled={isLoading || isUpdateLoading}
         isDisabled={isLoading || isUpdateLoading}
+
         actionCancelOnSubmit={handleReviewGoBack}
         actionCustomLabelSubmit={handleAddSignature}
         customActionStyle={{ border: "1px solid #007E7E", backgroundColor: "white" }}

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrders.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrders.js
@@ -4466,8 +4466,7 @@ const GenerateOrders = () => {
           setShowReviewModal={setShowReviewModal}
           setShowsignatureModal={setShowsignatureModal}
           setOrderPdfFileStoreID={setOrderPdfFileStoreID}
-          showActions={canESign && !currentDiaryEntry}
-          saveSignLater={canSaveSignLater}
+          showActions={(canESign || canSaveSignLater) && !currentDiaryEntry}
           setBusinessOfTheDay={setBusinessOfTheDay}
           currentDiaryEntry={currentDiaryEntry}
           handleUpdateBusinessOfDayEntry={handleUpdateBusinessOfDayEntry}

--- a/utilities/dristi-pdf/src/caseBundle/sections/processCourtEvidence.js
+++ b/utilities/dristi-pdf/src/caseBundle/sections/processCourtEvidence.js
@@ -37,7 +37,7 @@ async function processCourtEvidence(
         courtId: courtCase.courtId,
         filingNumber: courtCase.filingNumber,
         artifactType: "WITNESS_DEPOSITION",
-        status: "COMPLETED",
+        status: ["COMPLETED"],
         isVoid: false,
         tenantId,
       },


### PR DESCRIPTION
## Requirements
https://github.com/pucardotorg/dristi/issues/4541
https://github.com/pucardotorg/dristi/issues/4540


- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Order review actions are now visible to users with either eSign or Approver permissions (when no Diary Entry exists).

- Behavior Changes
  - The "Save, Finalise & Sign Later" button is now shown only when actions are displayed (a separate "save later" toggle was removed).

- Refactor
  - Simplified action-button display logic for more predictable behavior.

- Bug Fixes
  - Evidence search updated to use a status list filter, which may affect deposition results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->