### PR TITLE
redirect to home if user is not logged in in TopBarComponent

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/core/src/components/TopBarSideBar/TopBarComponent.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/core/src/components/TopBarSideBar/TopBarComponent.js
@@ -446,6 +446,10 @@ const TopBarComponent = ({
           <div
             style={{ display: "flex", gap: "16px", cursor: "pointer" }}
             onClick={() => {
+              if (!isUserLoggedIn) {
+                window.location.replace(window.location.origin);
+                return;
+              }
               if (isUserLoggedIn && pathname.includes("/citizen/dristi/home/registration")) {
                 history.push(`/${window?.contextPath}/citizen/dristi/home`);
               } else {


### PR DESCRIPTION
## Requirements
https://github.com/pucardotorg/dristi/issues/5631


- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved top bar logo security: added authentication verification to ensure only logged-in users can access associated navigation features. Unauthorized users are now redirected to the home page, while existing functionality for authenticated users remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->