### PR TITLE
restricting to update outcome if case is in LPR (#4391)

### DIFF
--- a/backend/analytics/src/main/java/org/pucar/dristi/util/CaseOverallStatusUtil.java
+++ b/backend/analytics/src/main/java/org/pucar/dristi/util/CaseOverallStatusUtil.java
@@ -316,6 +316,13 @@ public class CaseOverallStatusUtil {
 			}
 			else{
 				RequestInfo requestInfo = mapper.readValue(request.getJSONObject("RequestInfo").toString(), RequestInfo.class);
+                String filingNumber = outcome.getFilingNumber();
+                Object caseObject = caseUtil.getCase(request, config.getStateLevelTenantId(), null, filingNumber, null);
+                Boolean isLprCase = JsonPath.read(caseObject.toString(), IS_LPR_CASE_PATH);
+                if (isLprCase != null && isLprCase) {
+                    log.info("case is in long pending registration {} not eligible for case outcome update" , filingNumber);
+                    return;
+                }
 				AuditDetails auditDetails = new AuditDetails();
 				auditDetails.setLastModifiedBy(requestInfo.getUserInfo().getUuid());
 				auditDetails.setLastModifiedTime(System.currentTimeMillis());

--- a/backend/order-management/src/main/java/pucar/strategy/ordertype/PublishOrderWarrant.java
+++ b/backend/order-management/src/main/java/pucar/strategy/ordertype/PublishOrderWarrant.java
@@ -71,9 +71,11 @@ public class PublishOrderWarrant implements OrderUpdateStrategy {
         log.info("After order publish process,result = IN_PROGRESS, orderType :{}, orderNumber:{}", order.getOrderType(), order.getOrderNumber());
 
         // case search and update
-        List<CourtCase> cases = caseUtil.getCaseDetailsForSingleTonCriteria(CaseSearchRequest.builder()
+        CaseListResponse caseListResponse = caseUtil.searchCaseDetails(CaseSearchRequest.builder()
                 .criteria(Collections.singletonList(CaseCriteria.builder().filingNumber(order.getFilingNumber()).tenantId(order.getTenantId()).defaultFields(false).build()))
                 .requestInfo(requestInfo).build());
+
+        List<CourtCase> cases = caseListResponse.getCriteria().get(0).getResponseList();
 
         // add validation here
         CourtCase courtCase = cases.get(0);


### PR DESCRIPTION
## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents case outcome updates for Long Pending Registration (LPR) cases, avoiding incorrect status changes and downstream notifications.
- Refactor
  - Streamlined case data retrieval in the warrant publishing flow to use a more consistent search response, improving resilience and reducing edge-case failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->