### PR TITLE
Fix for prayer data persistance and save draft fix for productions of…

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/pages/employee/SubmissionsCreate.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/pages/employee/SubmissionsCreate.js
@@ -671,6 +671,7 @@ const SubmissionsCreate = ({ path }) => {
             name: `APPLICATION_TYPE_${applicationTypeParam}`,
           },
         }),
+        prayer: { text: "" },
       };
     } else if (hearingId && hearingsData?.HearingList?.[0]?.startTime && applicationTypeUrl) {
       let selectComplainant = null;
@@ -689,6 +690,7 @@ const SubmissionsCreate = ({ path }) => {
         },
         applicationDate: formatDate(new Date()),
         ...(selectComplainant !== null ? { selectComplainant } : {}),
+        prayer: { text: "" },
       };
     } else if (orderNumber) {
       if ((isComposite ? compositeMandatorySubmissionItem : orderDetails)?.orderType === orderTypes.MANDATORY_SUBMISSIONS_RESPONSES) {
@@ -729,6 +731,7 @@ const SubmissionsCreate = ({ path }) => {
               : orderDetails?.additionalDetails?.formdata?.documentType,
             initialSubmissionDate: initialSubmissionDate,
             ...(selectComplainant !== undefined ? { selectComplainant } : {}),
+            prayer: { text: "" },
           };
         } else {
           const currentLitigant = complainantsList?.find((c) => c?.uuid === litigant);
@@ -749,6 +752,7 @@ const SubmissionsCreate = ({ path }) => {
             refOrderId: orderDetails?.orderNumber,
             applicationDate: formatDate(new Date()),
             ...(selectComplainant !== undefined ? { selectComplainant } : {}),
+            prayer: { text: "" },
           };
         }
       } else if ((isComposite ? compositeWarrantItem : orderDetails)?.orderType === orderTypes.WARRANT) {
@@ -763,6 +767,7 @@ const SubmissionsCreate = ({ path }) => {
           },
           refOrderId: orderDetails?.orderNumber,
           applicationDate: formatDate(new Date()),
+          prayer: { text: "" },
         };
       } else if ((isComposite ? compositeSetTermBailItem : orderDetails)?.orderType === orderTypes.SET_BAIL_TERMS) {
         const currentLitigant = complainantsList?.find((c) => c?.uuid === litigant);
@@ -781,6 +786,7 @@ const SubmissionsCreate = ({ path }) => {
           refOrderId: orderDetails?.orderNumber,
           applicationDate: formatDate(new Date()),
           ...(selectComplainant !== undefined ? { selectComplainant } : {}),
+          prayer: { text: "" },
         };
       } else {
         return {
@@ -789,6 +795,7 @@ const SubmissionsCreate = ({ path }) => {
             name: "APPLICATION",
           },
           applicationDate: formatDate(new Date()),
+          prayer: { text: "" },
         };
       }
     } else if (applicationType) {
@@ -814,6 +821,7 @@ const SubmissionsCreate = ({ path }) => {
           : {}),
         ...(selectComplainant !== null ? { selectComplainant } : {}),
         ...(formdata || {}),
+        prayer: { text: "" },
       };
     } else {
       return {
@@ -822,6 +830,7 @@ const SubmissionsCreate = ({ path }) => {
           name: "APPLICATION",
         },
         applicationDate: formatDate(new Date()),
+        prayer: { text: "" },
       };
     }
   }, [
@@ -1112,21 +1121,26 @@ const SubmissionsCreate = ({ path }) => {
         //   (await Promise.all(documentsList?.map((doc, idx) => onDocumentUpload(doc, uploadFileNames?.[idx] || doc?.name, tenantId)))) || [];
         let file = null;
         const uploadedDocumentList = [...(documentsList || []), ...applicationDocuments];
-        uploadedDocumentList.forEach((res, index) => {
-          const resolvedName = res?.filename || res?.additionalDetails?.name || res?.name;
-          file = {
-            documentType: res?.fileType,
-            fileStore: res?.fileStore || res?.file?.files?.[0]?.fileStoreId,
-            documentOrder: index,
-            fileName: resolvedName,
-            additionalDetails: {
-              name: resolvedName,
-              documentType: res?.additionalDetails?.documentType,
-              documentTitle: res?.additionalDetails?.documentTitle,
-            },
-          };
-          documents.push(file);
-        });
+        if (uploadedDocumentList.length > 0) {
+          uploadedDocumentList.forEach((res, index) => {
+            const fileStore = res?.fileStore || res?.file?.files?.[0]?.fileStoreId;
+            if (!fileStore) return;
+            const resolvedName = res?.filename || res?.additionalDetails?.name || res?.name;
+            const file = {
+              documentType: res?.fileType,
+              fileStore: fileStore,
+              documentOrder: index,
+              fileName: resolvedName,
+              additionalDetails: {
+                name: resolvedName,
+                documentType: res?.additionalDetails?.documentType,
+                documentTitle: res?.additionalDetails?.documentTitle,
+              },
+            };
+
+            documents.push(file);
+          });
+        }
       }
 
       let applicationSchema = {};


### PR DESCRIPTION
… documents

## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prayer field support added to submission forms across all initialization workflows, providing expanded options for user data entry.

* **Bug Fixes**
  * Document upload validation improved with enhanced checks to ensure only complete file references are processed, preventing incomplete entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->