### PR TITLE
add initialAccessType ref to ManageOfficeMember for access type changes detection

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/Home/ManageOfficeMember.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/Home/ManageOfficeMember.js
@@ -47,6 +47,7 @@ const ManageOfficeMember = () => {
   const [casesRefreshKey, setCasesRefreshKey] = useState(0);
   const [caseSelectionDiff, setCaseSelectionDiff] = useState({ addCaseIds: [], removeCaseIds: [] });
   const [accessType, setAccessType] = useState(member?.accessType || "ALL_CASES");
+  const initialAccessType = useRef(member?.accessType || "ALL_CASES");
   const [showRemoveMemberModal, setShowRemoveMemberModal] = useState(false);
   const [isRemovingMember, setIsRemovingMember] = useState(false);
   const [showUpdateAccessModal, setShowUpdateAccessModal] = useState(false);
@@ -326,6 +327,13 @@ const ManageOfficeMember = () => {
     if (isNewMember) {
       setShowAddMemberConfirmModal(true);
     } else {
+      const accessTypeChanged = accessType !== initialAccessType.current;
+      const hasCaseDiff = currentDiff.addCaseIds.length > 0 || currentDiff.removeCaseIds.length > 0;
+
+      if (!accessTypeChanged && !hasCaseDiff) {
+        setToast({ label: t("NO_CHANGES_TO_UPDATE"), type: "error" });
+        return;
+      }
       setShowUpdateAccessModal(true);
     }
   };
@@ -444,7 +452,8 @@ const ManageOfficeMember = () => {
       setToast({ label: isNewMember ? t("MEMBER_ADDED_SUCCESSFULLY") : t("UPDATE_ACCESS_SUCCESS"), type: "success" });
       setShowUpdateAccessModal(false);
       setShowAddMemberConfirmModal(false);
-      
+      initialAccessType.current = accessType;
+
       setCaseSelectionDiff({ addCaseIds: [], removeCaseIds: [] });
       const container = document.querySelector(".manage-office-member-inbox");
       if (container) {


### PR DESCRIPTION
add initialAccessType ref to ManageOfficeMember for access type changes detection

## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`
