### PR TITLE
fixed the orderType filter bug

### DIFF
--- a/backend/task/src/main/java/org/pucar/dristi/service/TaskService.java
+++ b/backend/task/src/main/java/org/pucar/dristi/service/TaskService.java
@@ -442,8 +442,10 @@ public class TaskService {
 
         if (orderType.isEmpty()) {
             log.info("No order type found for user roles");
-            request.getPagination().setTotalCount(0D);
-            return new ArrayList<>();
+            if (request.getPagination() != null) {
+                request.getPagination().setTotalCount(0D);
+            }
+            return Collections.emptyList();
         }
         return taskRepository.getTaskWithCaseDetails(request);
 

--- a/backend/task/src/main/java/org/pucar/dristi/service/TaskService.java
+++ b/backend/task/src/main/java/org/pucar/dristi/service/TaskService.java
@@ -467,6 +467,10 @@ public class TaskService {
     private static List<String> getOrderType(TaskCaseSearchRequest request, List<Role> userRoles) {
         List<String> orderType = request.getCriteria().getOrderType();
 
+        if (orderType == null) {
+            orderType = new ArrayList<>();
+        }
+
         if (orderType.isEmpty()) {
             // Add orderType if the user has the corresponding role
             addOrderTypeIfRolePresent(orderType, userRoles, ROLE_VIEW_PROCESS_SUMMONS, SUMMON);


### PR DESCRIPTION
## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Searches without an order type now return an empty list with a total count of 0, avoiding misleading pagination.

* **Improvements**
  * Role-aware filtering of order types is stricter, ensuring users only see permitted order categories in results.
  * More predictable search results and pagination when order type filters are applied or omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->