### PR TITLE
enhacement related to reschedule pdf and adding infotext for selectin…

### DIFF
--- a/backend/ui-integration-services/dristi-pdf/src/applicationHandlers/applicationRescheduleHearing.js
+++ b/backend/ui-integration-services/dristi-pdf/src/applicationHandlers/applicationRescheduleHearing.js
@@ -308,6 +308,7 @@ async function applicationRescheduleHearing(
           partyName: partyName,
           qrCodeUrl: base64Url,
           purposeOfHearing: localizedPurposeOfHearing,
+          allPartiesAgreed: application?.applicationDetails?.isAllPartiesAgreed === "YES" ? true : false,
         },
       ],
     };

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/CustomErrorTooltip.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/CustomErrorTooltip.js
@@ -8,22 +8,28 @@ const CustomErrorTooltip = ({ message, showTooltip, icon }) => {
   }
 
   return (
-    <div className="custom-error-tooltip" style = {{ position:"relative"}}>
+    <div className="custom-error-tooltip" style={{ position: "relative" }}>
       <span>{icon ? <InfoIcon /> : <InfoToolTipIcon />}</span>
-      <div className="custom-error-tooltip-message" style={{ ...(!message && { border: "none" }),
-      position:"absolute",
-      whiteSpace: "unset",
-width: "max-content",
-maxWidth: "25vw",
-position: "absolute",
-top: "100%",
-left: "100%",
-bottom: "unset",
-right: "unset",
-backgroundColor:"white"
- }}>
-        {message}
-      </div>
+      {message && (
+        <div
+          className="custom-error-tooltip-message"
+          style={{
+            ...(!message && { border: "none" }),
+            position: "absolute",
+            whiteSpace: "unset",
+            width: "max-content",
+            maxWidth: "25vw",
+            position: "absolute",
+            top: "100%",
+            left: "100%",
+            bottom: "unset",
+            right: "unset",
+            backgroundColor: "white",
+          }}
+        >
+          {message}
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/configs/submissionsCreateConfig.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/configs/submissionsCreateConfig.js
@@ -2728,6 +2728,21 @@ export const configsAdvancementOrAdjournment = [
         },
       },
       {
+        type: "component",
+        component: "SelectCustomNote",
+        key: "bulkDateInputNote",
+        populators: {
+          inputs: [
+            {
+              infoHeader: "CS_COMMON_NOTE",
+              infoText: "SELECT_MULTIPLE_DATE_INFO_MESSAGE",
+              showTooltip: true,
+              type: "InfoComponent",
+            },
+          ],
+        },
+      },
+      {
         key: "newHearingDates",
         type: "component",
         label: "SUGGESTED_NEW_HEARING_DATES",
@@ -2760,6 +2775,8 @@ export const configsAdvancementOrAdjournment = [
         isMandatory: true,
         key: "isAllPartiesAgreed",
         type: "radio",
+        schemaKeyPath: "applicationDetails.isAllPartiesAgreed",
+        transformer: "customDropdown",
         populators: {
           name: "isAllPartiesAgreed",
           optionsKey: "name",


### PR DESCRIPTION
…g 5 multiple dates

## Requirements

https://github.com/pucardotorg/dristi/issues/5428
https://github.com/pucardotorg/dristi/issues/5429

- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced the "Reschedule Hearing" workflow to track party agreement status in generated documents.
  * Added an informational note component for date input in the submissions interface.

* **Bug Fixes**
  * Fixed unnecessary empty tooltip rendering when no message content is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->