### PR TITLE
Adding payment breakdown for ctc Application and minor bug fixes

### DIFF
--- a/backend/ui-integration-services/dristi-pdf/src/applicationHandlers/applicationCaseTransfer.js
+++ b/backend/ui-integration-services/dristi-pdf/src/applicationHandlers/applicationCaseTransfer.js
@@ -208,7 +208,7 @@ const applicationCaseTransfer = async (
           complainantList: complainantList,
           accusedList: accusedList,
           partyType: partyType,
-          applicationTitle: "APPLICATION FOR CASE TRANSFER",
+          applicationTitle: "APPLICATION FOR TRANSFER OF CRIMINAL COMPLAINT",
           reasonForTransfer: grounds, // need to confirm with PO if this is the correct field from application object to be used in template
         },
       ],

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/Utils/index.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/Utils/index.js
@@ -118,7 +118,8 @@ export const modifiedEvidenceNumber = (value, filingNumber = null) => {
 };
 export const getFilteredPaymentData = (paymentType, paymentData, bill) => {
   const processedPaymentType = paymentType?.toLowerCase()?.includes("application");
-  return processedPaymentType ? [{ key: "Total Amount", value: bill?.totalAmount }] : paymentData;
+  const isCTC = paymentType?.toLowerCase()?.includes("ctc");
+  return processedPaymentType && !isCTC ? [{ key: "Total Amount", value: bill?.totalAmount }] : paymentData;
 };
 
 export const getTaskType = (businessService) => {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/Payment/ViewPaymentDetails.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/Payment/ViewPaymentDetails.js
@@ -176,11 +176,12 @@ const ViewPaymentDetails = ({ location, match }) => {
     const fetchCalculation = async () => {
       setIsLoading(true);
       if (
-        consumerCode &&
-        ((demandBill?.additionalDetails?.chequeDetails?.totalAmount &&
-          demandBill?.additionalDetails?.chequeDetails?.totalAmount !== "0" &&
-          paymentType?.toLowerCase()?.includes("case")) ||
-          (paymentType?.toLowerCase()?.includes("task") && businessService === "task-management-payment"))
+        (consumerCode &&
+          ((demandBill?.additionalDetails?.chequeDetails?.totalAmount &&
+            demandBill?.additionalDetails?.chequeDetails?.totalAmount !== "0" &&
+            paymentType?.toLowerCase()?.includes("case")) ||
+            (paymentType?.toLowerCase()?.includes("task") && businessService === "task-management-payment"))) ||
+        (paymentType?.toLowerCase()?.includes("ctc") && businessService === "ctc-default")
       ) {
         try {
           const response = await DRISTIService.getTreasuryPaymentBreakup(

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/CTCApplications.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/CTCApplications.js
@@ -370,8 +370,8 @@ const CTCApplications = () => {
 
     const primaryDocType = app?.affidavitDocument?.documentName || app?.documents?.[0]?.documentType || "CTC Document";
 
-    return primaryFileStore ? [{ fileStore: primaryFileStore, name: primaryDocType }] : [];
-  }, [selectedRowApplicationData]);
+    return primaryFileStore ? [{ fileStore: primaryFileStore, name: t(primaryDocType) }] : [];
+  }, [selectedRowApplicationData, t]);
 
   return (
     <React.Fragment>

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/MainHomeScreen.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/MainHomeScreen.js
@@ -939,6 +939,19 @@ const MainHomeScreen = () => {
     applicationOptions.OTHERS = { name: "HOME_OTHER_APPLICATIONS" };
   }
 
+  const handleSetCount = useCallback((value) => {
+    if (typeof value === "function") {
+      setPendingTaskCount((prev) => {
+        const next = value(prev);
+        return { ...prev, ...next };
+      });
+    } else if (typeof value === "object" && value !== null) {
+      setPendingTaskCount((prev) => ({ ...prev, ...value }));
+    } else {
+      setPendingTaskCount((prev) => ({ ...prev, [activeTab]: Number(value) || 0 }));
+    }
+  }, [activeTab]);
+
   useEffect(() => {
     let updatedConfig = structuredClone(pendingTaskConfig);
     const openBailBondModal = (row) => {
@@ -1050,14 +1063,14 @@ const MainHomeScreen = () => {
               ?.map((column) => {
                 return column?.label === "PENDING_CASE_NAME"
                   ? {
-                      ...column,
-                      clickFunc:
-                        activeTab === "BAIL_BOND_STATUS"
-                          ? openBailBondModal
-                          : activeTab === "NOTICE_SUMMONS_MANAGEMENT"
+                    ...column,
+                    clickFunc:
+                      activeTab === "BAIL_BOND_STATUS"
+                        ? openBailBondModal
+                        : activeTab === "NOTICE_SUMMONS_MANAGEMENT"
                           ? setCourierServicePendingTask
                           : null,
-                    }
+                  }
                   : column;
               })
               ?.filter((column) => {
@@ -1080,7 +1093,7 @@ const MainHomeScreen = () => {
         },
       },
       additionalDetails: {
-        setCount: setPendingTaskCount,
+        setCount: handleSetCount,
         activeTab: activeTab,
         setShowBailBondModal: setShowBailBondModal,
         setSelectedBailBond: setSelectedBailBond,
@@ -1169,7 +1182,7 @@ const MainHomeScreen = () => {
           configs={{
             ...scrutinyConfig,
             additionalDetails: {
-              setCount: setPendingTaskCount,
+              setCount: handleSetCount,
               activeTab: activeTab,
               hasCaseReviewerAccess: hasCaseReviewerAccess,
             },

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/components/AddSubmissionDocument.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/components/AddSubmissionDocument.js
@@ -275,7 +275,7 @@ const AddSubmissionDocument = ({ t, config, onSelect, formData = {}, errors, cle
       )}
       {!disable && (
         <button type="button" onClick={addAnotherForm} style={{ background: "none", fontSize: "16px", fontWeight: 700, color: "#007E7E" }}>
-          {formInstances?.length < 1 ? `+ ${t("ADD_SUBMISSION_DOCUMENTS")}` : `+ ${t("ADD_ANOTHER_SURETY")}`}
+          {formInstances?.length < 1 ? `+ ${t("ADD_SUBMISSION_DOCUMENTS")}` : `+ ${t("ADD_ANOTHER_SUBMISSION_DOCUMENTS")}`}
         </button>
       )}
     </React.Fragment>


### PR DESCRIPTION
## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added translation support for document display labels across the application.

* **Improvements**
  * Updated application PDF template title for clarity.
  * Enhanced payment data filtering and treasury calculations for specific payment workflows.
  * Improved submission document form button labels for better user clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->