### PR TITLE
added create order on hearing enhancement, end hearing enhancement, fixed draft issue

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/ConfirmSubmissionAction.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/ConfirmSubmissionAction.js
@@ -50,7 +50,6 @@ function ConfirmSubmissionAction({
         handleAction(generateOrder, type);
       }}
       popupStyles={{ borderRadius: "4px" }}
-      headerBarMainStyle={{ height: "55px" }}
       isDisabled={!reasonOfApplication}
     >
       <div>

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/hooks/index.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/hooks/index.js
@@ -61,6 +61,7 @@ export const Urls = {
     searchHearings: "/hearing/v1/search",
     createHearings: "/hearing/v1/create",
     updateHearings: "/hearing/v1/update",
+    getDraftOrder: "/hearing/v1/getDraftOrder",
     demandCreate: "/billing-service/demand/_create",
     ordersSearch: "/order/v1/search",
     ordersCreate: "/order/v1/create",

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCaseV2.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCaseV2.js
@@ -2579,34 +2579,7 @@ const AdmittedCaseV2 = () => {
       } else if (option.value === "GENERATE_ORDER") {
         handleSelect("GENERATE_ORDER");
       } else if (option.value === "END_HEARING") {
-        try {
-          setApiCalled(true);
-          const orderResponse = await ordersService.searchOrder(
-            {
-              tenantId: caseDetails?.tenantId,
-              criteria: {
-                tenantID: caseDetails?.tenantId,
-                filingNumber: caseDetails?.filingNumber,
-                orderType: "SCHEDULING_NEXT_HEARING",
-                status: OrderWorkflowState.DRAFT_IN_PROGRESS,
-                ...(caseCourtId && { courtId: caseCourtId }),
-              },
-            },
-            { tenantId: caseDetails?.tenantId }
-          );
-          if (
-            orderResponse?.list?.length > 0 &&
-            orderResponse?.list?.find((order) => order?.additionalDetails?.refHearingId === currentInProgressHearing?.hearingId)
-          ) {
-            setShowEndHearingModal({ isNextHearingDrafted: true, openEndHearingModal: true });
-          } else {
-            setShowEndHearingModal({ isNextHearingDrafted: false, openEndHearingModal: true });
-          }
-        } catch (error) {
-          console.error("Error fetching order", error);
-        } finally {
-          setApiCalled(false);
-        }
+        setShowEndHearingModal({ isNextHearingDrafted: false, openEndHearingModal: true });
       } else if (option.value === "TAKE_WITNESS_DEPOSITION") {
         setShowWitnessModal(true);
       } else if (option.value === "SUBMIT_DOCUMENTS") {
@@ -2641,7 +2614,7 @@ const AdmittedCaseV2 = () => {
   }, [isCaseAdmitted]);
 
   const handleSelect = useCallback(
-    (option) => {
+    async (option) => {
       if (option === t("MAKE_SUBMISSION")) {
         history.push(`/${window?.contextPath}/employee/submissions/submissions-create?filingNumber=${filingNumber}&applicationType=DOCUMENT`);
         return;
@@ -2750,9 +2723,71 @@ const AdmittedCaseV2 = () => {
         setShowMenu(false);
         return;
       }
-      history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}`, { caseId: caseId, tab: "Orders" });
+
+      try {
+        setApiCalled(true);
+
+        let response;
+
+        if (currentInProgressHearing) {
+          response = await DRISTIService.getDraftOrder(
+            {
+              hearingDraftOrder: {
+                cnrNumber,
+                filingNumber,
+                tenantId,
+                hearingNumber: currentInProgressHearing?.hearingId,
+              },
+            },
+            {}
+          );
+        } else {
+          response = await DRISTIService.createOrder(
+            {
+              order: {
+                tenantId,
+                cnrNumber,
+                filingNumber,
+                statuteSection: { tenantId },
+                status: "",
+                orderTitle: t("DEFAULT_ORDER_TITLE"),
+                orderType: "",
+                orderCategory: "INTERMEDIATE",
+                isActive: true,
+                workflow: {
+                  action: "SAVE_DRAFT",
+                  documents: [{}],
+                },
+              },
+            },
+            { tenantId }
+          );
+        }
+
+        history.push(
+          `/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${response?.order?.orderNumber}`,
+          { caseId, tab: "Orders" }
+        );
+      } catch (error) {
+        console.error("Error fetching order", error);
+      } finally {
+        setApiCalled(false);
+      }
     },
-    [t, history, filingNumber, caseId, openHearingModule, tenantId, cnrNumber, OrderWorkflowAction.SAVE_DRAFT, ordersService, activeTab, showToast]
+    [
+      t,
+      currentInProgressHearing,
+      history,
+      filingNumber,
+      openHearingModule,
+      tenantId,
+      cnrNumber,
+      OrderWorkflowAction.SAVE_DRAFT,
+      ordersService,
+      caseId,
+      activeTab,
+      showToast,
+    ]
   );
 
   const handleDownload = useCallback(
@@ -3957,7 +3992,6 @@ const AdmittedCaseV2 = () => {
             />
           }
           actionSaveLabel={t(passOver ? "CS_CASE_PASS_OVER_START_NEXT_HEARING" : "CS_CASE_END_START_NEXT_HEARING")}
-          hideModalActionbar={!showEndHearingModal.isNextHearingDrafted}
           isBackButtonDisabled={apiCalled}
           isCustomButtonDisabled={apiCalled}
           isDisabled={apiCalled}
@@ -4026,18 +4060,14 @@ const AdmittedCaseV2 = () => {
           className={"confirm-end-hearing-modal"}
         >
           <div style={{ margin: "16px 0px" }}>
-            {!showEndHearingModal.isNextHearingDrafted ? (
-              <p>{t("CS_CASE_AN_ORDER_BOTD_FIRST")}</p>
-            ) : (
-              <CheckBox
-                onChange={(e) => {
-                  setPassOver(e.target.checked);
-                }}
-                label={`${t("CS_CASE_PASS_OVER")}: ${t("CS_CASE_PASS_OVER_HEARING_TEXT")}`}
-                checked={passOver}
-                disable={false}
-              />
-            )}
+            <CheckBox
+              onChange={(e) => {
+                setPassOver(e.target.checked);
+              }}
+              label={`${t("CS_CASE_PASS_OVER")}: ${t("CS_CASE_PASS_OVER_HEARING_TEXT")}`}
+              checked={passOver}
+              disable={false}
+            />
           </div>
         </Modal>
       )}

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/OrderDrafts.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/OrderDrafts.js
@@ -85,7 +85,7 @@ const OrderDrafts = ({ caseData, setOrderModal }) => {
                     color: "#101828",
                   }}
                 >
-                  {order?.orderCategory === "COMPOSITE" ? order?.orderTitle : t(`ORDER_TYPE_${order?.orderType?.toUpperCase()}`)}
+                  {order?.orderTitle}
                 </div>
                 <CustomArrowOut />
               </div>

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/services/index.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/services/index.js
@@ -198,6 +198,24 @@ export const DRISTIService = {
       params,
     });
   },
+  getDraftOrder: (data, params) => {
+    return Request({
+      url: Urls.dristi.getDraftOrder,
+      useCache: false,
+      userService: false,
+      data,
+      params,
+    });
+  },
+  createOrder: (data, params) => {
+    return Request({
+      url: Urls.dristi.ordersCreate,
+      useCache: false,
+      userService: false,
+      data,
+      params,
+    });
+  },
   searchOrders: (data, params) => {
     return Request({
       url: Urls.dristi.ordersSearch,

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/HomeHearingsTab.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/HomeHearingsTab.js
@@ -285,37 +285,7 @@ const HomeHearingsTab = ({
             showToast("error", t("ISSUE_IN_START_HEARING"), 5000);
           }
         } else if ((isBenchClerk || isCourtRoomManager) && ["IN_PROGRESS"].includes(hearingDetails?.status)) {
-          //for bench clerk action he will have end hearing instead of edit icon
-          try {
-            setLoader(true);
-            const orderResponse = await ordersService.searchOrder(
-              {
-                tenantId: hearingDetails?.tenantId,
-                criteria: {
-                  tenantID: hearingDetails?.tenantId,
-                  filingNumber: hearingDetails?.filingNumber,
-                  orderType: "SCHEDULING_NEXT_HEARING",
-                  status: OrderWorkflowState.DRAFT_IN_PROGRESS,
-                  ...(hearingDetails?.courtId && { courtId: hearingDetails?.courtId }),
-                },
-              },
-              { tenantId: hearingDetails?.tenantId }
-            );
-            if (
-              orderResponse?.list?.length > 0 &&
-              orderResponse?.list?.find((order) => order?.additionalDetails?.refHearingId === hearingDetails?.hearingNumber)
-            ) {
-              setShowEndHearingModal({ isNextHearingDrafted: true, openEndHearingModal: true, currentHearing: hearingDetails });
-              setLoader(false);
-            } else {
-              setShowEndHearingModal({ isNextHearingDrafted: false, openEndHearingModal: true, currentHearing: {} });
-              setLoader(false);
-            }
-          } catch (e) {
-            console.log(e);
-            setLoader(false);
-            showToast("error", t("ISSUE_IN_UPDATE_HEARING"), 5000);
-          }
+          setShowEndHearingModal({ isNextHearingDrafted: false, openEndHearingModal: true, currentHearing: {} });
         }
       }
     },
@@ -380,36 +350,7 @@ const HomeHearingsTab = ({
           label: "End Hearing",
           id: "end_hearing",
           action: async () => {
-            try {
-              setLoader(true);
-              const orderResponse = await ordersService.searchOrder(
-                {
-                  tenantId: hearingDetails?.tenantId,
-                  criteria: {
-                    tenantID: hearingDetails?.tenantId,
-                    filingNumber: hearingDetails?.filingNumber,
-                    orderType: "SCHEDULING_NEXT_HEARING",
-                    status: OrderWorkflowState.DRAFT_IN_PROGRESS,
-                    ...(hearingDetails?.courtId && { courtId: hearingDetails?.courtId }),
-                  },
-                },
-                { tenantId: hearingDetails?.tenantId }
-              );
-              if (
-                orderResponse?.list?.length > 0 &&
-                orderResponse?.list?.find((order) => order?.additionalDetails?.refHearingId === hearingDetails?.hearingNumber)
-              ) {
-                setShowEndHearingModal({ isNextHearingDrafted: true, openEndHearingModal: true, currentHearing: hearingDetails });
-                setLoader(false);
-              } else {
-                setShowEndHearingModal({ isNextHearingDrafted: false, openEndHearingModal: true, currentHearing: {} });
-                setLoader(false);
-              }
-            } catch (e) {
-              console.log(e);
-              setLoader(false);
-              showToast("error", t("ISSUE_IN_END_HEARING"), 5000);
-            }
+            setShowEndHearingModal({ isNextHearingDrafted: false, openEndHearingModal: true, currentHearing: {} });
           },
         });
       }
@@ -442,8 +383,6 @@ const HomeHearingsTab = ({
                 (orderResponse?.list?.length > 0 &&
                   orderResponse?.list?.find((order) => order?.additionalDetails?.refHearingId === hearingDetails?.hearingNumber))
               ) {
-                setShowEndHearingModal({ isNextHearingDrafted: true, openEndHearingModal: false, currentHearing: hearingDetails });
-
                 await hearingService
                   ?.searchHearings(
                     {
@@ -918,7 +857,6 @@ const HomeHearingsTab = ({
             />
           }
           actionSaveLabel={t(passOver ? "CS_CASE_PASS_OVER_START_NEXT_HEARING" : "CS_CASE_END_START_NEXT_HEARING")}
-          hideModalActionbar={!showEndHearingModal.isNextHearingDrafted}
           actionSaveOnSubmit={async () => {
             try {
               setLoader(true);
@@ -1032,18 +970,14 @@ const HomeHearingsTab = ({
           className={"confirm-end-hearing-modal"}
         >
           <div style={{ margin: "16px 0px" }}>
-            {!showEndHearingModal.isNextHearingDrafted ? (
-              <p>{t("CS_CASE_AN_ORDER_BOTD_FIRST")}</p>
-            ) : (
-              <CheckBox
-                onChange={(e) => {
-                  setPassOver(e.target.checked);
-                }}
-                label={`${t("CS_CASE_PASS_OVER")}: ${t("CS_CASE_PASS_OVER_HEARING_TEXT")}`}
-                checked={passOver}
-                disable={false}
-              />
-            )}
+            <CheckBox
+              onChange={(e) => {
+                setPassOver(e.target.checked);
+              }}
+              label={`${t("CS_CASE_PASS_OVER")}: ${t("CS_CASE_PASS_OVER_HEARING_TEXT")}`}
+              checked={passOver}
+              disable={false}
+            />
           </div>
         </Modal>
       )}


### PR DESCRIPTION
## Requirements
https://github.com/pucardotorg/dristi/issues/4546
https://github.com/pucardotorg/dristi/issues/4549


- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Generate Orders: Automatically retrieve/create draft orders, enhanced form (attendees, party names), warrant subtype handling, improved validation, and streamlined post-save navigation.
  - Drafts list now consistently displays the full order title.
  - Support added for fetching existing draft orders.

- Refactor/UX
  - Simplified End Hearing flow: always shows action bar and a Pass Over option; removed pre-checks.
  - Modal header now uses default sizing.

- Output/PDF
  - Orders PDF now includes both joined and unjoined respondents (accused) with improved address formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->