### PR TITLE
disabled hearing button if hearing is not in progress- develop

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/NextHearingCard.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/NextHearingCard.js
@@ -187,7 +187,7 @@ const NextHearingCard = ({ caseData, width, minWidth, cardStyle }) => {
           <Button
             variation={"outlined"}
             onButtonClick={handleButtonClick}
-            isDisabled={roles.includes("CITIZEN") && scheduledHearing?.status === "SCHEDULED"}
+            isDisabled={scheduledHearing?.status !== "IN_PROGRESS"}
             label={
               scheduledHearing?.status === "SCHEDULED"
                 ? t("AWAIT_START_HEARING")
@@ -195,6 +195,9 @@ const NextHearingCard = ({ caseData, width, minWidth, cardStyle }) => {
                 ? t("JOIN_HEARING")
                 : t("PASSED_OVER")
             }
+            style={{
+             ...(scheduledHearing?.status !== "IN_PROGRESS" ? {cursor: "default"} : {cursor: "pointer"})
+            }}
           />
         )}
       </div>


### PR DESCRIPTION
## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Button availability on Next Hearing cards now consistently reflects hearing status: clickable only during “In Progress,” disabled otherwise.
- Style
  - Cursor feedback updated: shows pointer when actionable and default when disabled.
- Bug Fixes
  - Eliminates role-based inconsistencies in button behavior, ensuring all users see the same status-driven enable/disable state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->