### PR TITLE
Changes in canSign and btn visibility

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/ReviewSummonsNoticeAndWarrant.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/ReviewSummonsNoticeAndWarrant.js
@@ -1528,7 +1528,7 @@ const ReviewSummonsNoticeAndWarrant = () => {
               {showNoticeModal && <ReviewNoticeModal infos={ReviewInfo} rowData={rowData} handleCloseNoticeModal={handleCloseNoticeModal} t={t} />}
             </div>
           </div>
-          {canSign && config?.label === "PENDING_SIGN" && (
+          {config?.label === "PENDING_SIGN" && (
             <div className={"bulk-submit-bar"}>
               <div style={{ justifyContent: "space-between", width: "fit-content", display: "flex", gap: 20 }}>
                 <SubmitBar
@@ -1537,11 +1537,11 @@ const ReviewSummonsNoticeAndWarrant = () => {
                   disabled={hasNoSelectedItems}
                   style={{ width: "auto" }}
                 />
-                <SubmitBar label={t("SIGN_SELECTED_DOCUMENTS")} onSubmit={handleBulkSign} disabled={hasNoSelectedItems} />
+                {canSign && <SubmitBar label={t("SIGN_SELECTED_DOCUMENTS")} onSubmit={handleBulkSign} disabled={hasNoSelectedItems} />}
               </div>
             </div>
           )}
-          {canSign && config?.label === "SIGNED" && (
+          {config?.label === "SIGNED" && (
             <div className={"bulk-submit-bar"}>
               <div style={{ justifyContent: "space-between", width: "fit-content", display: "flex", gap: 20 }}>
                 <SubmitBar


### PR DESCRIPTION
## Requirements

#4623

- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Fixed visibility of bulk action bars in Review Summons, Notice, and Warrant: PENDING_SIGN and SIGNED sections now appear based on status instead of signing permission.
  - SIGN Selected Documents button now shows only for users with signing permission, preventing unavailable actions for others.
  - Download Selected Documents remains available in PENDING_SIGN and SIGNED where applicable, ensuring consistent access to downloads across roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->