### PR TITLE
pending task for schedule hearing creation and closure

### DIFF
--- a/backend/hearing/src/main/java/org/pucar/dristi/config/Configuration.java
+++ b/backend/hearing/src/main/java/org/pucar/dristi/config/Configuration.java
@@ -278,4 +278,12 @@ public class Configuration {
     @Value("${dristi.analytics.create.pendingtask}")
     private String createPendingTaskEndPoint;
 
+    @Value("${dristi.pending.task.name}")
+    private String pendingTaskName;
+
+    @Value("${order.businessservice}")
+    private String orderEntityType;
+
+    @Value("${schedule.hearing.sla}")
+    private int scheduleHearingSla;
 }

--- a/backend/hearing/src/main/java/org/pucar/dristi/config/ServiceConstants.java
+++ b/backend/hearing/src/main/java/org/pucar/dristi/config/ServiceConstants.java
@@ -121,6 +121,13 @@ public class ServiceConstants {
             + "}"
             + "}\n";
 
+    public static final String CASE_TITLE = "caseTitle";
+    public static final String CASE_ID = "id";
+    public static final String SCHEDULE_HEARING_SUFFIX = "_SCHEDULE_HEARING";
+    public static final String ACTION_CATEGORY_SCHEDULE_HEARING = "Schedule Hearing";
+    public static final String STATUS_IN_PROGRESS = "IN_PROGRESS";
+    public static final String ASSIGNED_ROLE_JUDGE = "JUDGE_ROLE";
+    public static final String SCREEN_TYPE_HOME = "home";
 
     // module for localized hearing types
     public static final String HEARING_TYPE_MODULE_CODE = "hearingTypes";

--- a/backend/hearing/src/main/java/org/pucar/dristi/kafka/consumer/HearingUpdateConsumer.java
+++ b/backend/hearing/src/main/java/org/pucar/dristi/kafka/consumer/HearingUpdateConsumer.java
@@ -1,23 +1,32 @@
 package org.pucar.dristi.kafka.consumer;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.egov.common.contract.models.Workflow;
+import org.egov.common.contract.request.RequestInfo;
+import org.pucar.dristi.config.Configuration;
 import org.pucar.dristi.service.HearingService;
+import org.pucar.dristi.util.CaseUtil;
+import org.pucar.dristi.util.DateUtil;
 import org.pucar.dristi.util.OrderUtil;
-import org.pucar.dristi.web.models.HearingRequest;
-import org.pucar.dristi.web.models.WorkflowObject;
+import org.pucar.dristi.util.PendingTaskUtil;
+import org.pucar.dristi.web.models.*;
 import org.pucar.dristi.web.models.cases.CaseRequest;
 import org.pucar.dristi.web.models.cases.CourtCase;
 import org.pucar.dristi.web.models.orders.*;
-import org.pucar.dristi.web.models.Pagination;
+import org.pucar.dristi.web.models.orders.Order;
+import org.pucar.dristi.web.models.pendingtask.PendingTask;
+import org.pucar.dristi.web.models.pendingtask.PendingTaskRequest;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 
 import static org.pucar.dristi.config.ServiceConstants.*;
@@ -30,11 +39,19 @@ public class HearingUpdateConsumer {
     private final ObjectMapper objectMapper;
 
     private final OrderUtil orderUtil;
+    private final PendingTaskUtil pendingTaskUtil;
+    private final Configuration configuration;
+    private final DateUtil dateUtil;
+    private final CaseUtil caseUtil;
 
-    public HearingUpdateConsumer(HearingService hearingService, ObjectMapper objectMapper, OrderUtil orderUtil) {
+    public HearingUpdateConsumer(HearingService hearingService, ObjectMapper objectMapper, OrderUtil orderUtil, PendingTaskUtil pendingTaskUtil, Configuration configuration, DateUtil dateUtil, CaseUtil caseUtil) {
         this.hearingService = hearingService;
         this.objectMapper = objectMapper;
         this.orderUtil = orderUtil;
+        this.pendingTaskUtil = pendingTaskUtil;
+        this.configuration = configuration;
+        this.dateUtil = dateUtil;
+        this.caseUtil = caseUtil;
     }
 
     @KafkaListener(topics = {"${hearing.case.reference.number.update}"})
@@ -116,6 +133,8 @@ public class HearingUpdateConsumer {
                             .requestInfo(hearingRequest.getRequestInfo()).order(order).build();
                     OrderResponse orderResponse = orderUtil.createOrder(orderRequest);
                     log.info("Order created for Hearing ID: {}, orderNumber:: {}", hearingRequest.getHearing().getHearingId(), orderResponse.getOrder().getOrderNumber());
+
+                    checkAndCreatePendingTasks(hearingRequest);
                 }
             }
             log.info("Updated hearings");
@@ -123,4 +142,103 @@ public class HearingUpdateConsumer {
             log.error("Error while listening to hearings topic: {}: {}", topic, e.getMessage());
         }
     }
+
+    private void checkAndCreatePendingTasks(HearingRequest hearingRequest) {
+        Hearing hearing = hearingRequest.getHearing();
+        RequestInfo requestInfo = hearingRequest.getRequestInfo();
+
+        if (!COMPLETED.equalsIgnoreCase(hearing.getStatus())) {
+            return;
+        }
+
+        String filingNumber = getFirstFilingNumber(hearing);
+        if (filingNumber == null) {
+            log.error("Filing number is null for Hearing ID: {}", hearing.getHearingId());
+            return;
+        }
+
+        if (hasScheduledHearings(requestInfo, hearing, filingNumber)) {
+            log.info("Found scheduled hearings for Hearing ID: {}", hearing.getHearingId());
+            return;
+        }
+
+        createPendingTaskForHearing(requestInfo, hearing, filingNumber);
+    }
+
+    private String getFirstFilingNumber(Hearing hearing) {
+        return (hearing.getFilingNumber() != null && !hearing.getFilingNumber().isEmpty())
+                ? hearing.getFilingNumber().get(0)
+                : null;
+    }
+
+    private boolean hasScheduledHearings(RequestInfo requestInfo, Hearing hearing, String filingNumber) {
+        HearingCriteria criteria = HearingCriteria.builder()
+                .filingNumber(filingNumber)
+                .tenantId(hearing.getTenantId())
+                .build();
+
+        HearingSearchRequest searchRequest = HearingSearchRequest.builder()
+                .requestInfo(requestInfo)
+                .criteria(criteria)
+                .build();
+
+        List<Hearing> hearings = hearingService.searchHearing(searchRequest);
+
+        return hearings.stream().anyMatch(h -> SCHEDULED.equalsIgnoreCase(h.getStatus()));
+    }
+
+    private void createPendingTaskForHearing(RequestInfo requestInfo, Hearing hearing, String filingNumber) {
+        LocalDateTime slaDate = LocalDateTime.now().plusDays(configuration.getScheduleHearingSla());
+
+        JsonNode caseDetails = getCaseDetails(requestInfo, hearing);
+        String caseTitle = textValueOrNull(caseDetails, CASE_TITLE);
+        String caseId = textValueOrNull(caseDetails, CASE_ID);
+
+        PendingTask pendingTask = PendingTask.builder()
+                .name(configuration.getPendingTaskName())
+                .referenceId(MANUAL + filingNumber + SCHEDULE_HEARING_SUFFIX)
+                .actionCategory(ACTION_CATEGORY_SCHEDULE_HEARING)
+                .entityType(configuration.getOrderEntityType())
+                .status(STATUS_IN_PROGRESS)
+                .assignedRole(List.of(ASSIGNED_ROLE_JUDGE))
+                .screenType(SCREEN_TYPE_HOME)
+                .stateSla(dateUtil.getEpochFromLocalDateTime(slaDate))
+                .filingNumber(filingNumber)
+                .caseTitle(caseTitle)
+                .caseId(caseId)
+                .isCompleted(false)
+                .build();
+
+        PendingTaskRequest pendingTaskRequest = PendingTaskRequest.builder()
+                .requestInfo(requestInfo)
+                .pendingTask(pendingTask)
+                .build();
+
+        log.info("Creating pending task for filing number: {}", filingNumber);
+        pendingTaskUtil.createPendingTask(pendingTaskRequest);
+    }
+
+    private JsonNode getCaseDetails(RequestInfo requestInfo, Hearing hearing) {
+        CaseSearchRequest caseSearchRequest = createCaseSearchRequest(requestInfo, hearing);
+        return caseUtil.searchCaseDetails(caseSearchRequest).get(0);
+    }
+
+    private String textValueOrNull(JsonNode node, String field) {
+        return node.get(field).isNull() ? null : node.get(field).textValue();
+    }
+
+    public CaseSearchRequest createCaseSearchRequest(RequestInfo requestInfo, Hearing hearing) {
+        String filingNumber = getFirstFilingNumber(hearing);
+        CaseCriteria caseCriteria = CaseCriteria.builder()
+                .filingNumber(filingNumber)
+                .defaultFields(false)
+                .build();
+
+        CaseSearchRequest caseSearchRequest = new CaseSearchRequest();
+        caseSearchRequest.setRequestInfo(requestInfo);
+        caseSearchRequest.addCriteriaItem(caseCriteria);
+        return caseSearchRequest;
+    }
+
+
 }

