### PR TITLE
Make generate order button visible outside for typist

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCaseV2.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCaseV2.js
@@ -3144,10 +3144,6 @@ const AdmittedCaseV2 = () => {
                   label: "END_HEARING",
                 },
                 {
-                  value: "GENERATE_ORDER",
-                  label: "GENERATE_ORDER",
-                },
-                {
                   value: "SUBMIT_DOCUMENTS",
                   label: "SUBMIT_DOCUMENTS",
                 },
@@ -3647,6 +3643,14 @@ const AdmittedCaseV2 = () => {
                               onButtonClick={() => handleEmployeeAction({ value: "VIEW_CALENDAR" })}
                               style={{ boxShadow: "none" }}
                             ></Button>
+                            {!hasHearingPriorityView && userRoles?.includes("ORDER_CREATOR") && (
+                              <Button
+                                variation={"outlined"}
+                                label={t("CS_CASE_GENERATE_ORDER")}
+                                onButtonClick={() => handleEmployeeAction({ value: "GENERATE_ORDER" })}
+                                style={{ boxShadow: "none" }}
+                              ></Button>
+                            )}
                             {hasHearingPriorityView && hasHearingEditAccess && (
                               <Button
                                 variation={"outlined"}


### PR DESCRIPTION
## Requirements
#4821



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Interface**
  * Reorganized the Generate Order functionality to appear as a dedicated button instead of a dropdown option for eligible users during active hearing sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->