### PR TITLE
Task editor role for send and update

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/ReviewSummonsNoticeAndWarrant.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/ReviewSummonsNoticeAndWarrant.js
@@ -98,6 +98,8 @@ const ReviewSummonsNoticeAndWarrant = () => {
   const hasSignWarrantAccess = useMemo(() => roles?.some((role) => role?.code === "SIGN_PROCESS_WARRANT"), [roles]);
   const hasSignNoticeAccess = useMemo(() => roles?.some((role) => role?.code === "SIGN_PROCESS_NOTICE"), [roles]);
 
+  const hasEditTaskAccess = useMemo(() => roles?.some((role) => role?.code === "TASK_EDITOR"), [roles]);
+
   const isJudge = roles?.some((role) => role.code === "JUDGE_ROLE");
   const isTypist = roles?.some((role) => role.code === "TYPIST_ROLE");
 
@@ -1201,7 +1203,7 @@ const ReviewSummonsNoticeAndWarrant = () => {
                     <CustomStepperSuccess
                       successMessage={successMessage}
                       bannerSubText={t("PARTY_NOTIFIED_ABOUT_DOCUMENT")}
-                      submitButtonText={documents ? "MARK_AS_SENT" : "CS_CLOSE"}
+                      submitButtonText={documents && hasEditTaskAccess ? "MARK_AS_SENT" : "CS_CLOSE"}
                       closeButtonText={documents ? "CS_CLOSE" : "DOWNLOAD_DOCUMENT"}
                       closeButtonAction={handleClose}
                       submitButtonAction={handleSubmit}
@@ -1246,7 +1248,7 @@ const ReviewSummonsNoticeAndWarrant = () => {
     return {
       handleClose: () => handleCloseActionModal(),
       heading: { label: t("PRINT_SEND_DOCUMENT") },
-      actionSaveLabel: t("MARK_AS_SENT"),
+      actionSaveLabel: hasEditTaskAccess ? t("MARK_AS_SENT") : null,
       isStepperModal: false,
       hideSubmit: isTypist,
       modalBody: (
@@ -1265,7 +1267,7 @@ const ReviewSummonsNoticeAndWarrant = () => {
     return {
       handleClose: () => handleCloseActionModal(),
       heading: { label: t("DELIVERY_STATUS_AND_DETAILS") },
-      actionSaveLabel: t("UPDATE_STATUS"),
+      actionSaveLabel: hasEditTaskAccess ? t("UPDATE_STATUS") : null,
       actionCancelLabel: t("VIEW_DOCUMENT_TEXT"),
       isStepperModal: false,
       modalBody: (
@@ -1541,7 +1543,9 @@ const ReviewSummonsNoticeAndWarrant = () => {
                   disabled={hasNoSelectedItems}
                   style={{ width: "auto" }}
                 />
-                <SubmitBar label={t("SEND_SELECTED_DOCUMENTS")} onSubmit={handleBulkSend} disabled={hasNoSelectedItems || isBulkSending} />
+                {hasEditTaskAccess && (
+                  <SubmitBar label={t("SEND_SELECTED_DOCUMENTS")} onSubmit={handleBulkSend} disabled={hasNoSelectedItems || isBulkSending} />
+                )}
               </div>
             </div>
           )}
@@ -1607,7 +1611,7 @@ const ReviewSummonsNoticeAndWarrant = () => {
           headerBarEnd={<CloseBtn onClick={() => setShowBulkSendConfirmModal(false)} />}
           actionCancelLabel={t("CS_BULK_BACK")}
           actionCancelOnSubmit={() => setShowBulkSendConfirmModal(false)}
-          actionSaveLabel={t("MARK_AS_SENT")}
+          actionSaveLabel={hasEditTaskAccess ? t("MARK_AS_SENT") : null}
           actionSaveOnSubmit={handleBulkSendConfirm}
           style={{ height: "40px", background: "#007E7E" }}
           popupStyles={{ width: "35%" }}


### PR DESCRIPTION
## Requirements



- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Role-based controls on Review Summons/Notice/Warrant: users with task editing permission can send documents; others see view/close options only.
  * Button labels now adapt to permissions and document status (e.g., Mark as Sent vs Close).
  * Bulk actions respect permissions: “Send Selected Documents” appears only for authorized users on the Signed tab.
  * Modal dialogs dynamically adjust action availability and labels based on user permissions for clearer, consistent workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->