--- a/backend/hearing/src/main/java/org/pucar/dristi/kafka/consumer/HearingUpdateConsumer.java
+++ b/backend/hearing/src/main/java/org/pucar/dristi/kafka/consumer/HearingUpdateConsumer.java
@@ -220,7 +220,7 @@ public class HearingUpdateConsumer {
 
     private JsonNode getCaseDetails(RequestInfo requestInfo, Hearing hearing) {
         CaseSearchRequest caseSearchRequest = createCaseSearchRequest(requestInfo, hearing);
-        return caseUtil.searchCaseDetails(caseSearchRequest).get(0);
+        return caseUtil.searchCaseDetails(caseSearchRequest);
     }
 
     private String textValueOrNull(JsonNode node, String field) {

--- a/backend/hearing/src/main/resources/application.properties
+++ b/backend/hearing/src/main/resources/application.properties
@@ -180,3 +180,7 @@ dristi.analytics.host=http://localhost:8060
 dristi.analytics.create.pendingtask=/analytics/pending_task/v1/create
 
 lpr.case.details.update.kafka.topic=lpr-case-details-update
+
+dristi.pending.task.name=Schedule Hearing
+order.businessservice=order-default
+schedule.hearing.sla=1

--- a/backend/hearing/src/main/resources/application.properties
+++ b/backend/hearing/src/main/resources/application.properties
@@ -183,4 +183,4 @@ lpr.case.details.update.kafka.topic=lpr-case-details-update
 
 dristi.pending.task.name=Schedule Hearing
 order.businessservice=order-default
-schedule.hearing.sla=1
+schedule.hearing.sla=0

--- a/backend/hearing/src/test/java/org/pucar/dristi/kafka/consumer/HearingUpdateConsumerTest.java
+++ b/backend/hearing/src/test/java/org/pucar/dristi/kafka/consumer/HearingUpdateConsumerTest.java
@@ -9,8 +9,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.pucar.dristi.config.Configuration;
 import org.pucar.dristi.service.HearingService;
+import org.pucar.dristi.util.CaseUtil;
+import org.pucar.dristi.util.DateUtil;
 import org.pucar.dristi.util.OrderUtil;
+import org.pucar.dristi.util.PendingTaskUtil;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.messaging.MessageHeaders;
 import org.slf4j.Logger;
@@ -34,11 +38,23 @@ class HearingUpdateConsumerTest {
     private OrderUtil orderUtil;
 
     @Mock
+    private PendingTaskUtil pendingTaskUtil;
+
+    @Mock
+    private Configuration configuration;
+
+    @Mock
+    private DateUtil dateUtil;
+
+    @Mock
+    private CaseUtil caseUtil;
+
+    @Mock
     private Logger log;
 
     @BeforeEach
     void setup() {
-        hearingUpdateConsumer = new HearingUpdateConsumer(hearingService, objectMapper, orderUtil);
+        hearingUpdateConsumer = new HearingUpdateConsumer(hearingService, objectMapper, orderUtil, pendingTaskUtil, configuration, dateUtil, caseUtil);
     }
 
     @Test

--- a/backend/order-management/src/main/java/pucar/config/ServiceConstants.java
+++ b/backend/order-management/src/main/java/pucar/config/ServiceConstants.java
@@ -158,4 +158,6 @@ public class ServiceConstants {
     public static final String ACCUSED = "ACCUSED";
 
     public static final String MOVE_CASE_TO_LONG_PENDING_REGISTER_EXCEPTION = "MOVE_CASE_TO_LONG_PENDING_REGISTER_EXCEPTION";
+
+    public static final String SCHEDULE_HEARING_SUFFIX = "_SCHEDULE_HEARING";
 }

--- a/backend/order-management/src/main/java/pucar/strategy/ordertype/PublishOrderScheduleOfHearingDate.java
+++ b/backend/order-management/src/main/java/pucar/strategy/ordertype/PublishOrderScheduleOfHearingDate.java
@@ -123,6 +123,9 @@ public class PublishOrderScheduleOfHearingDate implements OrderUpdateStrategy {
         // close manual pending task for filing number
         log.info("close manual pending task for hearing number:{}", order.getHearingNumber());
         pendingTaskUtil.closeManualPendingTask(order.getHearingNumber(), requestInfo, courtCase.getFilingNumber(), courtCase.getCnrNumber(), courtCase.getId().toString(), courtCase.getCaseTitle());
+        // close manual pending task of schedule of hearing
+        log.info("close manual pending task of schedule of hearing");
+        pendingTaskUtil.closeManualPendingTask(order.getFilingNumber() + SCHEDULE_HEARING_SUFFIX, requestInfo, courtCase.getFilingNumber(), courtCase.getCnrNumber(), courtCase.getId().toString(), courtCase.getCaseTitle());
 
         log.info("post processing, result= SUCCESS,orderNumber:{}, orderType:{}", order.getOrderNumber(), order.getOrderType());
 


### PR DESCRIPTION
## Requirements

#4477

- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically creates a “Schedule Hearing” pending task when a hearing is completed and no future hearing is scheduled.

* **Improvements**
  * Pending task now includes case title/ID, filing number, assigned Judge role, and SLA calculated from configurable days.
  * Related manual pending tasks are automatically closed when publishing the schedule-of-hearing order.

* **Chores**
  * Added configuration defaults for pending task name, business service, and SLA.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->