### PR TITLE
advocate login -> if not approved/rejected -> dropdown should not be visible

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/core/src/components/TopBarSideBar/TopBarComponent.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/core/src/components/TopBarSideBar/TopBarComponent.js
@@ -250,6 +250,16 @@ const TopBarComponent = ({
     );
   }, [searchResult, userType]);
 
+  const isRejected = useMemo(() => {
+    return (
+      userType !== "LITIGANT" &&
+      Array.isArray(searchResult) &&
+      searchResult?.length > 0 &&
+      searchResult?.[0]?.isActive === false &&
+      searchResult?.[0]?.status === "INACTIVE"
+    );
+  }, [searchResult, userType]);
+
   const advocateId = useMemo(() => {
     return userType === "ADVOCATE" ? searchResult?.[0]?.id : null;
   }, [searchResult, userType]);
@@ -271,7 +281,7 @@ const TopBarComponent = ({
     },
     { tenantId },
     searchCriteria + isApprovalPending,
-    Boolean((advocateId || advClerkId) && tenantId && !isApprovalPending)
+    Boolean((advocateId || advClerkId) && tenantId && !isApprovalPending && !isRejected)
   );
 
   const seniorAdvocates = useMemo(() => {
@@ -411,12 +421,21 @@ const TopBarComponent = ({
   const hasMembers = Array.isArray(seniorAdvocates) && seniorAdvocates?.length > 0;
 
   const advocateDropdownOptions = useMemo(() => {
-    if (isSearchLoading || isApprovalPending || individualDataLoading || isIndividuaIdMappingsLoading) return [];
+    if (isSearchLoading || isApprovalPending || isRejected || individualDataLoading || isIndividuaIdMappingsLoading) return [];
     else if (isUserLoggedIn && !isSearchLoading && !isApprovalPending && hasMembers && !individualDataLoading) {
       return seniorAdvocates;
     }
     return [];
-  }, [hasMembers, individualDataLoading, isApprovalPending, isIndividuaIdMappingsLoading, isSearchLoading, isUserLoggedIn, seniorAdvocates]);
+  }, [
+    hasMembers,
+    individualDataLoading,
+    isApprovalPending,
+    isRejected,
+    isIndividuaIdMappingsLoading,
+    isSearchLoading,
+    isUserLoggedIn,
+    seniorAdvocates,
+  ]);
 
   return (
     <div className="navbar" style={{ zIndex: "999" }}>
@@ -461,7 +480,7 @@ const TopBarComponent = ({
 
         <div className="RightMostTopBarOptions">
           {/* Manage Office button & Advocate profile dropdown - only visible for advocates / clerks */}
-          {(isAdvocate || (isAdvocateClerk && advocateDropdownOptions?.length > 0)) && (
+          {(isAdvocate || (isAdvocateClerk && advocateDropdownOptions?.length > 0)) && !isApprovalPending && !isRejected && (
             <div style={{ display: "flex", alignItems: "center", gap: "16px", marginRight: "16px" }}>
               <AdvocateProfileDropdown
                 t={t}


### PR DESCRIPTION

## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for handling rejected or inactive user accounts in the top navigation bar.

* **Improvements**
  * Updated visibility of advocate and clerk dropdown controls based on account status.
  * Refined conditional logic for user interface elements to account for account rejection state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->