### PR TITLE
sent popup coming in signed tab

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/ReviewSummonsNoticeAndWarrant.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/ReviewSummonsNoticeAndWarrant.js
@@ -1507,13 +1507,20 @@ const ReviewSummonsNoticeAndWarrant = () => {
               {showActionModal && (
                 <DocumentModal
                   config={
-                    config?.label === "SENT"
-                      ? sentModalConfig
-                      : hasSignedDoc
-                      ? signedModalConfig
-                      : actionModalType === "SIGN_PENDING"
+                    config?.label === "PENDING_SIGN"
                       ? unsignedModalConfig
+                      : config?.label === "SIGNED"
+                      ? signedModalConfig
+                      : config?.label === "SENT"
+                      ? sentModalConfig
                       : signedModalConfig
+                    // config?.label === "SENT"
+                    //   ? sentModalConfig
+                    //   : hasSignedDoc
+                    //   ? signedModalConfig
+                    //   : actionModalType === "SIGN_PENDING"
+                    //   ? unsignedModalConfig
+                    //   : signedModalConfig
                   }
                   currentStep={step}
                 />


### PR DESCRIPTION
## Requirements

#4753

- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected which document modal appears on the Review Summons, Notice & Warrant page based on the active tab. “Pending Sign” now shows the unsigned document modal, “Signed” shows the signed modal, “Sent” shows the sent modal, and other tabs default to the signed view. This ensures consistent, accurate modals per tab, reducing confusion and improving workflow clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->