### PR TITLE
Age Validation of complainent and accused [Filing Bugs] Missing Data …

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingCases.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingCases.js
@@ -2134,9 +2134,29 @@ function EFilingCases({ path }) {
       if(isValidationError){
         return;
       }
-    }
+      if (
+  formdata
+  ?.filter((data) => data.isenabled)
+  ?.some((data) =>
+  ageValidation({
+  formData: data?.data,
+  selected: "complainantAge",
+  setFormErrors: setFormErrors.current,
+  clearFormDataErrors:clearFormDataErrors.current,
+  })
+  )
+  ) {
+  isValidationError = isValidationError || true;
+  }
+  if(isValidationError){
+  return;
+  }
 
+    }
+    
+  
     if (selected === "respondentDetails") {
+      let isValidationError = false;
       if (
         formdata
           ?.filter((data) => data.isenabled)
@@ -2146,13 +2166,31 @@ function EFilingCases({ path }) {
               selected: selected === "complainantDetails" ? "complainantType" : "respondentType",
               setAddressError,
               config: modifiedFormConfig[index],
+              setFormErrors: setFormErrors.current,
             })
           )
       ) {
-        return;
+        isValidationError = true;
       }
+     if (
+  formdata
+  ?.filter((data) => data.isenabled)
+  ?.some((data) =>
+  ageValidation({
+  formData: data?.data,
+  selected: "respondentAge",
+  setFormErrors: setFormErrors.current,
+  clearFormDataErrors:clearFormDataErrors.current,
+  })
+  )
+  ) {
+  isValidationError = isValidationError || true;
+  }
+  if(isValidationError){
+  return;
+  }
     }
-
+ 
     if (
       formdata
         .filter((data) => data.isenabled)

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EfilingValidationUtils.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EfilingValidationUtils.js
@@ -339,6 +339,7 @@ export const checkNameValidation = ({ formData, setValue, selected, reset, index
       formData?.witnessDesignation ||
       formData?.witnessAge ||
       formData?.complainantAge ||
+      formData?.respondentAge||
       formData?.poaAge
     ) {
       const formDataCopy = structuredClone(formData);
@@ -1097,7 +1098,26 @@ export const ageValidation = ({ formData, selected, setFormErrors, clearFormData
     }
     clearFormDataErrors("poaAge");
   }
-};
+  else
+    if (selected === "complainantAge"){
+    const complainantAge = parseInt(formData?.complainantAge, 10);
+    if (complainantAge < 18 || complainantAge > 999) {
+      setFormErrors("complainantAge", { message: "ONLY_AGE_ALLOWED" }); 
+      return true;
+    } 
+    clearFormDataErrors("complainantAge"); 
+  }
+  else
+    if (selected === "respondentAge"){
+    const respondentAge = parseInt(formData?.respondentAge, 10);
+    if (respondentAge < 18 || respondentAge > 999) {
+      setFormErrors("respondentAge", { message: "ONLY_AGE_ALLOWED" }); 
+      return true;
+    } 
+    clearFormDataErrors("respondentAge"); 
+  } 
+}
+
 
 export const addressValidation = ({ formData, selected, setAddressError, config }) => {
   if (


### PR DESCRIPTION
…Validations on Old eFiling Screen

## Requirements

#4844

- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added age validation for complainants and respondents in e-filing cases
  * Age fields now require numeric values between 18–999; invalid entries are blocked from submission with error messages

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->