### PR TITLE
auto populate advocate bar details in re registration flow

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/Home/TakeUserToRegistration.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/Home/TakeUserToRegistration.js
@@ -6,7 +6,7 @@ import { ReactComponent as RegisterImage } from "./ImageUpload/image/register.sv
 import { ReactComponent as RightArrow } from "./ImageUpload/image/arrow_forward.svg";
 import { getFileByFileStore } from "../../../Utils";
 
-function TakeUserToRegistration({ message, isRejected, data, userType }) {
+function TakeUserToRegistration({ message, isRejected, data, advocate }) {
   const { t } = useTranslation();
   const history = useHistory();
 
@@ -30,6 +30,9 @@ function TakeUserToRegistration({ message, isRejected, data, userType }) {
 
       const uri = `${window.location.origin}/filestore/v1/files/id?tenantId=${individual?.tenantId}&fileStoreId=${identifierIdDetails?.fileStoreId}`;
       const file = await getFileByFileStore(uri, identifierIdDetails?.filename);
+
+      const barCouncilUri = `${window.location.origin}/filestore/v1/files/id?tenantId=${advocate?.tenantId}&fileStoreId=${advocate?.documents?.[0]?.fileStore}`;
+      const barCouncilFile = await getFileByFileStore(barCouncilUri, advocate?.documents?.[0]?.additionalDetails?.fileName);
 
       const permanentAddress = individual?.address?.find((a) => a.type === "PERMANENT");
       const correspondenceAddress = individual?.address?.find((a) => a.type === "CORRESPONDENCE");
@@ -88,6 +91,20 @@ function TakeUserToRegistration({ message, isRejected, data, userType }) {
           IdType: identifierTypeData?.find((identifier) => identifier?.type === individual?.identifiers[0]?.identifierType) || {},
           filename: identifierIdDetails?.filename || "",
         },
+        formData: {
+          clientDetails: {
+            barCouncilId: [
+              [
+                advocate?.documents?.[0]?.additionalDetails?.fileName || "",
+                {
+                  file: barCouncilFile,
+                  fileStoreId: advocate?.documents?.[0]?.fileStore || "",
+                },
+              ],
+            ],
+            barRegistrationNumber: advocate?.barRegistrationNumber || "",
+          },
+        },
       };
     }
 
@@ -95,7 +112,7 @@ function TakeUserToRegistration({ message, isRejected, data, userType }) {
       ? history.push(`/${window?.contextPath}/citizen/dristi/home/registration/user-name`)
       : history.push(`/${window?.contextPath}/citizen/dristi/home/registration/email`, {
           newParams: { ...data, ...params, isRejected: isRejected },
-          userType: userType,
+          userType: advocate?.additionalDetails?.userType,
         });
   };
   return (

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/Home/index.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/Home/index.js
@@ -166,7 +166,7 @@ function CitizenHome({ tenantId, setHideBack }) {
           message={isRejected ? `${t("CS_REJECT_MESSAGE")} due to ${rejectionReason}. ${t("KINDLY_REGISTER_AGAIN")}` : t("CS_REGISTRATION_MESSAGE")}
           isRejected={isRejected}
           data={data}
-          userType={searchResult?.[0]?.additionalDetails?.userType}
+          advocate={searchResult?.[0]}
         />
       )}
     </div>

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/Login/SelectId.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/Login/SelectId.js
@@ -64,6 +64,35 @@ function SelectId({ config, t, params, history, onSelect, pathOnRefresh }) {
         const fileStoreId = newParams?.uploadedDocument?.filedata?.files?.[0]?.fileStoreId;
         const filename = newParams?.uploadedDocument?.filename;
 
+        const barCouncilFileStoreId = newParams?.formData?.clientDetails?.barCouncilId?.[1]?.fileStoreId;
+        const barCouncilFilename = newParams?.formData?.clientDetails?.barCouncilId?.[0];
+
+        if (barCouncilFileStoreId && barCouncilFilename) {
+          const barCouncilUri = `${
+            window.location.origin
+          }/filestore/v1/files/id?tenantId=${Digit.ULBService.getCurrentTenantId()}&fileStoreId=${barCouncilFileStoreId}`;
+          const barCouncilFile = await getFileByFileStore(barCouncilUri, barCouncilFilename);
+
+          newParams = {
+            ...newParams,
+            formData: {
+              ...newParams.formData,
+              clientDetails: {
+                ...newParams.formData.clientDetails,
+                barCouncilId: [
+                  [
+                    barCouncilFilename,
+                    {
+                      file: barCouncilFile,
+                      fileStoreId: barCouncilFileStoreId,
+                    },
+                  ],
+                ],
+              },
+            },
+          };
+        }
+
         if (fileStoreId && filename) {
           const uri = `${window.location.origin}/filestore/v1/files/id?tenantId=${Digit.ULBService.getCurrentTenantId()}&fileStoreId=${fileStoreId}`;
           const file = await getFileByFileStore(uri, filename);

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/registration/AdvocateClerkAdditionalDetail.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/registration/AdvocateClerkAdditionalDetail.js
@@ -170,6 +170,35 @@ function AdvocateClerkAdditionalDetail({ params, setParams, path, config, pathOn
         const fileStoreId = newParams?.uploadedDocument?.filedata?.files?.[0]?.fileStoreId;
         const filename = newParams?.uploadedDocument?.filename;
 
+        const barCouncilFileStoreId = newParams?.formData?.clientDetails?.barCouncilId?.[1]?.fileStoreId;
+        const barCouncilFilename = newParams?.formData?.clientDetails?.barCouncilId?.[0];
+
+        if (barCouncilFileStoreId && barCouncilFilename) {
+          const barCouncilUri = `${
+            window.location.origin
+          }/filestore/v1/files/id?tenantId=${Digit.ULBService.getCurrentTenantId()}&fileStoreId=${barCouncilFileStoreId}`;
+          const barCouncilFile = await getFileByFileStore(barCouncilUri, barCouncilFilename);
+
+          newParams = {
+            ...newParams,
+            formData: {
+              ...newParams.formData,
+              clientDetails: {
+                ...newParams.formData.clientDetails,
+                barCouncilId: [
+                  [
+                    barCouncilFilename,
+                    {
+                      file: barCouncilFile,
+                      fileStoreId: barCouncilFileStoreId,
+                    },
+                  ],
+                ],
+              },
+            },
+          };
+        }
+
         if (fileStoreId && filename) {
           const uri = `${window.location.origin}/filestore/v1/files/id?tenantId=${Digit.ULBService.getCurrentTenantId()}&fileStoreId=${fileStoreId}`;
           const file = await getFileByFileStore(uri, filename);
@@ -212,7 +241,7 @@ function AdvocateClerkAdditionalDetail({ params, setParams, path, config, pathOn
         }}
         isDisabled={isDisabled}
         label={"CS_COMMON_CONTINUE"}
-        defaultValues={{ ...params?.registrationData } || {}}
+        defaultValues={{ ...params?.formData } || {}}
         submitInForm
         onFormValueChange={onFormValueChange}
       ></FormComposerV2>

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/registration/SelectName.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/registration/SelectName.js
@@ -30,6 +30,35 @@ const SelectName = ({ config, t, onSubmit, isDisabled, params, history, value, i
         const fileStoreId = newParams?.uploadedDocument?.filedata?.files?.[0]?.fileStoreId;
         const filename = newParams?.uploadedDocument?.filename;
 
+        const barCouncilFileStoreId = newParams?.formData?.clientDetails?.barCouncilId?.[1]?.fileStoreId;
+        const barCouncilFilename = newParams?.formData?.clientDetails?.barCouncilId?.[0];
+
+        if (barCouncilFileStoreId && barCouncilFilename) {
+          const barCouncilUri = `${
+            window.location.origin
+          }/filestore/v1/files/id?tenantId=${Digit.ULBService.getCurrentTenantId()}&fileStoreId=${barCouncilFileStoreId}`;
+          const barCouncilFile = await getFileByFileStore(barCouncilUri, barCouncilFilename);
+
+          newParams = {
+            ...newParams,
+            formData: {
+              ...newParams.formData,
+              clientDetails: {
+                ...newParams.formData.clientDetails,
+                barCouncilId: [
+                  [
+                    barCouncilFilename,
+                    {
+                      file: barCouncilFile,
+                      fileStoreId: barCouncilFileStoreId,
+                    },
+                  ],
+                ],
+              },
+            },
+          };
+        }
+
         if (fileStoreId && filename) {
           const uri = `${window.location.origin}/filestore/v1/files/id?tenantId=${Digit.ULBService.getCurrentTenantId()}&fileStoreId=${fileStoreId}`;
           const file = await getFileByFileStore(uri, filename);

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/registration/SelectUserAddress.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/registration/SelectUserAddress.js
@@ -63,6 +63,35 @@ const SelectUserAddress = ({ config, onSelect, t, params, pathOnRefresh }) => {
         const fileStoreId = newParams?.uploadedDocument?.filedata?.files?.[0]?.fileStoreId;
         const filename = newParams?.uploadedDocument?.filename;
 
+        const barCouncilFileStoreId = newParams?.formData?.clientDetails?.barCouncilId?.[1]?.fileStoreId;
+        const barCouncilFilename = newParams?.formData?.clientDetails?.barCouncilId?.[0];
+
+        if (barCouncilFileStoreId && barCouncilFilename) {
+          const barCouncilUri = `${
+            window.location.origin
+          }/filestore/v1/files/id?tenantId=${Digit.ULBService.getCurrentTenantId()}&fileStoreId=${barCouncilFileStoreId}`;
+          const barCouncilFile = await getFileByFileStore(barCouncilUri, barCouncilFilename);
+
+          newParams = {
+            ...newParams,
+            formData: {
+              ...newParams.formData,
+              clientDetails: {
+                ...newParams.formData.clientDetails,
+                barCouncilId: [
+                  [
+                    barCouncilFilename,
+                    {
+                      file: barCouncilFile,
+                      fileStoreId: barCouncilFileStoreId,
+                    },
+                  ],
+                ],
+              },
+            },
+          };
+        }
+
         if (fileStoreId && filename) {
           const uri = `${window.location.origin}/filestore/v1/files/id?tenantId=${Digit.ULBService.getCurrentTenantId()}&fileStoreId=${fileStoreId}`;
           const file = await getFileByFileStore(uri, filename);

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/registration/SelectUserType.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/registration/SelectUserType.js
@@ -295,6 +295,35 @@ const SelectUserType = ({ config, t, params = {}, setParams = () => {}, pathOnRe
         const fileStoreId = newParams?.uploadedDocument?.filedata?.files?.[0]?.fileStoreId;
         const filename = newParams?.uploadedDocument?.filename;
 
+        const barCouncilFileStoreId = newParams?.formData?.clientDetails?.barCouncilId?.[1]?.fileStoreId;
+        const barCouncilFilename = newParams?.formData?.clientDetails?.barCouncilId?.[0];
+
+        if (barCouncilFileStoreId && barCouncilFilename) {
+          const barCouncilUri = `${
+            window.location.origin
+          }/filestore/v1/files/id?tenantId=${Digit.ULBService.getCurrentTenantId()}&fileStoreId=${barCouncilFileStoreId}`;
+          const barCouncilFile = await getFileByFileStore(barCouncilUri, barCouncilFilename);
+
+          newParams = {
+            ...newParams,
+            formData: {
+              ...newParams.formData,
+              clientDetails: {
+                ...newParams.formData.clientDetails,
+                barCouncilId: [
+                  [
+                    barCouncilFilename,
+                    {
+                      file: barCouncilFile,
+                      fileStoreId: barCouncilFileStoreId,
+                    },
+                  ],
+                ],
+              },
+            },
+          };
+        }
+
         if (fileStoreId && filename) {
           const uri = `${window.location.origin}/filestore/v1/files/id?tenantId=${Digit.ULBService.getCurrentTenantId()}&fileStoreId=${fileStoreId}`;
           const file = await getFileByFileStore(uri, filename);

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/registration/TermsCondition.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/registration/TermsCondition.js
@@ -433,6 +433,35 @@ const TermsCondition = ({ t, config, params, setParams, pathOnRefresh }) => {
         const fileStoreId = newParams?.uploadedDocument?.filedata?.files?.[0]?.fileStoreId;
         const filename = newParams?.uploadedDocument?.filename;
 
+        const barCouncilFileStoreId = newParams?.formData?.clientDetails?.barCouncilId?.[1]?.fileStoreId;
+        const barCouncilFilename = newParams?.formData?.clientDetails?.barCouncilId?.[0];
+
+        if (barCouncilFileStoreId && barCouncilFilename) {
+          const barCouncilUri = `${
+            window.location.origin
+          }/filestore/v1/files/id?tenantId=${Digit.ULBService.getCurrentTenantId()}&fileStoreId=${barCouncilFileStoreId}`;
+          const barCouncilFile = await getFileByFileStore(barCouncilUri, barCouncilFilename);
+
+          newParams = {
+            ...newParams,
+            formData: {
+              ...newParams.formData,
+              clientDetails: {
+                ...newParams.formData.clientDetails,
+                barCouncilId: [
+                  [
+                    barCouncilFilename,
+                    {
+                      file: barCouncilFile,
+                      fileStoreId: barCouncilFileStoreId,
+                    },
+                  ],
+                ],
+              },
+            },
+          };
+        }
+
         if (fileStoreId && filename) {
           const uri = `${window.location.origin}/filestore/v1/files/id?tenantId=${Digit.ULBService.getCurrentTenantId()}&fileStoreId=${fileStoreId}`;
           const file = await getFileByFileStore(uri, filename);

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/registration/UploadIdType.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/registration/UploadIdType.js
@@ -68,6 +68,35 @@ function UploadIdType({ config, t, onAadharChange, onDocumentUpload, params, pat
         const fileStoreId = newParams?.uploadedDocument?.filedata?.files?.[0]?.fileStoreId;
         const filename = newParams?.uploadedDocument?.filename;
 
+        const barCouncilFileStoreId = newParams?.formData?.clientDetails?.barCouncilId?.[1]?.fileStoreId;
+        const barCouncilFilename = newParams?.formData?.clientDetails?.barCouncilId?.[0];
+
+        if (barCouncilFileStoreId && barCouncilFilename) {
+          const barCouncilUri = `${
+            window.location.origin
+          }/filestore/v1/files/id?tenantId=${Digit.ULBService.getCurrentTenantId()}&fileStoreId=${barCouncilFileStoreId}`;
+          const barCouncilFile = await getFileByFileStore(barCouncilUri, barCouncilFilename);
+
+          newParams = {
+            ...newParams,
+            formData: {
+              ...newParams.formData,
+              clientDetails: {
+                ...newParams.formData.clientDetails,
+                barCouncilId: [
+                  [
+                    barCouncilFilename,
+                    {
+                      file: barCouncilFile,
+                      fileStoreId: barCouncilFileStoreId,
+                    },
+                  ],
+                ],
+              },
+            },
+          };
+        }
+
         if (fileStoreId && filename) {
           const uri = `${window.location.origin}/filestore/v1/files/id?tenantId=${Digit.ULBService.getCurrentTenantId()}&fileStoreId=${fileStoreId}`;
           const file = await getFileByFileStore(uri, filename);

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/registration/index.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/registration/index.js
@@ -291,7 +291,8 @@ const Registration = ({ stateCode }) => {
     const identityObj = {
       IdVerification: {
         selectIdType: {
-          code: "OTHER ID",
+          id: 2,
+          code: "OTHER_ID",
           name: "CS_OTHER",
           subText: "CS_OTHER_SUB_TEXT",
         },


### PR DESCRIPTION
## Requirements
https://github.com/pucardotorg/dristi/issues/5209


- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bar council documents are now properly managed and automatically retrieved throughout the registration and login workflows.

* **Bug Fixes**
  * Document retrieval has been improved across all registration steps.
  * ID verification handling enhanced for better accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->