### PR TITLE
fix: fetch judge designation from MDMS instead of hardcoding in witness deposition #5688

### DIFF
--- a/backend/ui-integration-services/dristi-pdf/src/hearingHandlers/witnessDeposition.js
+++ b/backend/ui-integration-services/dristi-pdf/src/hearingHandlers/witnessDeposition.js
@@ -183,7 +183,7 @@ const witnessDeposition = async (req, res, qrCode) => {
           depositionType: "",
           witnessDeposition: witnessDepositionText,
           witnessPlaceholder: "Deponent",
-          judgePlaceholder: "Judicial Magistrate of First Class",
+          judgePlaceholder: courtCaseJudgeDetails.judgeDetails?.designation,
           qrCodeUrl: base64Url,
           designation:
             witnessEvidence.additionalDetails.witnessDetails.designation,
@@ -195,6 +195,7 @@ const witnessDeposition = async (req, res, qrCode) => {
       qrCode === "true"
         ? config.pdf.new_witness_deposition_qr
         : config.pdf.new_witness_deposition;
+    console.log("[witnessDeposition] data being sent to create_pdf:", JSON.stringify(data?.Data?.[0], null, 2));
     const pdfResponse = await handleApiCall(
       () => create_pdf(tenantId, pdfKey, data, req.body),
       "Failed to generate PDF of Application Bail Bond"

--- a/backend/ui-integration-services/dristi-pdf/src/hearingHandlers/witnessDeposition.js
+++ b/backend/ui-integration-services/dristi-pdf/src/hearingHandlers/witnessDeposition.js
@@ -195,7 +195,6 @@ const witnessDeposition = async (req, res, qrCode) => {
       qrCode === "true"
         ? config.pdf.new_witness_deposition_qr
         : config.pdf.new_witness_deposition;
-    console.log("[witnessDeposition] data being sent to create_pdf:", JSON.stringify(data?.Data?.[0], null, 2));
     const pdfResponse = await handleApiCall(
       () => create_pdf(tenantId, pdfKey, data, req.body),
       "Failed to generate PDF of Application Bail Bond"

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/BulkWitnessDepositionView.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/BulkWitnessDepositionView.js
@@ -49,6 +49,12 @@ function BulkWitnessDepositionView({ setShowToast = () => {} }) {
   const hasEvidenceEsignAccess = useMemo(() => roles?.some((role) => role.code === "EVIDENCE_ESIGN"), [roles]);
   const [needConfigRefresh, setNeedConfigRefresh] = useState(false);
   const [counter, setCounter] = useState(0);
+
+  const { data: designationData } = Digit.Hooks.useCustomMDMS(tenantId, "common-masters", [{ name: "Designation" }]);
+  const judgeDesignation = useMemo(
+    () => designationData?.["common-masters"]?.Designation?.find((d) => d.code === "JUDICIAL_MAGISTRATE")?.name || "",
+    [designationData]
+  );
   const config = useMemo(() => {
     const setWitnessDepositionFunc = async (deposition) => {
       setShowBulkSignModal(true);
@@ -200,7 +206,7 @@ function BulkWitnessDepositionView({ setShowToast = () => {} }) {
             return {
               fileStoreId: deposition?.businessObject?.artifactDetails?.file?.fileStore,
               artifactNumber: deposition?.businessObject?.artifactDetails?.artifactNumber,
-              placeholder: "Judicial Magistrate of First Class",
+              placeholder: judgeDesignation,
               tenantId: tenantId,
             };
           });

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/WitnessDepositionSignModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/WitnessDepositionSignModal.js
@@ -83,6 +83,12 @@ export const WitnessDepositionSignModal = ({
   const { uploadDocuments } = Digit.Hooks.orders.useDocumentUpload();
   const mockESignEnabled = window?.globalConfigs?.getConfig("mockESignEnabled") === "true" ? true : false;
 
+  const { data: designationData } = Digit.Hooks.useCustomMDMS(tenantId, "common-masters", [{ name: "Designation" }]);
+  const judgeDesignation = useMemo(
+    () => designationData?.["common-masters"]?.Designation?.find((d) => d.code === "JUDICIAL_MAGISTRATE")?.name || "",
+    [designationData]
+  );
+
   const witnessDepositionDocuments = useMemo(() => {
     return effectiveRowData?.businessObject?.artifactDetails?.file || effectiveRowData?.file || docObj?.artifactList.file
       ? [effectiveRowData?.businessObject?.artifactDetails?.file || effectiveRowData?.file || docObj?.artifactList.file]
@@ -321,7 +327,7 @@ export const WitnessDepositionSignModal = ({
           sessionStorage.setItem("bulkWitnessDepositionSignCaseTitle", witnessDepositionPaginationData?.caseTitle);
         if (witnessDepositionPaginationData?.offset)
           sessionStorage.setItem("bulkWitnessDepositionSignoffset", witnessDepositionPaginationData?.offset);
-        handleEsign(name, pageModule, selectedWitnessDepositionFilestoreid, setShowToast, t, "Judicial Magistrate of First Class");
+        handleEsign(name, pageModule, selectedWitnessDepositionFilestoreid, setShowToast, t, judgeDesignation);
       } catch (error) {
         console.error("E-sign navigation error:", error);
         setLoader(false);


### PR DESCRIPTION
## Requirements

- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`

## Summary

[Fixes #5688](https://github.com/pucardotorg/dristi/issues/5688#issue-4335337977)

The `judgePlaceholder` value ("Judicial Magistrate of First Class") was hardcoded in three places. This PR replaces all hardcoded occurrences with a dynamic value fetched from the `common-masters.Designation` MDMS master using code `JUDICIAL_MAGISTRATE`.

**Files changed:**
- `backend/ui-integration-services/dristi-pdf/src/hearingHandlers/witnessDeposition.js` — uses `courtCaseJudgeDetails.judgeDetails?.designation` which is already fetched from MDMS via `getCourtAndJudgeDetails` in `commonUtils.js`
- `frontend/.../home/src/pages/employee/WitnessDepositionSignModal.js` — fetches designation via `Digit.Hooks.useCustomMDMS` and passes it to `handleEsign`
- `frontend/.../home/src/pages/employee/BulkWitnessDepositionView.js` — fetches designation via `Digit.Hooks.useCustomMDMS` and passes it as `placeholder` in the bulk sign payload

**No impact on existing functionality** — the `JUDICIAL_MAGISTRATE` code in `common-masters.Designation` is not read anywhere else in the codebase. The `njdg-transformer` service uses the same code but queries a separate `desg_type` DB table directly, unaffected by this change.

## Data Changes

The MDMS entry for `common-masters.Designation` with code `JUDICIAL_MAGISTRATE` should have its `name` updated to `"Judicial Magistrate of First Class"` to match the required display value.

## Preview

Verified locally — newly generated witness deposition PDFs and eSign/bulk-sign flows now read the designation dynamically from MDMS.

## Other

No breaking changes. No new dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Witness deposition documents and signing workflows now dynamically retrieve judge designation from system configuration instead of using a hardcoded placeholder value, ensuring accurate and consistent representation across all deposition-related processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->