### PR TITLE
bug fix for updating witness after depostion

### DIFF
--- a/backend/case/src/main/java/org/pucar/dristi/service/CaseService.java
+++ b/backend/case/src/main/java/org/pucar/dristi/service/CaseService.java
@@ -37,9 +37,7 @@ import org.pucar.dristi.web.models.analytics.Outcome;
 import org.pucar.dristi.web.models.task.Task;
 import org.pucar.dristi.web.models.task.TaskRequest;
 import org.pucar.dristi.web.models.task.TaskResponse;
-import org.pucar.dristi.web.models.v2.WitnessDetails;
-import org.pucar.dristi.web.models.v2.WitnessDetailsRequest;
-import org.pucar.dristi.web.models.v2.WitnessDetailsResponse;
+import org.pucar.dristi.web.models.v2.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
@@ -5675,9 +5673,11 @@ public class CaseService {
                         uniqueId != null &&
                         uniqueId.equals(existingNode.get("uniqueId").asText())) {
 
-                    // Update existing record - replace the data field
+                    JsonNode data = existingNode.get("data");
+                    WitnessDetails existingWitness = objectMapper.convertValue(data, WitnessDetails.class);
+                    updateWitnessDetails(existingWitness, witnessDetails);
                     ObjectNode existingObjectNode = (ObjectNode) existingNode;
-                    JsonNode updatedDataNode = objectMapper.convertValue(witnessDetails, JsonNode.class);
+                    JsonNode updatedDataNode = objectMapper.convertValue(existingWitness, JsonNode.class);
                     existingObjectNode.set("data", updatedDataNode);
                     found = true;
                     log.debug("Updated existing witness record with uniqueId: {}", uniqueId);
@@ -5699,6 +5699,82 @@ public class CaseService {
         }
         courtCase.setAdditionalDetails(additionalDetailsNode);
     }
+
+    private void updateWitnessDetails(WitnessDetails existingWitness, WitnessDetails witnessDetails) {
+        if (witnessDetails == null) {
+            return;
+        }
+
+        // Update phone numbers
+        if (witnessDetails.getPhoneNumbers() != null &&
+                witnessDetails.getPhoneNumbers().getMobileNumber() != null &&
+                !witnessDetails.getPhoneNumbers().getMobileNumber().isEmpty()) {
+
+            if (existingWitness.getPhoneNumbers() == null) {
+                existingWitness.setPhoneNumbers(new PhoneNumbers()); // assuming PhoneNumbers is the class
+            }
+            if (existingWitness.getPhoneNumbers().getMobileNumber() == null) {
+                existingWitness.getPhoneNumbers().setMobileNumber(new ArrayList<>());
+            }
+            existingWitness.getPhoneNumbers().getMobileNumber()
+                    .addAll(witnessDetails.getPhoneNumbers().getMobileNumber());
+        }
+
+        // Update emails
+        if (witnessDetails.getEmails() != null &&
+                witnessDetails.getEmails().getEmailId() != null &&
+                !witnessDetails.getEmails().getEmailId().isEmpty()) {
+
+            if (existingWitness.getEmails() == null) {
+                existingWitness.setEmails(new Emails());
+            }
+            if (existingWitness.getEmails().getEmailId() == null) {
+                existingWitness.getEmails().setEmailId(new ArrayList<>());
+            }
+            existingWitness.getEmails().getEmailId()
+                    .addAll(witnessDetails.getEmails().getEmailId());
+        }
+
+        // Update address details
+        if (witnessDetails.getAddressDetails() != null &&
+                !witnessDetails.getAddressDetails().isEmpty()) {
+
+            if (existingWitness.getAddressDetails() == null) {
+                existingWitness.setAddressDetails(new ArrayList<>());
+            }
+            existingWitness.getAddressDetails().addAll(witnessDetails.getAddressDetails());
+        }
+
+        // Update simple string fields
+        if (witnessDetails.getFirstName() != null && !witnessDetails.getFirstName().trim().isEmpty()) {
+            existingWitness.setFirstName(witnessDetails.getFirstName());
+        }
+        if (witnessDetails.getLastName() != null && !witnessDetails.getLastName().trim().isEmpty()) {
+            existingWitness.setLastName(witnessDetails.getLastName());
+        }
+        if (witnessDetails.getMiddleName() != null && !witnessDetails.getMiddleName().trim().isEmpty()) {
+            existingWitness.setMiddleName(witnessDetails.getMiddleName());
+        }
+        if (witnessDetails.getWitnessDesignation() != null && !witnessDetails.getWitnessDesignation().trim().isEmpty()) {
+            existingWitness.setWitnessDesignation(witnessDetails.getWitnessDesignation());
+        }
+        if (witnessDetails.getWitnessAge() != null && !witnessDetails.getWitnessAge().trim().isEmpty()) {
+            existingWitness.setWitnessAge(witnessDetails.getWitnessAge());
+        }
+        if (witnessDetails.getAdditionalDetails() != null) {
+            existingWitness.setAdditionalDetails(witnessDetails.getAdditionalDetails());
+        }
+        if (witnessDetails.getDateOfService() != null && !witnessDetails.getDateOfService().trim().isEmpty()) {
+            existingWitness.setDateOfService(witnessDetails.getDateOfService());
+        }
+        if (witnessDetails.getWitnessTag() != null && !witnessDetails.getWitnessTag().trim().isEmpty()) {
+            existingWitness.setWitnessTag(witnessDetails.getWitnessTag());
+        }
+        if (witnessDetails.getOwnerType() != null && !witnessDetails.getOwnerType().trim().isEmpty()) {
+            existingWitness.setOwnerType(witnessDetails.getOwnerType());
+        }
+    }
+
 
 
     /**

--- a/backend/evidence/src/main/java/org/pucar/dristi/service/EvidenceService.java
+++ b/backend/evidence/src/main/java/org/pucar/dristi/service/EvidenceService.java
@@ -320,7 +320,9 @@ public class EvidenceService {
 
         // Remark: may need to add email laters to witness details
 //        updateWitnessEmails(body, witness);
-        updateWitnessMobileNumbers(body, witness);
+        if(body.getArtifact().getWitnessMobileNumbers() != null && !body.getArtifact().getWitnessMobileNumbers().isEmpty()){
+            updateWitnessMobileNumbers(body, witness);
+        }
 
         WitnessDetailsRequest witnessDetailsRequest = WitnessDetailsRequest.builder()
                 .requestInfo(body.getRequestInfo())


### PR DESCRIPTION
#4538
## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
The issue is about if witness already has a mobile numbers then if should not ask at the time of esign which is happening now.
The cause for this issue is when we update the witness tag we are also updating witness mobile number within same method which is updating the phonenumbers to null.
To fix the issue we are updating all entries line by line if updated in payload.







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->
