### PR TITLE
[bug 4690] cherrypick for develop

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/css/src/dristi/eFiling.scss
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/css/src/dristi/eFiling.scss
@@ -502,6 +502,13 @@
     color: #0a0a0a;
   }
 
+  .toast-success.error {
+    h2 {
+      font-weight: normal !important;
+      color: white !important;
+    }
+  }
+
   .custom-text-area-main-div {
     .custom-text-area-header-div {
       gap: 12px !important;


### PR DESCRIPTION
issue: https://github.com/pucardotorg/dristi/issues/4690
fix: css override for error toast
## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined visual styling for certain toast notifications that show both success and error states. Headlines now appear with normal font weight and white text for improved contrast and readability.
  * Delivers a clearer, more consistent appearance for these mixed-status messages without changing behavior or layout elsewhere.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->