### PR TITLE
chore: MDMS data update for JUDICIAL_MAGISTRATE designation #5688

### DIFF
--- a/support/v1.18.0-sprint-32/deployment.md
+++ b/support/v1.18.0-sprint-32/deployment.md
@@ -1,2 +1,7 @@
 need to restart egov-accesscontrol service
 'need to restart egov-encrption service and case service
+
+## Fix #5688 - Judge Designation MDMS Update
+- Run MDMS data update: `support/v1.18.0-sprint-32/mdms-data/fix-5688-designation-update.json5`
+- Updates `common-masters.Designation` entry with code `JUDICIAL_MAGISTRATE` — changes `name` to "Judicial Magistrate of First Class"
+- Restart dristi-pdf service after deploying

--- a/support/v1.18.0-sprint-32/mdms-data/fix-5688-designation-update.json5
+++ b/support/v1.18.0-sprint-32/mdms-data/fix-5688-designation-update.json5
@@ -1,0 +1,15 @@
+[
+  {
+    "id": "2dfa01a4-c780-462e-9e6e-b10f8814e259",
+    "tenantId": "kl",
+    "schemaCode": "common-masters.Designation",
+    "uniqueIdentifier": "JUDICIAL_MAGISTRATE",
+    "data": {
+      "code": "JUDICIAL_MAGISTRATE",
+      "name": "Judicial Magistrate of First Class",
+      "active": true,
+      "description": "Judicial Magistrate of First Class"
+    },
+    "isActive": true
+  }
+]


### PR DESCRIPTION
## Requirements

- [x] This PR has a proper title that briefly describes the work done
- [x] I have referenced the github issues('s)
- [x] I performed a self-review of my own code
- [x] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [x] I have added MDMS data changes to `support/v1.18.0-sprint-32/mdms-data/fix-5688-designation-update.json5`
  - [x] I have added deployment configuration steps to `support/v1.18.0-sprint-32/deployment.md`

## Summary

Closes https://github.com/pucardotorg/dristi/issues/5688#issue-4335337977 (MDMS data change companion to the code fix already merged in #6534)

Updates the `common-masters.Designation` MDMS entry with code `JUDICIAL_MAGISTRATE` — changes `name` from `"Judicial Magistrate 1st Class"` to `"Judicial Magistrate of First Class"` so that the witness deposition PDF and eSign/bulk-sign flows display the correct designation text dynamically from MDMS.

## Data Changes

- **File:** `support/v1.18.0-sprint-32/mdms-data/fix-5688-designation-update.json5`
- **Schema:** `common-masters.Designation`
- **Record:** `JUDICIAL_MAGISTRATE` (id: `2dfa01a4-c780-462e-9e6e-b10f8814e259`)
- **Change:** `name` updated to `"Judicial Magistrate of First Class"`
- **Post-deploy:** Restart dristi-pdf service

## Other

No code changes. This is a data-only update to complement the code fix in #6534.