### PR TITLE
Modified generate-order breadCrumb

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/configs/UICustomizations.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/configs/UICustomizations.js
@@ -925,7 +925,7 @@ export const UICustomizations = {
                 .createOrder(requestBody, { tenantId: Digit.ULBService.getCurrentTenantId() })
                 .then((res) => {
                   history.push(
-                    `/${window.contextPath}/employee/orders/generate-orders?filingNumber=${row.filingNumber[0]}&orderNumber=${res.order.orderNumber}`,
+                    `/${window.contextPath}/employee/orders/generate-order?filingNumber=${row.filingNumber[0]}&orderNumber=${res.order.orderNumber}`,
                     {
                       caseId: row.caseId,
                       tab: "Orders",
@@ -1761,7 +1761,7 @@ export const UICustomizations = {
                 .createOrder(requestBody, { tenantId: Digit.ULBService.getCurrentTenantId() })
                 .then((res) => {
                   history.push(
-                    `/${window.contextPath}/employee/orders/generate-orders?filingNumber=${row.filingNumber[0]}&orderNumber=${res.order.orderNumber}`,
+                    `/${window.contextPath}/employee/orders/generate-order?filingNumber=${row.filingNumber[0]}&orderNumber=${res.order.orderNumber}`,
                     {
                       caseId: row.caseId,
                       tab: "Orders",
@@ -1817,7 +1817,7 @@ export const UICustomizations = {
                 .createOrder(requestBody, { tenantId: Digit.ULBService.getCurrentTenantId() })
                 .then((res) => {
                   history.push(
-                    `/${window.contextPath}/employee/orders/generate-orders?filingNumber=${row.filingNumber[0]}&orderNumber=${res.order.orderNumber}`,
+                    `/${window.contextPath}/employee/orders/generate-order?filingNumber=${row.filingNumber[0]}&orderNumber=${res.order.orderNumber}`,
                     {
                       caseId: row.caseId,
                       tab: "Orders",
@@ -1876,7 +1876,7 @@ export const UICustomizations = {
                 .createOrder(requestBody, { tenantId: Digit.ULBService.getCurrentTenantId() })
                 .then((res) => {
                   history.push(
-                    `/${window.contextPath}/employee/orders/generate-orders?filingNumber=${row.filingNumber[0]}&orderNumber=${res.order.orderNumber}`,
+                    `/${window.contextPath}/employee/orders/generate-order?filingNumber=${row.filingNumber[0]}&orderNumber=${res.order.orderNumber}`,
                     {
                       caseId: row.caseId,
                       tab: "Orders",
@@ -1932,7 +1932,7 @@ export const UICustomizations = {
                 .createOrder(requestBody, { tenantId: Digit.ULBService.getCurrentTenantId() })
                 .then((res) => {
                   history.push(
-                    `/${window.contextPath}/employee/orders/generate-orders?filingNumber=${row.filingNumber[0]}&orderNumber=${res.order.orderNumber}`,
+                    `/${window.contextPath}/employee/orders/generate-order?filingNumber=${row.filingNumber[0]}&orderNumber=${res.order.orderNumber}`,
                     {
                       caseId: row.caseId,
                       tab: "Orders",

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCase.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCase.js
@@ -669,7 +669,7 @@ const AdmittedCases = () => {
           setShowOrderReviewModal(true);
         } else {
           if (order?.status === OrderWorkflowState.DRAFT_IN_PROGRESS) {
-            history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${order?.orderNumber}`);
+            history.push(`/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${order?.orderNumber}`);
           } else if (order?.status === OrderWorkflowState.PENDING_BULK_E_SIGN) {
             history.push(`/${window.contextPath}/employee/home/bulk-esign-order?orderNumber=${order?.orderNumber}`);
           } else {
@@ -1561,7 +1561,7 @@ const AdmittedCases = () => {
               },
             });
             history.push(
-              `/${window?.contextPath}/employee/orders/generate-orders?filingNumber=${caseDetails?.filingNumber}&orderNumber=${res.order.orderNumber}`,
+              `/${window?.contextPath}/employee/orders/generate-order?filingNumber=${caseDetails?.filingNumber}&orderNumber=${res.order.orderNumber}`,
               {
                 caseId: caseDetails?.id,
                 tab: "Orders",
@@ -1739,7 +1739,7 @@ const AdmittedCases = () => {
               },
             });
             history.push(
-              `/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${res?.order?.orderNumber}`
+              `/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${res?.order?.orderNumber}`
             );
           } catch (error) {}
         }
@@ -1899,7 +1899,7 @@ const AdmittedCases = () => {
     DRISTIService.customApiService(Urls.dristi.ordersCreate, reqBody, { tenantId })
       .then((res) => {
         history.push(
-          `/${window?.contextPath}/employee/orders/generate-orders?filingNumber=${caseDetails?.filingNumber}&orderNumber=${res.order.orderNumber}`,
+          `/${window?.contextPath}/employee/orders/generate-order?filingNumber=${caseDetails?.filingNumber}&orderNumber=${res.order.orderNumber}`,
           {
             caseId: caseId,
             tab: "Orders",
@@ -2184,7 +2184,7 @@ const AdmittedCases = () => {
             orderData?.orderType === "NOTICE"
           ) {
             history.push(
-              `/${window?.contextPath}/employee/orders/generate-orders?filingNumber=${caseDetails?.filingNumber}&orderNumber=${orderData.orderNumber}`,
+              `/${window?.contextPath}/employee/orders/generate-order?filingNumber=${caseDetails?.filingNumber}&orderNumber=${orderData.orderNumber}`,
               {
                 caseId: caseId,
                 tab: "Orders",
@@ -2251,7 +2251,7 @@ const AdmittedCases = () => {
         ordersService
           .createOrder(requestBody, { tenantId: Digit.ULBService.getCurrentTenantId() })
           .then((res) => {
-            history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${res.order.orderNumber}`, {
+            history.push(`/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${res.order.orderNumber}`, {
               caseId: caseDetails?.id,
               tab: "Orders",
             });
@@ -2361,7 +2361,7 @@ const AdmittedCases = () => {
         ordersService
           .createOrder(reqBody, { tenantId })
           .then((res) => {
-            history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${res.order.orderNumber}`, {
+            history.push(`/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${res.order.orderNumber}`, {
               caseId: caseId,
               tab: activeTab,
             });
@@ -2407,7 +2407,7 @@ const AdmittedCases = () => {
         ordersService
           .createOrder(reqBody, { tenantId })
           .then((res) => {
-            history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${res.order.orderNumber}`, {
+            history.push(`/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${res.order.orderNumber}`, {
               caseId: caseId,
               tab: activeTab,
             });
@@ -2417,7 +2417,7 @@ const AdmittedCases = () => {
           });
         return;
       }
-      history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}`, { caseId: caseId, tab: "Orders" });
+      history.push(`/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}`, { caseId: caseId, tab: "Orders" });
     },
     [t, history, filingNumber, caseId, openHearingModule, tenantId, cnrNumber, OrderWorkflowAction.SAVE_DRAFT, ordersService, activeTab, showToast]
   );
@@ -2546,7 +2546,7 @@ const AdmittedCases = () => {
         });
         refetchCaseData();
         revalidateWorkflow();
-        history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${res.order.orderNumber}`);
+        history.push(`/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${res.order.orderNumber}`);
       })
       .catch((err) => {
         showToast({ isError: true, message: "ORDER_CREATION_FAILED" });

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCaseV2.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCaseV2.js
@@ -855,7 +855,7 @@ const AdmittedCaseV2 = () => {
           setShowOrderReviewModal(true);
         } else {
           if (order?.status === OrderWorkflowState.DRAFT_IN_PROGRESS) {
-            history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${order?.orderNumber}`);
+            history.push(`/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${order?.orderNumber}`);
           } else if (order?.status === OrderWorkflowState.PENDING_BULK_E_SIGN) {
             history.push(`/${window.contextPath}/employee/home/bulk-esign-order?orderNumber=${order?.orderNumber}`);
           } else {
@@ -1785,7 +1785,7 @@ const AdmittedCaseV2 = () => {
               },
             });
             history.push(
-              `/${window?.contextPath}/employee/orders/generate-orders?filingNumber=${caseDetails?.filingNumber}&orderNumber=${res.order.orderNumber}`,
+              `/${window?.contextPath}/employee/orders/generate-order?filingNumber=${caseDetails?.filingNumber}&orderNumber=${res.order.orderNumber}`,
               {
                 caseId: caseDetails?.id,
                 tab: "Orders",
@@ -1931,7 +1931,7 @@ const AdmittedCaseV2 = () => {
               },
             });
             history.push(
-              `/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${res?.order?.orderNumber}`
+              `/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${res?.order?.orderNumber}`
             );
           } catch (error) {}
         }
@@ -2090,7 +2090,7 @@ const AdmittedCaseV2 = () => {
     DRISTIService.customApiService(Urls.dristi.ordersCreate, reqBody, { tenantId })
       .then((res) => {
         history.push(
-          `/${window?.contextPath}/employee/orders/generate-orders?filingNumber=${caseDetails?.filingNumber}&orderNumber=${res.order.orderNumber}`,
+          `/${window?.contextPath}/employee/orders/generate-order?filingNumber=${caseDetails?.filingNumber}&orderNumber=${res.order.orderNumber}`,
           {
             caseId: caseId,
             tab: "Orders",
@@ -2393,7 +2393,7 @@ const AdmittedCaseV2 = () => {
             orderData?.orderType === "NOTICE"
           ) {
             history.push(
-              `/${window?.contextPath}/employee/orders/generate-orders?filingNumber=${caseDetails?.filingNumber}&orderNumber=${orderData.orderNumber}`,
+              `/${window?.contextPath}/employee/orders/generate-order?filingNumber=${caseDetails?.filingNumber}&orderNumber=${orderData.orderNumber}`,
               {
                 caseId: caseId,
                 tab: "Orders",
@@ -2460,7 +2460,7 @@ const AdmittedCaseV2 = () => {
         ordersService
           .createOrder(requestBody, { tenantId: Digit.ULBService.getCurrentTenantId() })
           .then((res) => {
-            history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${res.order.orderNumber}`, {
+            history.push(`/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${res.order.orderNumber}`, {
               caseId: caseDetails?.id,
               tab: "Orders",
             });
@@ -2745,7 +2745,7 @@ const AdmittedCaseV2 = () => {
         ordersService
           .createOrder(reqBody, { tenantId })
           .then((res) => {
-            history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${res.order.orderNumber}`, {
+            history.push(`/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${res.order.orderNumber}`, {
               caseId: caseId,
               tab: activeTab,
             });
@@ -2791,7 +2791,7 @@ const AdmittedCaseV2 = () => {
         ordersService
           .createOrder(reqBody, { tenantId })
           .then((res) => {
-            history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${res.order.orderNumber}`, {
+            history.push(`/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${res.order.orderNumber}`, {
               caseId: caseId,
               tab: activeTab,
             });
@@ -2847,7 +2847,7 @@ const AdmittedCaseV2 = () => {
         }
 
         history.push(
-          `/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${response?.order?.orderNumber}`,
+          `/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${response?.order?.orderNumber}`,
           { caseId, tab: "Orders" }
         );
       } catch (error) {
@@ -2999,7 +2999,7 @@ const AdmittedCaseV2 = () => {
         });
         refetchCaseData();
         revalidateWorkflow();
-        history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${res.order.orderNumber}`);
+        history.push(`/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${res.order.orderNumber}`);
       })
       .catch((err) => {
         showToast({ isError: true, message: "ORDER_CREATION_FAILED" });

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/CaseOverview.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/CaseOverview.js
@@ -114,7 +114,7 @@ const CaseOverview = ({
   ).sort((hearing1, hearing2) => hearing2.endTime - hearing1.endTime);
 
   const navigateOrdersGenerate = () => {
-    history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}`);
+    history.push(`/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}`);
   };
 
   const orderList = useMemo(
@@ -331,7 +331,7 @@ const CaseOverview = ({
                         onClick={() => {
                           if (order?.status === OrderWorkflowState.DRAFT_IN_PROGRESS) {
                             history.push(
-                              `/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${order?.orderNumber}`
+                              `/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${order?.orderNumber}`
                             );
                           } else if (order?.status === OrderWorkflowState.PENDING_BULK_E_SIGN) {
                             history.push(homePath, { isBulkEsignSelected: true });

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/EvidenceModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/EvidenceModal.js
@@ -1037,7 +1037,7 @@ const EvidenceModal = ({
             },
           });
           history.replace(
-            `/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${response?.order?.orderNumber}`
+            `/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${response?.order?.orderNumber}`
           );
         } catch (error) {
           toast.error(t("SOMETHING_WENT_WRONG"));
@@ -1110,7 +1110,7 @@ const EvidenceModal = ({
               tenantId,
             },
           });
-          history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${res?.order?.orderNumber}`);
+          history.push(`/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${res?.order?.orderNumber}`);
         } catch (error) {}
       } else {
         if (showConfirmationModal.type === "reject") {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/OrderDrafts.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/OrderDrafts.js
@@ -70,7 +70,7 @@ const OrderDrafts = ({ caseData, setOrderModal }) => {
               }}
               onClick={() => {
                 setCurrentOrder(order);
-                history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${order.orderNumber}`, {
+                history.push(`/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${order.orderNumber}`, {
                   caseId: caseId,
                   tab: "Orders",
                 });

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/OrderDrawer.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/OrderDrawer.js
@@ -346,7 +346,7 @@ const OrderDrawer = ({
           try {
             const response = await ordersService.updateOrder(payload, { tenantId: Digit.ULBService.getCurrentTenantId() });
             history.push(
-              `/${window.contextPath}/${userType}/orders/generate-orders?filingNumber=${caseDetails?.filingNumber}&orderNumber=${response?.order?.orderNumber}`
+              `/${window.contextPath}/${userType}/orders/generate-order?filingNumber=${caseDetails?.filingNumber}&orderNumber=${response?.order?.orderNumber}`
             );
           } catch (error) {
             console.error("error", error);
@@ -397,7 +397,7 @@ const OrderDrawer = ({
           try {
             const response = await ordersService.createOrder(payload, { tenantId: Digit.ULBService.getCurrentTenantId() });
             history.push(
-              `/${window.contextPath}/${userType}/orders/generate-orders?filingNumber=${caseDetails?.filingNumber}&orderNumber=${response?.order?.orderNumber}`
+              `/${window.contextPath}/${userType}/orders/generate-order?filingNumber=${caseDetails?.filingNumber}&orderNumber=${response?.order?.orderNumber}`
             );
           } catch (error) {
             console.error("error", error);

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/ReviewLitigantDetails.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/ReviewLitigantDetails.js
@@ -279,7 +279,7 @@ const ReviewLitigantDetails = ({ path }) => {
       const res = await HomeService.customApiService(Urls.dristi.ordersCreate, reqBody, { tenantId });
       if (res.order.orderNumber) {
         history.push(
-          `/${window.contextPath}/employee/orders/generate-orders?filingNumber=${caseDetails?.filingNumber}&orderNumber=${res.order.orderNumber}`
+          `/${window.contextPath}/employee/orders/generate-order?filingNumber=${caseDetails?.filingNumber}&orderNumber=${res.order.orderNumber}`
         );
       }
     } catch (error) {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/ViewAllOrderDrafts.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/ViewAllOrderDrafts.js
@@ -45,7 +45,7 @@ const ViewAllOrderDrafts = ({ t, setShow, draftOrderList, filingNumber }) => {
           <div
             onClick={() => {
               setShow(false);
-              history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${order?.orderNumber}`);
+              history.push(`/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${order?.orderNumber}`);
             }}
             style={{ cursor: "pointer", fontWeight: 500, fontSize: "16px", lineHeight: "20px", color: "#007E7E" }}
           >

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/admission/AdmissionActionModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/admission/AdmissionActionModal.js
@@ -238,7 +238,7 @@ function AdmissionActionModal({
       DRISTIService.customApiService(Urls.dristi.ordersCreate, orderBody, { tenantId })
         .then((res) => {
           history.push(
-            `/${window?.contextPath}/employee/orders/generate-orders?filingNumber=${caseDetails?.filingNumber}&orderNumber=${res.order.orderNumber}`,
+            `/${window?.contextPath}/employee/orders/generate-order?filingNumber=${caseDetails?.filingNumber}&orderNumber=${res.order.orderNumber}`,
             {
               caseId: caseDetails?.id,
               tab: "Orders",

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/admission/CaseFileAdmission.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/admission/CaseFileAdmission.js
@@ -359,7 +359,7 @@ function CaseFileAdmission({ t, path }) {
             },
           });
           history.push(
-            `/${window?.contextPath}/employee/orders/generate-orders?filingNumber=${caseDetails?.filingNumber}&orderNumber=${res.order.orderNumber}`,
+            `/${window?.contextPath}/employee/orders/generate-order?filingNumber=${caseDetails?.filingNumber}&orderNumber=${res.order.orderNumber}`,
             {
               caseId: caseDetails?.id,
               tab: "Orders",
@@ -965,7 +965,7 @@ function CaseFileAdmission({ t, path }) {
     DRISTIService.customApiService(Urls.dristi.ordersCreate, reqBody, { tenantId })
       .then((res) => {
         history.push(
-          `/${window?.contextPath}/employee/orders/generate-orders?filingNumber=${caseDetails?.filingNumber}&orderNumber=${res.order.orderNumber}`,
+          `/${window?.contextPath}/employee/orders/generate-order?filingNumber=${caseDetails?.filingNumber}&orderNumber=${res.order.orderNumber}`,
           {
             caseId: caseId,
             tab: "Orders",
@@ -1093,7 +1093,7 @@ function CaseFileAdmission({ t, path }) {
           },
         });
         history.push(
-          `/${window.contextPath}/employee/orders/generate-orders?filingNumber=${caseDetails?.filingNumber}&orderNumber=${res.order.orderNumber}`
+          `/${window.contextPath}/employee/orders/generate-order?filingNumber=${caseDetails?.filingNumber}&orderNumber=${res.order.orderNumber}`
         );
       })
       .catch((err) => {});

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/admission/ScheduleHearingModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/admission/ScheduleHearingModal.js
@@ -331,7 +331,7 @@ function ScheduleHearing({
               tenantId,
             },
           });
-          history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${res.order.orderNumber}`);
+          history.push(`/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${res.order.orderNumber}`);
           setIsSubmitDisabled(false);
         })
         .catch((err) => {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/hearings/src/components/NextHearingModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/hearings/src/components/NextHearingModal.js
@@ -156,7 +156,7 @@ const NextHearingModal = ({ hearingId, hearing, stepper, setStepper, transcript,
       .createOrder(requestBody, { tenantId: Digit.ULBService.getCurrentTenantId() })
       .then((res) => {
         history.push(
-          `/${window.contextPath}/${userType}/orders/generate-orders?filingNumber=${caseDetails?.filingNumber}&orderNumber=${res.order.orderNumber}`
+          `/${window.contextPath}/${userType}/orders/generate-order?filingNumber=${caseDetails?.filingNumber}&orderNumber=${res.order.orderNumber}`
         );
       })
       .catch((err) => {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/hearings/src/components/SummaryModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/hearings/src/components/SummaryModal.js
@@ -157,7 +157,7 @@ const SummaryModal = ({
       .createOrder(requestBody, { tenantId: Digit.ULBService.getCurrentTenantId() })
       .then((res) => {
         history.push(
-          `/${window.contextPath}/${userType}/orders/generate-orders?filingNumber=${caseDetails?.filingNumber}&orderNumber=${res.order.orderNumber}`
+          `/${window.contextPath}/${userType}/orders/generate-order?filingNumber=${caseDetails?.filingNumber}&orderNumber=${res.order.orderNumber}`
         );
       })
       .catch((err) => {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/hearings/src/pages/employee/EvidenceHeader.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/hearings/src/pages/employee/EvidenceHeader.js
@@ -52,7 +52,7 @@ const EvidenceHearingHeader = ({
         hearingId: hearing.hearingId,
         filingNumber,
       });
-      window.open(`${window.location.origin}/${window.contextPath}/${userType}/${"orders/generate-orders"}?${searchParams.toString()}`, "_blank");
+      window.open(`${window.location.origin}/${window.contextPath}/${userType}/${"orders/generate-order"}?${searchParams.toString()}`, "_blank");
       return;
     }
 

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/hearings/src/pages/employee/ReschedulingPurpose.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/hearings/src/pages/employee/ReschedulingPurpose.js
@@ -152,7 +152,7 @@ export const ReschedulingPurpose = ({ courtData, caseDetails, closeFunc, resched
       .createOrder(requestBody, { tenantId: Digit.ULBService.getCurrentTenantId() })
       .then((res) => {
         history.push(
-          `/${window.contextPath}/${userType}/orders/generate-orders?filingNumber=${caseDetails.filingNumber}&orderNumber=${res.order.orderNumber}`
+          `/${window.contextPath}/${userType}/orders/generate-order?filingNumber=${caseDetails.filingNumber}&orderNumber=${res.order.orderNumber}`
         );
       })
       .catch((err) => {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/hearings/src/pages/employee/SummonsAndWarrantsModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/hearings/src/pages/employee/SummonsAndWarrantsModal.js
@@ -229,7 +229,7 @@ const SummonsAndWarrantsModal = ({ handleClose }) => {
           tenantId,
         },
       });
-      history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${res.order.orderNumber}`);
+      history.push(`/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${res.order.orderNumber}`);
     } catch (error) {}
   };
 

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/components/AdvocateReplacementComponent.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/components/AdvocateReplacementComponent.js
@@ -196,7 +196,7 @@ const AdvocateReplacementComponent = ({ filingNumber, taskNumber, setPendingTask
           tenantId,
         },
       });
-      history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${res?.order?.orderNumber}`);
+      history.push(`/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${res?.order?.orderNumber}`);
     } catch (error) {
       console.error("error", error);
     } finally {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/components/TaskComponent.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/components/TaskComponent.js
@@ -304,7 +304,7 @@ const TasksComponent = ({
               tenantId,
             },
           });
-        history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${res.order.orderNumber}`);
+        history.push(`/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${res.order.orderNumber}`);
       } catch (error) {}
     },
     [history, tenantId]

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/configs/HomeConfig.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/configs/HomeConfig.js
@@ -389,7 +389,7 @@ export const pendingTaskHearingActions = {
     customFunction: "handleCreateOrder",
     // additionalDetailsKeys: ["orderType"],
     redirectDetails: {
-      url: "/orders/generate-orders",
+      url: "/orders/generate-order",
       params: [{ key: "filingNumber", value: "filingNumber" }],
     },
   },
@@ -400,7 +400,7 @@ export const pendingTaskOrderActions = {
     actorName: ["JUDGE"],
     actionName: "Schedule hearing",
     redirectDetails: {
-      url: "/orders/generate-orders",
+      url: "/orders/generate-order",
       params: [{ key: "filingNumber", value: "filingNumber" }],
     },
   },
@@ -410,7 +410,7 @@ export const pendingTaskOrderActions = {
     customFunction: "handleCreateOrder",
     additionalDetailsKeys: ["orderType"],
     redirectDetails: {
-      url: "/orders/generate-orders",
+      url: "/orders/generate-order",
       params: [
         { key: "filingNumber", value: "filingNumber" },
         { key: "applicationNumber", value: "referenceId" },
@@ -421,7 +421,7 @@ export const pendingTaskOrderActions = {
     actorName: ["JUDGE"],
     actionName: "Draft in Progress for Order",
     redirectDetails: {
-      url: "/orders/generate-orders",
+      url: "/orders/generate-order",
       params: [
         { key: "filingNumber", value: "filingNumber" },
         { key: "orderNumber", value: "referenceId" },

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/ADiaryPage.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/ADiaryPage.js
@@ -361,7 +361,7 @@ const ADiaryPage = ({ path }) => {
   const handleRowClick = (entry) => {
     if (entry?.referenceType === "Order") {
       history.push(
-        `/${window?.contextPath}/${userInfoType}/orders/generate-orders?filingNumber=${entry?.additionalDetails?.filingNumber}&orderNumber=${entry?.referenceId}`,
+        `/${window?.contextPath}/${userInfoType}/orders/generate-order?filingNumber=${entry?.additionalDetails?.filingNumber}&orderNumber=${entry?.referenceId}`,
         { diaryEntry: entry }
       );
     }

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/BailBondModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/BailBondModal.js
@@ -204,9 +204,9 @@ const BailBondModal = ({ row, setShowBailModal = () => {}, setUpdateCounter, sho
       const res = await ordersService.createOrder(reqbody, { tenantId });
       //need to check
       if (queryStrings?.filingNumber) {
-        history.replace(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${res?.order?.orderNumber}`);
+        history.replace(`/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${res?.order?.orderNumber}`);
       }
-      history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${res?.order?.orderNumber}`);
+      history.push(`/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${res?.order?.orderNumber}`);
       setShowBailModal(false);
     } catch (error) {
       console.log(error);

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/BulkESignView.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/BulkESignView.js
@@ -189,7 +189,7 @@ function BulkESignView() {
 
         if (order?.status === OrderWorkflowState.DRAFT_IN_PROGRESS) {
           history.push(
-            `/${window.contextPath}/${userType}/orders/generate-orders?filingNumber=${order?.filingNumber}&orderNumber=${order?.orderNumber}`
+            `/${window.contextPath}/${userType}/orders/generate-order?filingNumber=${order?.filingNumber}&orderNumber=${order?.orderNumber}`
           );
         } else if (order?.status === OrderWorkflowState.PENDING_BULK_E_SIGN) {
           history.push(`/${window?.contextPath}/${userType}/home/bulk-esign-order?orderNumber=${order?.orderNumber}`);

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/HomeHearingsTab.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/HomeHearingsTab.js
@@ -254,7 +254,7 @@ const HomeHearingsTab = ({
             {}
           );
           history.push(
-            `/${window.contextPath}/employee/orders/generate-orders?filingNumber=${hearingDetails?.filingNumber}&orderNumber=${response?.order?.orderNumber}`
+            `/${window.contextPath}/employee/orders/generate-order?filingNumber=${hearingDetails?.filingNumber}&orderNumber=${response?.order?.orderNumber}`
           );
         }
         return;

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/ScheduleHearing.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/ScheduleHearing.js
@@ -342,7 +342,7 @@ function ScheduleHearing({
               tenantId,
             },
           });
-          history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${res.order.orderNumber}`);
+          history.push(`/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${res.order.orderNumber}`);
           setIsSubmitDisabled(false);
         })
         .catch((err) => {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/ScheduleNextHearing.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/ScheduleNextHearing.js
@@ -292,7 +292,7 @@ function ScheduleNextHearing({
               tenantId,
             },
           });
-          history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${res.order.orderNumber}`);
+          history.push(`/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${res.order.orderNumber}`);
           setIsSubmitDisabled(false);
         })
         .catch((err) => {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/components/ReIssueSummonsModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/components/ReIssueSummonsModal.js
@@ -132,7 +132,7 @@ function ReIssueSummonsModal() {
         tenantId,
       },
     });
-    history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${res?.order?.orderNumber}`);
+    history.push(`/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${res?.order?.orderNumber}`);
   };
   const handleRescheduleHearing = async () => {
     try {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pageComponents/OrderBulkReviewModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pageComponents/OrderBulkReviewModal.js
@@ -77,7 +77,7 @@ function OrderBulkReviewModal({ t, history, orderDetails }) {
         )
         .then(async (response) => {
           history.replace(
-            `/${window.contextPath}/${userType}/orders/generate-orders?filingNumber=${response?.order?.filingNumber}&orderNumber=${response?.order?.orderNumber}`
+            `/${window.contextPath}/${userType}/orders/generate-order?filingNumber=${response?.order?.filingNumber}&orderNumber=${response?.order?.orderNumber}`
           );
         });
     } catch (e) {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrders.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrders.js
@@ -4067,11 +4067,11 @@ const GenerateOrders = () => {
     }
     if (successModalActionSaveLabel === t("ISSUE_SUMMONS_BUTTON")) {
       await handleIssueSummons(extractedHearingDate, newHearingNumber || hearingId || hearingNumber);
-      history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${createdSummon}`);
+      history.push(`/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${createdSummon}`);
     }
     if (successModalActionSaveLabel === t("ISSUE_NOTICE_BUTTON")) {
       await handleIssueNotice(extractedHearingDate, newHearingNumber || hearingId || hearingNumber);
-      history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${createdNotice}`);
+      history.push(`/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${createdNotice}`);
     }
   };
 

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrdersV2.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrdersV2.js
@@ -2607,7 +2607,7 @@ const GenerateOrdersV2 = () => {
 
       if (!orderNumber || orderNumber === "null" || orderNumber === "undefined" || updateOrderResponse?.order?.orderNumber) {
         history.replace(
-          `/${window.contextPath}/employee/orders/generate-orders?filingNumber=${caseDetails?.filingNumber}&orderNumber=${updateOrderResponse?.order?.orderNumber}`
+          `/${window.contextPath}/employee/orders/generate-order?filingNumber=${caseDetails?.filingNumber}&orderNumber=${updateOrderResponse?.order?.orderNumber}`
         );
       } else {
         await refetchOrdersData();
@@ -3417,11 +3417,11 @@ const GenerateOrdersV2 = () => {
     }
     if (successModalActionSaveLabel === t("ISSUE_SUMMONS_BUTTON")) {
       await handleIssueSummons(extractedHearingDate, hearingId || hearingNumber);
-      history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${createdSummon}`);
+      history.push(`/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${createdSummon}`);
     }
     if (successModalActionSaveLabel === t("ISSUE_NOTICE_BUTTON")) {
       await handleIssueNotice(extractedHearingDate, hearingId || hearingNumber);
-      history.push(`/${window.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}&orderNumber=${createdNotice}`);
+      history.push(`/${window.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}&orderNumber=${createdNotice}`);
     }
   };
 

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/OrdersHome.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/OrdersHome.js
@@ -70,7 +70,7 @@ const OrdersHome = () => {
     ordersService
       .createOrder(reqbody, { tenantId })
       .then(() => {
-        history.push(`/${window?.contextPath}/employee/orders/generate-orders?filingNumber=${filingNumber}`);
+        history.push(`/${window?.contextPath}/employee/orders/generate-order?filingNumber=${filingNumber}`);
       })
       .catch(() => {});
   };

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/index.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/index.js
@@ -103,7 +103,7 @@ const App = ({ path, stateCode, userType, tenants }) => {
         <PrivateRoute path={`${path}/orders-response`} component={() => <OrdersResponse></OrdersResponse>} />
         <PrivateRoute path={`${path}/orders-create`} component={() => <OrdersCreate />} />
         <PrivateRoute path={`${path}/orders-home`} component={() => <OrdersHome />} />
-        <PrivateRoute path={`${path}/generate-orders`} component={() => <GenerateOrdersV2 />} />
+        <PrivateRoute path={`${path}/generate-order`} component={() => <GenerateOrdersV2 />} />
         {/* <PrivateRoute path={`${path}/make-submission`} component={() => <MakeSubmission />} /> */}
         <PrivateRoute path={`${path}/Summons&Notice`} component={() => <ReviewSummonsNoticeAndWarrant />} />
         <PrivateRoute path={`${path}/payment-screen`} component={() => <PaymentStatus />} />


### PR DESCRIPTION
## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized order-generation navigation to a single page: all flows now route to /orders/generate-order.
  - Redirects after creating or updating orders consistently land on the single-order view; existing query parameters (filing number, order number) remain intact.
  - Updated links and actions across Admission, Hearings, Home (tasks, diary, bulk e-sign), and Orders modules to open the new destination.
  - Router updated to reflect the new path, ensuring consistent behavior from drafts, reviews, and modals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->