### PR TITLE
revert: remove LPR lifecycle status commits (#6530, #6540) from develop

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/cases/src/pages/employee/JoinCaseHome.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/cases/src/pages/employee/JoinCaseHome.js
@@ -19,7 +19,7 @@ import JoinCaseSuccess from "./joinCaseComponent/JoinCaseSuccess";
 import LitigantVerification from "./joinCaseComponent/LitigantVerification";
 import usePaymentProcess from "../../../../home/src/hooks/usePaymentProcess";
 import POAInfo from "./joinCaseComponent/POAInfo";
-import { cleanString, combineMultipleFiles, getAuthorizedUuid, isLPRCase, removeInvalidNameParts } from "@egovernments/digit-ui-module-dristi/src/Utils";
+import { cleanString, combineMultipleFiles, getAuthorizedUuid, removeInvalidNameParts } from "@egovernments/digit-ui-module-dristi/src/Utils";
 import { SubmissionWorkflowAction } from "@egovernments/digit-ui-module-orders/src/utils/submissionWorkflow";
 import { useHistory } from "react-router-dom/cjs/react-router-dom.min";
 import { CloseBtn } from "@egovernments/digit-ui-module-dristi/src/components/ModalComponents";
@@ -1223,7 +1223,7 @@ const JoinCaseHome = ({ refreshInbox, setShowJoinCase, showJoinCase, type, data 
                   },
                   caseTitle: caseDetails?.caseTitle,
                   caseNumber:
-                    (isLPRCase(caseDetails) ? caseDetails?.lprNumber : caseDetails?.courtCaseNumber) ||
+                    (caseDetails?.isLPRCase ? caseDetails?.lprNumber : caseDetails?.courtCaseNumber) ||
                     caseDetails?.courtCaseNumber ||
                     caseDetails?.cmpNumber ||
                     caseDetails?.filingNumber,

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/cases/src/pages/employee/joinCaseComponent/JoinCaseSuccess.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/cases/src/pages/employee/joinCaseComponent/JoinCaseSuccess.js
@@ -6,7 +6,7 @@ import NameListWithModal from "../../../components/NameListWithModal";
 import { useHistory } from "react-router-dom/cjs/react-router-dom.min";
 import { RightArrow } from "@egovernments/digit-ui-module-dristi/src/icons/svgIndex";
 import { useTranslation } from "react-i18next";
-import { DateUtils, getAuthorizedUuid, isLPRCase } from "@egovernments/digit-ui-module-dristi/src/Utils";
+import { DateUtils, getAuthorizedUuid } from "@egovernments/digit-ui-module-dristi/src/Utils";
 import { DRISTIService } from "@egovernments/digit-ui-module-dristi/src/services";
 
 const JoinCaseSuccess = ({
@@ -51,7 +51,7 @@ const JoinCaseSuccess = ({
         {
           key: "CASE_NUMBER",
           value:
-            (isLPRCase(caseDetails) ? caseDetails?.lprNumber : caseDetails?.courtCaseNumber) ||
+            (caseDetails?.isLPRCase ? caseDetails?.lprNumber : caseDetails?.courtCaseNumber) ||
             caseDetails?.courtCaseNumber ||
             caseDetails?.cmpNumber ||
             caseDetails?.filingNumber,

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/cases/src/pages/employee/joinCaseComponent/SearchCaseAndShowDetails.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/cases/src/pages/employee/joinCaseComponent/SearchCaseAndShowDetails.js
@@ -5,7 +5,7 @@ import React, { useMemo } from "react";
 import NameListWithModal from "../../../components/NameListWithModal";
 import { createShorthand } from "../../../utils/joinCaseUtils";
 import { useTranslation } from "react-i18next";
-import { DateUtils, isLPRCase } from "@egovernments/digit-ui-module-dristi/src/Utils";
+import { DateUtils } from "@egovernments/digit-ui-module-dristi/src/Utils";
 
 const SearchCaseAndShowDetails = ({
   caseNumber,
@@ -39,7 +39,7 @@ const SearchCaseAndShowDetails = ({
         {
           key: "CASE_NUMBER",
           value:
-            (isLPRCase(caseDetails) ? caseDetails?.lprNumber : caseDetails?.courtCaseNumber) ||
+            (caseDetails?.isLPRCase ? caseDetails?.lprNumber : caseDetails?.courtCaseNumber) ||
             caseDetails?.courtCaseNumber ||
             caseDetails?.cmpNumber ||
             caseDetails?.filingNumber,

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/Utils/index.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/Utils/index.js
@@ -116,29 +116,6 @@ export const modifiedEvidenceNumber = (value, filingNumber = null) => {
   }
   return value;
 };
-
-// Returns true when a case is in the Long Pending Register lifecycle.
-// Prefers the new `lifecycleStatus` field and falls back to the legacy
-// `isLPRCase` boolean while older payloads are still in flight.
-export const isLPRCase = (caseObj) => {
-  if (!caseObj) return false;
-  if (caseObj.lifecycleStatus !== undefined && caseObj.lifecycleStatus !== null) {
-    return caseObj.lifecycleStatus === "LPR";
-  }
-  return Boolean(isLPRCase(caseObj));
-};
-
-// Returns the case-number to display, taking LPR cases into account.
-export const getDisplayCaseNumber = (caseObj) => {
-  if (!caseObj) return "";
-  return (
-    (isLPRCase(caseObj) ? caseObj?.lprNumber : caseObj?.courtCaseNumber) ||
-    caseObj?.courtCaseNumber ||
-    caseObj?.cmpNumber ||
-    caseObj?.filingNumber ||
-    ""
-  );
-};
 export const getFilteredPaymentData = (paymentType, paymentData, bill) => {
   const processedPaymentType = paymentType?.toLowerCase()?.includes("application");
   const isCTC = paymentType?.toLowerCase()?.includes("ctc");

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/Utils/index.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/Utils/index.js
@@ -125,7 +125,7 @@ export const isLPRCase = (caseObj) => {
   if (caseObj.lifecycleStatus !== undefined && caseObj.lifecycleStatus !== null) {
     return caseObj.lifecycleStatus === "LPR";
   }
-  return Boolean(caseObj?.isLPRCase);
+  return Boolean(isLPRCase(caseObj));
 };
 
 // Returns the case-number to display, taking LPR cases into account.

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/configs/UICustomizations.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/configs/UICustomizations.js
@@ -15,7 +15,6 @@ import {
   getAuthorizedUuid,
   getClerkMembersForPartiesTab,
   getDate,
-  isLPRCase,
   modifiedEvidenceNumber,
   removeInvalidNameParts,
 } from "../Utils";
@@ -2860,7 +2859,7 @@ export const UICustomizations = {
           return rawTitle ? rawTitle : t("CASE_UNTITLED") || "Case Untitled";
         }
         case "CASE_NUMBER": {
-          const caseNumber = isLPRCase(row) ? row?.lprNumber : row?.courtCaseNumber || row?.cmpNumber || row?.filingNumber || "";
+          const caseNumber = row?.isLPRCase ? row?.lprNumber : row?.courtCaseNumber || row?.cmpNumber || row?.filingNumber || "";
           return caseNumber || "";
         }
         default:

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCaseV2.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCaseV2.js
@@ -28,8 +28,6 @@ import {
   getAllAssociatedPartyUuids,
   getAuthorizedUuid,
   getDate,
-  isLPRCase,
-  removeInvalidNameParts,
 } from "../../../Utils";
 import useSearchOrdersService from "@egovernments/digit-ui-module-orders/src/hooks/orders/useSearchOrdersService";
 import VoidSubmissionBody from "./VoidSubmissionBody";
@@ -1251,7 +1249,7 @@ const AdmittedCaseV2 = () => {
             tenantId: tenantId,
             filingNumber: [caseDetails.filingNumber],
             hearingType: purpose,
-            courtCaseNumber: isLPRCase(caseDetails) ? caseDetails?.lprNumber : caseDetails?.courtCaseNumber,
+            courtCaseNumber: caseDetails?.isLPRCase ? caseDetails?.lprNumber : caseDetails?.courtCaseNumber,
             cmpNumber: caseDetails?.cmpNumber,
             status: true,
             attendees: [

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/EvidenceModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/EvidenceModal.js
@@ -22,7 +22,6 @@ import {
   getDate,
   getOrderActionName,
   getOrderTypes,
-  isLPRCase,
   setApplicationStatus,
 } from "../../../Utils";
 import useGetAllOrderApplicationRelatedDocuments from "../../../hooks/dristi/useGetAllOrderApplicationRelatedDocuments";
@@ -834,7 +833,7 @@ const EvidenceModal = ({
       const applicationCMPNumber = documentSubmission?.[0]?.applicationList?.applicationCMPNumber;
       const currentHearingPurpose = documentSubmission?.[0]?.applicationList?.applicationDetails?.initialHearingPurpose || "";
       const caseNumber =
-        (isLPRCase(caseData) ? caseData?.lprNumber : caseData?.courtCaseNumber) ||
+        (caseData?.isLPRCase ? caseData?.lprNumber : caseData?.courtCaseNumber) ||
         caseData?.courtCaseNumber ||
         caseData?.cmpNumber ||
         caseData?.filingNumber;

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/MarkAsEvidence.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/MarkAsEvidence.js
@@ -8,7 +8,7 @@ import { getFullName } from "../../../../../cases/src/utils/joinCaseUtils";
 import { Urls } from "../../../hooks";
 import { useHistory } from "react-router-dom";
 import { InfoCard } from "@egovernments/digit-ui-components";
-import { getAuthorizedUuid, isLPRCase, sanitizeData } from "../../../Utils";
+import { getAuthorizedUuid, sanitizeData } from "../../../Utils";
 import { getFormattedName } from "@egovernments/digit-ui-module-orders/src/utils";
 import axiosInstance from "@egovernments/digit-ui-module-core/src/Utils/axiosInstance";
 import { CloseBtn, Heading } from "../../../components/ModalComponents";
@@ -255,7 +255,7 @@ const MarkAsEvidence = ({
             courtId: courtId,
             markedAs: `${taggedEvidenceNumber || `${evidenceTag?.value}${evidenceNumber}`}`,
             caseNumber:
-              (isLPRCase(caseDetails) ? caseDetails?.lprNumber : caseDetails?.courtCaseNumber) ||
+              (caseDetails?.isLPRCase ? caseDetails?.lprNumber : caseDetails?.courtCaseNumber) ||
               caseDetails?.courtCaseNumber ||
               caseDetails?.cmpNumber ||
               caseDetails?.filingNumber,
@@ -765,7 +765,7 @@ const MarkAsEvidence = ({
                   tenantId: tenantId,
                   entryDate: new Date().setHours(0, 0, 0, 0),
                   caseNumber:
-                    (isLPRCase(caseDetails) ? caseDetails?.lprNumber : caseDetails?.courtCaseNumber) ||
+                    (caseDetails?.isLPRCase ? caseDetails?.lprNumber : caseDetails?.courtCaseNumber) ||
                     caseDetails?.courtCaseNumber ||
                     caseDetails?.cmpNumber ||
                     caseDetails?.filingNumber,

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/PaymentDemandModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/PaymentDemandModal.js
@@ -3,7 +3,7 @@ import Modal from "../../../components/Modal";
 import { Dropdown, Loader, CloseSvg, TextArea, TextInput, LabelFieldPair, CardLabel } from "@egovernments/digit-ui-react-components";
 import { DRISTIService } from "../../../services";
 import { Urls } from "../../../hooks";
-import { isLPRCase, sanitizeData } from "../../../Utils";
+import { sanitizeData } from "../../../Utils";
 
 const INITIAL_PAYMENT_ITEM = { type: "", amount: "" };
 const MIN_AMOUNT = 0;
@@ -208,7 +208,7 @@ const PaymentDemandModal = ({
           status: "",
           filingNumber: caseDetails?.filingNumber,
           cmpNumber: caseDetails?.cmpNumber,
-          courtCaseNumber: (isLPRCase(caseDetails) ? caseDetails?.lprNumber : caseDetails?.courtCaseNumber) || caseDetails?.courtCaseNumber,
+          courtCaseNumber: (caseDetails?.isLPRCase ? caseDetails?.lprNumber : caseDetails?.courtCaseNumber) || caseDetails?.courtCaseNumber,
           taskDescription: comments || null,
           taskType: "GENERIC",
           duedate: dueDateTimestamp,

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/ScheduleHearing.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/ScheduleHearing.js
@@ -5,7 +5,6 @@ import { Modal } from "@egovernments/digit-ui-react-components";
 import AdmissionActionModal from "../admission/AdmissionActionModal";
 import { DRISTIService } from "../../../services";
 import { CloseBtn } from "../../../components/ModalComponents";
-import { isLPRCase } from "../../../Utils";
 
 const ScheduleHearing = ({
   tenantId,
@@ -43,7 +42,7 @@ const ScheduleHearing = ({
           filingNumber: [caseData.filingNumber],
           hearingType: data.purpose,
           courtCaseNumber:
-            (isLPRCase(caseData?.case) ? caseData?.case?.lprNumber : caseData?.case?.courtCaseNumber) || caseData?.case?.courtCaseNumber,
+            (caseData?.case?.isLPRCase ? caseData?.case?.lprNumber : caseData?.case?.courtCaseNumber) || caseData?.case?.courtCaseNumber,
           cmpNumber: caseData?.case?.cmpNumber,
           status: true,
           attendees: [

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/components/CaseDetailsStrip.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/components/CaseDetailsStrip.js
@@ -1,5 +1,4 @@
 import React from "react";
-import { isLPRCase } from "../../../../Utils";
 
 const delayCondonationStylsMain = {
   padding: "6px 8px",
@@ -39,7 +38,7 @@ const CaseDetailsStrip = ({
             <hr className="vertical-line" />
           </React.Fragment>
         )}
-        {isLPRCase(caseDetails) ? (
+        {caseDetails?.isLPRCase ? (
           <React.Fragment>
             <div className="sub-details-text">{caseDetails?.lprNumber}</div>
             <hr className="vertical-line" />

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/utils/caseSubmissionUtils.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/utils/caseSubmissionUtils.js
@@ -1,4 +1,4 @@
-import { DateUtils, isLPRCase } from "../../../../Utils";
+import { DateUtils } from "../../../../Utils";
 import { OrderWorkflowAction } from "../../../../Utils/orderWorkflow";
 
 // Helper function to handle admit/dismiss case order creation
@@ -18,7 +18,7 @@ export const handleAdmitDismissCaseOrder = async ({
 }) => {
   try {
     const caseNumber =
-      (isLPRCase(caseDetails) ? caseDetails?.lprNumber : caseDetails?.courtCaseNumber) ||
+      (caseDetails?.isLPRCase ? caseDetails?.lprNumber : caseDetails?.courtCaseNumber) ||
       caseDetails?.courtCaseNumber ||
       caseDetails?.cmpNumber ||
       caseDetails?.filingNumber;

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/configs/BenchHomeConfig.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/configs/BenchHomeConfig.js
@@ -124,9 +124,7 @@ export const TabBenchSearchConfig = {
         requestParam: {},
         requestBody: {
           tenantId: "pg",
-          criteria: {
-            lifecycleStatus: "ACTIVE",
-          },
+          criteria: {},
         },
         masterName: "commonUiConfig",
         moduleName: "homeJudgeUIConfig",
@@ -280,7 +278,7 @@ export const TabBenchSearchConfig = {
         requestBody: {
           tenantId: "pg",
           criteria: {
-            lifecycleStatus: "ACTIVE",
+            isLPRCase: false,
             stage: [
               "Long Pending Register",
               "Post-Judgement",
@@ -451,7 +449,6 @@ export const TabBenchSearchConfig = {
         requestBody: {
           tenantId: "pg",
           criteria: {
-            lifecycleStatus: "ACTIVE",
             stage: [
               "Long Pending Register",
               "Post-Disposal",
@@ -636,7 +633,6 @@ export const TabBenchSearchConfig = {
         requestBody: {
           tenantId: "pg",
           criteria: {
-            lifecycleStatus: "ACTIVE",
             outcome: [],
           },
         },
@@ -781,7 +777,7 @@ export const TabBenchSearchConfig = {
         requestBody: {
           tenantId: "pg",
           criteria: {
-            lifecycleStatus: "LPR",
+            isLPRCase: true,
           },
         },
         masterName: "commonUiConfig",

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/configs/CourtRoomHomeConfig.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/configs/CourtRoomHomeConfig.js
@@ -136,9 +136,7 @@ export const TabCourtRoomSearchConfig = {
         requestParam: {},
         requestBody: {
           tenantId: "pg",
-          criteria: {
-            lifecycleStatus: "ACTIVE",
-          },
+          criteria: {},
         },
         masterName: "commonUiConfig",
         moduleName: "homeJudgeUIConfig",
@@ -292,7 +290,7 @@ export const TabCourtRoomSearchConfig = {
         requestBody: {
           tenantId: "pg",
           criteria: {
-            lifecycleStatus: "ACTIVE",
+            isLPRCase: false,
             stage: [
               "Long Pending Register",
               "Post-Judgement",
@@ -463,7 +461,6 @@ export const TabCourtRoomSearchConfig = {
         requestBody: {
           tenantId: "pg",
           criteria: {
-            lifecycleStatus: "ACTIVE",
             stage: [
               "Long Pending Register",
               "Post-Disposal",
@@ -649,7 +646,6 @@ export const TabCourtRoomSearchConfig = {
         requestBody: {
           tenantId: "pg",
           criteria: {
-            lifecycleStatus: "ACTIVE",
             outcome: [],
           },
         },
@@ -794,7 +790,7 @@ export const TabCourtRoomSearchConfig = {
         requestBody: {
           tenantId: "pg",
           criteria: {
-            lifecycleStatus: "LPR",
+            isLPRCase: true,
           },
         },
         masterName: "commonUiConfig",

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/configs/HomeConfig.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/configs/HomeConfig.js
@@ -131,9 +131,7 @@ export const TabUnifiedEmployeeSearchConfig = {
         requestParam: {},
         requestBody: {
           tenantId: Digit.ULBService.getCurrentTenantId(),
-          criteria: {
-            lifecycleStatus: "ACTIVE",
-          },
+          criteria: {},
         },
         masterName: "commonUiConfig",
         moduleName: "homeJudgeUIConfig",
@@ -290,7 +288,7 @@ export const TabUnifiedEmployeeSearchConfig = {
         requestBody: {
           tenantId: Digit.ULBService.getCurrentTenantId(),
           criteria: {
-            lifecycleStatus: "ACTIVE",
+            isLPRCase: false,
             stage: [
               "Long Pending Register",
               "Post-Judgement",
@@ -464,7 +462,6 @@ export const TabUnifiedEmployeeSearchConfig = {
         requestBody: {
           tenantId: Digit.ULBService.getCurrentTenantId(),
           criteria: {
-            lifecycleStatus: "ACTIVE",
             stage: [
               "Long Pending Register",
               "Post-Disposal",
@@ -653,7 +650,6 @@ export const TabUnifiedEmployeeSearchConfig = {
         requestBody: {
           tenantId: Digit.ULBService.getCurrentTenantId(),
           criteria: {
-            lifecycleStatus: "ACTIVE",
             outcome: [],
           },
         },
@@ -801,7 +797,7 @@ export const TabUnifiedEmployeeSearchConfig = {
         requestBody: {
           tenantId: Digit.ULBService.getCurrentTenantId(),
           criteria: {
-            lifecycleStatus: "LPR",
+            isLPRCase: true,
           },
         },
         masterName: "commonUiConfig",

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/configs/JudgeHomeConfig.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/configs/JudgeHomeConfig.js
@@ -132,9 +132,7 @@ export const TabJudgeSearchConfig = {
         requestParam: {},
         requestBody: {
           tenantId: "pg",
-          criteria: {
-            lifecycleStatus: "ACTIVE",
-          },
+          criteria: {},
         },
         masterName: "commonUiConfig",
         moduleName: "homeJudgeUIConfig",
@@ -288,7 +286,7 @@ export const TabJudgeSearchConfig = {
         requestBody: {
           tenantId: "pg",
           criteria: {
-            lifecycleStatus: "ACTIVE",
+            isLPRCase: false,
             stage: [
               "Long Pending Register",
               "Post-Judgement",
@@ -459,7 +457,6 @@ export const TabJudgeSearchConfig = {
         requestBody: {
           tenantId: "pg",
           criteria: {
-            lifecycleStatus: "ACTIVE",
             stage: [
               "Long Pending Register",
               "Post-Disposal",
@@ -646,7 +643,6 @@ export const TabJudgeSearchConfig = {
         requestBody: {
           tenantId: "pg",
           criteria: {
-            lifecycleStatus: "ACTIVE",
             outcome: [],
           },
         },
@@ -792,7 +788,7 @@ export const TabJudgeSearchConfig = {
         requestBody: {
           tenantId: "pg",
           criteria: {
-            lifecycleStatus: "LPR",
+            isLPRCase: true,
           },
         },
         masterName: "commonUiConfig",

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/configs/UICustomizations.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/configs/UICustomizations.js
@@ -8,7 +8,7 @@ import OverlayDropdown from "@egovernments/digit-ui-module-dristi/src/components
 import { OrderWorkflowState } from "@egovernments/digit-ui-module-dristi/src/Utils/orderWorkflow";
 import { BulkCheckBox } from "@egovernments/digit-ui-module-dristi/src/components/BulkCheckbox";
 import { AdvocateName } from "@egovernments/digit-ui-module-dristi/src/components/AdvocateName";
-import { DateUtils, modifiedEvidenceNumber, isLPRCase } from "@egovernments/digit-ui-module-dristi/src/Utils";
+import { DateUtils, modifiedEvidenceNumber } from "@egovernments/digit-ui-module-dristi/src/Utils";
 import { ADiaryRowClick } from "@egovernments/digit-ui-module-dristi/src/components/ADiaryRowClick";
 import PencilIconEdit from "@egovernments/digit-ui-module-dristi/src/components/PencilIconEdit";
 import EditDeleteModal from "@egovernments/digit-ui-module-dristi/src/components/EditDeleteModal";
@@ -256,7 +256,7 @@ export const UICustomizations = {
       const activeTab = searchResult?.additionalDetails?.activeTab || "";
       const isDisposedTab = activeTab === "DISPOSED";
       const caseId =
-        (isLPRCase(row) && !isDisposedTab ? row?.lprNumber : row?.courtCaseNumber) || row?.courtCaseNumber || row?.cmpNumber || row?.filingNumber;
+        (row?.isLPRCase && !isDisposedTab ? row?.lprNumber : row?.courtCaseNumber) || row?.courtCaseNumber || row?.cmpNumber || row?.filingNumber;
       switch (key) {
         case "Draft Name":
         case "CS_CASE_NAME":
@@ -270,7 +270,7 @@ export const UICustomizations = {
         case "CS_OUTCOME":
           return t(value);
         case "CS_STAGE":
-          return isLPRCase(row) ? t("Long Pending Register") : t(value);
+          return t(value);
         case "CS_SECONDARY_STAGE": {
           const stages = Array.isArray(value) ? value : [value];
           const normalized = stages.filter(Boolean);
@@ -364,12 +364,12 @@ export const UICustomizations = {
       const activeTab = searchResult?.additionalDetails?.activeTab || "";
       const isDisposedTab = activeTab === "DISPOSED";
       const caseId =
-        (isLPRCase(row) && !isDisposedTab ? row?.lprNumber : row?.courtCaseNumber) || row?.courtCaseNumber || row?.cmpNumber || row?.filingNumber;
+        (row?.isLPRCase && !isDisposedTab ? row?.lprNumber : row?.courtCaseNumber) || row?.courtCaseNumber || row?.cmpNumber || row?.filingNumber;
       switch (key) {
         case "CASE_TYPE":
           return <span>NIA S138</span>;
         case "CS_STAGE":
-          return isLPRCase(row) ? t("Long Pending Register") : t(value);
+          return t(value);
         case "CS_SECONDARY_STAGE": {
           const stages = Array.isArray(value) ? value : [value];
           const normalized = stages.filter(Boolean);
@@ -475,7 +475,7 @@ export const UICustomizations = {
       const activeTab = searchResult?.additionalDetails?.activeTab || "";
       const isDisposedTab = activeTab === "DISPOSED";
       const caseId =
-        (isLPRCase(row) && !isDisposedTab ? row?.lprNumber : row?.courtCaseNumber) || row?.courtCaseNumber || row?.cmpNumber || row?.filingNumber;
+        (row?.isLPRCase && !isDisposedTab ? row?.lprNumber : row?.courtCaseNumber) || row?.courtCaseNumber || row?.cmpNumber || row?.filingNumber;
       switch (key) {
         case "CASE_TYPE":
           return <span>NIA S138</span>;
@@ -484,7 +484,7 @@ export const UICustomizations = {
         case "CD_OUTCOME":
           return t(value);
         case "CS_STAGE":
-          return isLPRCase(row) ? t("Long Pending Register") : t(value);
+          return t(value);
         case "CS_SECONDARY_STAGE": {
           const stages = Array.isArray(value) ? value : [value];
           const normalized = stages.filter(Boolean);
@@ -607,7 +607,7 @@ export const UICustomizations = {
       const activeTab = searchResult?.additionalDetails?.activeTab || "";
       const isDisposedTab = activeTab === "DISPOSED";
       const caseId =
-        (isLPRCase(row) && !isDisposedTab ? row?.lprNumber : row?.courtCaseNumber) || row?.courtCaseNumber || row?.cmpNumber || row?.filingNumber;
+        (row?.isLPRCase && !isDisposedTab ? row?.lprNumber : row?.courtCaseNumber) || row?.courtCaseNumber || row?.cmpNumber || row?.filingNumber;
 
       switch (key) {
         // case "CASE_NAME_ID":

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrdersV2.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrdersV2.js
@@ -49,7 +49,6 @@ import {
   getAuthorizedUuid,
   getOrderActionName,
   getOrderTypes,
-  isLPRCase,
   setApplicationStatus,
 } from "@egovernments/digit-ui-module-dristi/src/Utils";
 import useSearchMiscellaneousTemplate from "../../hooks/orders/useSearchMiscellaneousTemplate";
@@ -338,7 +337,7 @@ const GenerateOrdersV2 = () => {
       else if (isBailApplicationPending) baseSet = ORDER_TYPE_SETS.PENDING_BAIL;
       else baseSet = ORDER_TYPE_SETS.PENDING_DEFAULT;
     } else if (caseDetails?.courtCaseNumber) {
-      if (isLPRCase(caseDetails)) baseSet = ORDER_TYPE_SETS.ADMITTED_LPR;
+      if (caseDetails?.isLPRCase) baseSet = ORDER_TYPE_SETS.ADMITTED_LPR;
       else if (!caseDetails?.lprNumber) baseSet = ORDER_TYPE_SETS.ADMITTED_NO_LPR;
       else baseSet = ORDER_TYPE_SETS.ADMITTED_DEFAULT;
     } else {
@@ -1097,7 +1096,7 @@ const GenerateOrdersV2 = () => {
         updatedFormdata.nameofRespondentAdvocate = uuidNameMap?.[allAdvocates?.[respondentPrimary?.additionalDetails?.uuid]] || "";
         setValueRef?.current?.[index]?.("nameofRespondentAdvocate", updatedFormdata.nameofRespondentAdvocate);
 
-        updatedFormdata.caseNumber = (isLPRCase(caseDetails) ? caseDetails?.lprNumber : caseDetails?.courtCaseNumber) || caseDetails?.courtCaseNumber;
+        updatedFormdata.caseNumber = (caseDetails?.isLPRCase ? caseDetails?.lprNumber : caseDetails?.courtCaseNumber) || caseDetails?.courtCaseNumber;
         setValueRef?.current?.[index]?.("caseNumber", updatedFormdata.caseNumber);
 
         updatedFormdata.nameOfCourt = courtRooms.find((room) => room.code === caseDetails?.courtId)?.name;
@@ -1388,8 +1387,7 @@ const GenerateOrdersV2 = () => {
       applicationData?.applicationList,
       orderTypeData,
       caseDetails?.litigants,
-      caseDetails?.lifecycleStatus,
-      isLPRCase(caseDetails),
+      caseDetails?.isLPRCase,
       caseDetails?.lprNumber,
       caseDetails?.courtCaseNumber,
       caseDetails?.additionalDetails?.respondentDetails?.formdata,
@@ -1616,7 +1614,7 @@ const GenerateOrdersV2 = () => {
       });
 
       const caseNumber =
-        (isLPRCase(caseDetails) ? caseDetails?.lprNumber : caseDetails?.courtCaseNumber) ||
+        (caseDetails?.isLPRCase ? caseDetails?.lprNumber : caseDetails?.courtCaseNumber) ||
         caseDetails?.courtCaseNumber ||
         caseDetails?.cmpNumber ||
         caseDetails?.filingNumber;
@@ -2119,7 +2117,7 @@ const GenerateOrdersV2 = () => {
             "WITHDRAWAL_REJECT",
             "WITHDRAWAL_ACCEPT",
           ].includes(orderType) &&
-          isLPRCase(caseDetails)
+          caseDetails?.isLPRCase
         ) {
           setShowToast({
             label: t("ORDER_NOT_ALLOWED_FOR_LPR_CASE"),
@@ -2550,7 +2548,7 @@ const GenerateOrdersV2 = () => {
       const applicationCMPNumber = documentSubmission?.[0]?.applicationList?.applicationCMPNumber;
       const currentHearingPurpose = documentSubmission?.[0]?.applicationList?.applicationDetails?.initialHearingPurpose || "";
       const caseNumber =
-        (isLPRCase(caseDetails) ? caseDetails?.lprNumber : caseDetails?.courtCaseNumber) ||
+        (caseDetails?.isLPRCase ? caseDetails?.lprNumber : caseDetails?.courtCaseNumber) ||
         caseDetails?.courtCaseNumber ||
         caseDetails?.cmpNumber ||
         caseDetails?.filingNumber;

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/ReviewSummonsNoticeAndWarrant.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/ReviewSummonsNoticeAndWarrant.js
@@ -19,7 +19,7 @@ import { useHistory } from "react-router-dom";
 import isEqual from "lodash/isEqual";
 import ReviewNoticeModal from "../../components/ReviewNoticeModal";
 import useDownloadCasePdf from "@egovernments/digit-ui-module-dristi/src/hooks/dristi/useDownloadCasePdf";
-import { DateUtils, isLPRCase } from "@egovernments/digit-ui-module-dristi/src/Utils";
+import { DateUtils } from "@egovernments/digit-ui-module-dristi/src/Utils";
 import { ORDER_TYPES, CHANNEL_IDS, DELIVERY_CHANNELS } from "../../utils/constants";
 import { CloseBtn, Heading } from "@egovernments/digit-ui-module-dristi/src/components/ModalComponents";
 import CustomToast from "@egovernments/digit-ui-module-dristi/src/components/CustomToast";
@@ -1406,7 +1406,7 @@ const ReviewSummonsNoticeAndWarrant = () => {
             return s.charAt(0) + s.slice(1).toLowerCase();
           })();
           const caseNumber = (
-            (isLPRCase(item) ? item?.lprNumber : item?.courtCaseNumber) ||
+            (item?.isLPRCase ? item?.lprNumber : item?.courtCaseNumber) ||
             item?.courtCaseNumber ||
             item?.cmpNumber ||
             item?.filingNumber ||

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/utils/orderApiCallUtils.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/utils/orderApiCallUtils.js
@@ -1,7 +1,6 @@
 import { HomeService } from "@egovernments/digit-ui-module-home/src/hooks/services";
 import { ordersService } from "../hooks/services";
 import { getMediationChangedFlag, getParties } from "./orderUtils";
-import { isLPRCase } from "@egovernments/digit-ui-module-dristi/src/Utils";
 
 export const getCourtFee = async (channelId, receiverPincode, taskType, tenantId) => {
   try {
@@ -77,7 +76,7 @@ export const addOrderItem = async (
     }));
 
     const caseNumber =
-      (isLPRCase(caseDetails) ? caseDetails?.lprNumber : caseDetails?.courtCaseNumber) ||
+      (caseDetails?.isLPRCase ? caseDetails?.lprNumber : caseDetails?.courtCaseNumber) ||
       caseDetails?.courtCaseNumber ||
       caseDetails?.cmpNumber ||
       caseDetails?.filingNumber;
@@ -160,7 +159,7 @@ export const createOrder = async (order, tenantId, applicationTypeConfigUpdated,
     );
 
     const caseNumber =
-      (isLPRCase(caseDetails) ? caseDetails?.lprNumber : caseDetails?.courtCaseNumber) ||
+      (caseDetails?.isLPRCase ? caseDetails?.lprNumber : caseDetails?.courtCaseNumber) ||
       caseDetails?.courtCaseNumber ||
       caseDetails?.cmpNumber ||
       caseDetails?.filingNumber;


### PR DESCRIPTION
## Summary

Reverts the following two commits from `develop`:

- `3242d9db9a` — fix: resolve infinite recursion in isLPRCase utility function (#6540)
- `87452a4189` — Feat/lpr lifecycle status 5465 (#6530)

These are being removed as requested. History is preserved via revert commits (no force-push).

## Commits reverted

| Commit | PR | Description |
|--------|----|-------------|
| `3242d9db9a` | #6540 | fix: resolve infinite recursion in isLPRCase utility function |
| `87452a4189` | #6530 | Feat/lpr lifecycle status 5465 |

## Test plan

- [ ] Verify LPR lifecycle status feature is no longer present after merge
- [ ] Verify no regressions in unrelated features on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal case classification logic across case management, home, and order modules for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->