### PR TITLE
Change next hearing button link to go to order screen

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrdersV2.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrdersV2.js
@@ -1169,55 +1169,64 @@ const GenerateOrdersV2 = () => {
   }, [data, currentInProgressHearing, todayScheduledHearing]);
 
   const nextHearing = useCallback(
-    (isStartHearing) => {
-      if (data?.length === 0) {
-        history.push(`/${window?.contextPath}/employee/home/home-screen`);
-      } else {
-        const validData = data?.filter((item) => ["SCHEDULED", "PASSED_OVER", "IN_PROGRESS"]?.includes(item?.businessObject?.hearingDetails?.status));
-        const index = validData?.findIndex(
+    async () => {
+      try {
+        const validData = (data || []).filter((item) =>
+          ["SCHEDULED", "PASSED_OVER", "IN_PROGRESS"].includes(item?.businessObject?.hearingDetails?.status)
+        );
+
+        if (!validData?.length) {
+          setShowErrorToast({ error: true, label: t("No next hearing with a draft order found") });
+          return;
+        }
+
+        const currentIndex = validData?.findIndex(
           (item) => item?.businessObject?.hearingDetails?.hearingNumber === (currentInProgressHearing?.hearingId || todayScheduledHearing?.hearingId)
         );
-        if (index === -1 || validData?.length === 1) {
-          history.push(`/${window?.contextPath}/employee/home/home-screen`);
-        } else {
-          const row = validData[(index + 1) % validData?.length];
-          if (["SCHEDULED", "PASSED_OVER"].includes(row?.businessObject?.hearingDetails?.status)) {
-            if (isStartHearing) {
-              hearingService
-                .searchHearings(
-                  {
-                    criteria: {
-                      hearingId: row?.businessObject?.hearingDetails?.hearingNumber,
-                      tenantId: row?.businessObject?.hearingDetails?.tenantId,
-                      ...(row?.businessObject?.hearingDetails?.courtId &&
-                        userType === "employee" && { courtId: row?.businessObject?.hearingDetails?.courtId }),
-                    },
-                  },
-                  { tenantId: row?.businessObject?.hearingDetails?.tenantId }
-                )
-                .then((response) => {
-                  hearingService.startHearing({ hearing: response?.HearingList?.[0] }).then(() => {
-                    window.location = `/${window.contextPath}/${userType}/dristi/home/view-case?caseId=${row?.businessObject?.hearingDetails?.caseUuid}&filingNumber=${row?.businessObject?.hearingDetails?.filingNumber}&tab=Overview`;
-                  });
-                })
-                .catch((error) => {
-                  console.error("Error starting hearing", error);
-                  history.push(`/${window?.contextPath}/employee/home/home-screen`);
-                });
-            } else {
-              history.push(
-                `/${window?.contextPath}/employee/dristi/home/view-case?caseId=${row?.businessObject?.hearingDetails?.caseUuid}&filingNumber=${row?.businessObject?.hearingDetails?.filingNumber}&tab=Overview`
-              );
-            }
-          } else {
-            history.push(
-              `/${window?.contextPath}/employee/dristi/home/view-case?caseId=${row?.businessObject?.hearingDetails?.caseUuid}&filingNumber=${row?.businessObject?.hearingDetails?.filingNumber}&tab=Overview`
+
+        for (let step = 1; step < validData.length; step++) {
+          const row = validData[(Math.max(currentIndex, 0) + step) % validData.length];
+          const nextFiling = row?.businessObject?.hearingDetails?.filingNumber;
+          const nextTenantId = row?.businessObject?.hearingDetails?.tenantId || tenantId;
+          const nextCourtId = row?.businessObject?.hearingDetails?.courtId;
+          const nextHearingNumber = row?.businessObject?.hearingDetails?.hearingNumber;
+          if (!nextFiling) continue;
+
+          try {
+            const response = await ordersService.searchOrder(
+              {
+                tenantId: nextTenantId,
+                criteria: {
+                  tenantId: nextTenantId,
+                  filingNumber: nextFiling,
+                  hearingNumber: nextHearingNumber,
+                  applicationNumber: "",
+                  status: OrderWorkflowState.DRAFT_IN_PROGRESS,
+                  ...(nextCourtId && { courtId: nextCourtId }),
+                },
+                pagination: { limit: 1, offset: 0 },
+              },
+              { tenantId: nextTenantId }
             );
+
+            const orderDraft = response?.list?.[0];
+            if (orderDraft?.orderNumber) {
+              history.push(
+                `/${window.contextPath}/${userType}/orders/generate-order?filingNumber=${nextFiling}&orderNumber=${orderDraft.orderNumber}`
+              );
+              return;
+            }
+          } catch (e) {
+            // continue to next item on error
           }
         }
+
+        setShowErrorToast({ error: true, label: t("No next hearing with a draft order found") });
+      } catch (e) {
+        setShowErrorToast({ error: true, label: t("No next hearing with a draft order found") });
       }
     },
-    [currentInProgressHearing, todayScheduledHearing, data, history, userType]
+    [data, currentInProgressHearing, todayScheduledHearing, ordersService, tenantId, caseCourtId, history, userType, t]
   );
 
   // TODO: temporary Form Config, need to be replaced with the actual config
@@ -3640,7 +3649,7 @@ const GenerateOrdersV2 = () => {
 
   const handleNextHearingClick = async () => {
     await handleSaveDraft(currentOrder);
-    nextHearing(false);
+    nextHearing();
   };
 
   const handleGoBack = async () => {
@@ -3657,7 +3666,7 @@ const GenerateOrdersV2 = () => {
       <div className="generate-orders-v2-content">
         <div className="generate-orders-v2-header">
           <Header>{`${t("CS_ORDER")} : ${caseDetails?.caseTitle}`}</Header>
-          {(isJudge || isTypist) && !hideNextHearingButton && (
+          {(isJudge || isTypist) && (
             <Button
               variation={"primary"}
               label={t("CS_CASE_NEXT_HEARING")}


### PR DESCRIPTION
## Requirements

#4822

- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced next hearing navigation flow with improved error handling and better resilience when searching for corresponding draft orders
* Simplified the Next Hearing button visibility condition for judges and typists
* Provides clearer error notifications when draft orders cannot be located during the navigation process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->