### PR TITLE
Fix for opening modal without orderType

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/configs/ordersCreateConfig.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/configs/ordersCreateConfig.js
@@ -1242,6 +1242,7 @@ export const configsScheduleNextHearingDate = [
               name: "PARTY_1",
             },
           ],
+          hideInForm: true,
         },
       },
     ],

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrdersV2.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrdersV2.js
@@ -2648,6 +2648,9 @@ const GenerateOrdersV2 = () => {
   );
 
   const handleOrderTypeChange = (index, orderType) => {
+    if(!orderType){
+      return;
+    }
     const orderTypeValidationObj = checkOrderValidation(orderType?.code, index);
     if (orderTypeValidationObj?.showModal) {
       setShowOrderValidationModal(orderTypeValidationObj);


### PR DESCRIPTION
## Requirements



- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stops triggering validation and the Add Order modal when no order type is selected, preventing accidental actions and errors.
  * Improves stability when changing order types by safely ignoring empty selections.

* **UI/UX**
  * Streamlines the “Schedule Next Hearing Date” form by hiding an unnecessary party field, reducing clutter and potential confusion for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->