### PR TITLE
download submission after submit documents via upload flow -> fix

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/SelectCustomFormatterTextArea.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/SelectCustomFormatterTextArea.js
@@ -94,7 +94,7 @@ const SelectCustomFormatterTextArea = ({ t, config, formData = {}, onSelect, err
   // race conditions where a stale parent update overwrites a user's recent clear.
   useEffect(() => {
     const nextFromProps = initialHtml;
-    if (nextFromProps !== editorHtml && nextFromProps !== lastEmittedValueRef.current) {
+    if (nextFromProps !== editorHtml) {
       setEditorHtml(nextFromProps);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/WitnessDrawerV2.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/WitnessDrawerV2.js
@@ -782,21 +782,16 @@ const WitnessDrawerV2 = ({
   };
 
   const isWitnessTypeDisabled = useMemo(() => {
-    const party = allParties?.find(
-      (p) =>
-        p?.uuid === selectedWitness?.value ||
-        p?.uniqueId === selectedWitness?.value
-    );
+    const party = allParties?.find((p) => p?.uuid === selectedWitness?.value || p?.uniqueId === selectedWitness?.value);
 
     // Check if tag ends with a number
     const hasNumberSuffix = (tag) => {
       if (!tag || !tag.trim()) return false;
-      return /\d+$/.test(tag);   // same as Java's ".*\\d+$"
+      return /\d+$/.test(tag); // same as Java's ".*\\d+$"
     };
 
     return hasNumberSuffix(party?.tag);
   }, [selectedWitness, allParties]);
-
 
   const handleConfirmWitnessAndSign = async (evidence) => {
     try {
@@ -962,6 +957,7 @@ const WitnessDrawerV2 = ({
       setLoader(false);
       setShowsignatureModal(false);
       setShowUploadSignature(false);
+      setWitnessDepositionText("");
     }
   };
 
@@ -1165,9 +1161,6 @@ const WitnessDrawerV2 = ({
     }
   };
 
-  if (isFilingTypeLoading || isEvidenceLoading || caseApiLoading) {
-    return <Loader />;
-  }
   const CONFIG_KEY = "witnessDeposition";
   const FIELD_NAME = "comment";
 
@@ -1182,6 +1175,10 @@ const WitnessDrawerV2 = ({
       setWitnessDepositionText(value[FIELD_NAME]);
     }
   };
+
+  if (isFilingTypeLoading || isEvidenceLoading || caseApiLoading) {
+    return <Loader />;
+  }
 
   const isDisabled = isProceeding;
 
@@ -1361,7 +1358,14 @@ const WitnessDrawerV2 = ({
               <div style={{ marginTop: "16px" }}>{t("CS_DESCRIPTION")}</div>
 
               <div style={{ gap: "16px", border: "1px solid" }} className="witness-editor">
-                <SelectCustomFormatterTextArea t={t} config={config} formData={formData} onSelect={onSelect} errors={{}} />
+                <SelectCustomFormatterTextArea
+                  key={`${activeTabIndex}-${selectedWitness?.value}-${currentArtifactNumber}`}
+                  t={t}
+                  config={config}
+                  formData={formData}
+                  onSelect={onSelect}
+                  errors={{}}
+                />
                 {IsSelectedWitness && (
                   <TranscriptComponent
                     setWitnessDepositionText={setWitnessDepositionText}
@@ -1504,6 +1508,7 @@ const WitnessDrawerV2 = ({
               evidenceRefetch();
               setCurrentEvidence(null);
               setWitnessDepositionUploadLoader(false);
+              setWitnessDepositionText("");
             }}
             message={"WITNESS_DEPOSITION_SUCCESS_BANNER_HEADER"}
           />

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/pages/employee/SubmissionDocuments.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/pages/employee/SubmissionDocuments.js
@@ -338,6 +338,8 @@ const SubmissionDocuments = ({ path }) => {
             },
           },
         };
+        const updateIdForDownload = signedDocumentUploadedID !== "" ? signedDocumentUploadedID : localStorageID;
+        setSignedDocumentUploadID(updateIdForDownload);
         sessionStorage.removeItem("fileStoreId");
         evidence = await DRISTIService.updateEvidence(evidenceReqBody);
         await createPendingTask({


### PR DESCRIPTION
file store id for uplaoad flow in nsubmit documents, key introduced in witness deposition text editor

## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS or workflow data changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Witness deposition text now clears properly after evidence submission and acknowledgment
  * Component state correctly resets when switching between tabs and witnesses
  * Document download identifier handling improved for the signing workflow

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->