### PR TITLE
ci: narrow sync scope to frontend/oncourts-ui only

### DIFF
--- a/.github/workflows/sync-frontend-to-pbhrch.yml
+++ b/.github/workflows/sync-frontend-to-pbhrch.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     paths:
-      - 'frontend/**'
+      - 'frontend/oncourts-ui/**'
   workflow_dispatch:
     inputs:
       from_sha:
@@ -13,7 +13,7 @@ on:
 
 jobs:
   sync-frontend:
-    name: Sync frontend to dristi-frontend-pbhrch
+    name: Sync frontend/oncourts-ui to dristi-frontend-pbhrch
     runs-on: ubuntu-latest
 
     steps:
@@ -54,20 +54,20 @@ jobs:
           echo "from=$FROM" >> $GITHUB_OUTPUT
           echo "to=$TO" >> $GITHUB_OUTPUT
 
-          CHANGED=$(git diff --name-only "$FROM" "$TO" -- frontend/ | wc -l | tr -d ' ')
+          CHANGED=$(git diff --name-only "$FROM" "$TO" -- frontend/oncourts-ui/ | wc -l | tr -d ' ')
           echo "changed_count=$CHANGED" >> $GITHUB_OUTPUT
-          echo "Frontend files changed: $CHANGED"
+          echo "oncourts-ui files changed: $CHANGED"
 
-      - name: Exit - no frontend changes
+      - name: Exit - no oncourts-ui changes
         if: steps.range.outputs.changed_count == '0'
-        run: echo "No frontend/ changes in this range. Nothing to sync."
+        run: echo "No frontend/oncourts-ui changes in this range. Nothing to sync."
 
       - name: Generate patch
         if: steps.range.outputs.changed_count != '0'
         run: |
           FROM="${{ steps.range.outputs.from }}"
           TO="${{ steps.range.outputs.to }}"
-          git diff --binary "$FROM" "$TO" -- frontend/ > /tmp/kerala-frontend.patch
+          git diff --binary "$FROM" "$TO" -- frontend/oncourts-ui/ > /tmp/kerala-frontend.patch
           echo "Patch: $(wc -l < /tmp/kerala-frontend.patch) lines / $(wc -c < /tmp/kerala-frontend.patch) bytes"
 
       - name: Check for existing open sync PR
@@ -102,6 +102,7 @@ jobs:
           BRANCH="sync/kerala-$(date +%Y%m%d%H%M)-${{ github.run_number }}"
           git checkout -b "$BRANCH"
 
+          # -p2 strips 'a/frontend/' → maps frontend/oncourts-ui/* to oncourts-ui/* in pbhrch root
           APPLY_STATUS="clean"
           if ! git apply --binary -p2 /tmp/kerala-frontend.patch 2>/tmp/apply-log.txt; then
             echo "Clean apply failed - retrying with --reject"
@@ -125,7 +126,7 @@ jobs:
           SHORT_TO=$(echo "${{ steps.range.outputs.to }}" | cut -c1-7)
 
           git commit \
-            -m "sync: Kerala frontend ${SHORT_FROM}..${SHORT_TO}" \
+            -m "sync: Kerala oncourts-ui ${SHORT_FROM}..${SHORT_TO}" \
             -m "Source: pucardotorg/dristi-solutions@${{ steps.range.outputs.to }}" \
             -m "Apply status: $APPLY_STATUS"
 
@@ -146,9 +147,9 @@ jobs:
           BRANCH="${{ steps.apply.outputs.branch }}"
           STATUS="${{ steps.apply.outputs.apply_status }}"
 
-          COMMITS=$(git -C .. log --oneline "$FROM".."$TO" -- frontend/ | head -25)
-          FILES=$(git -C .. diff --name-only "$FROM" "$TO" -- frontend/ | sed 's|^frontend/||' | head -30)
-          FILE_COUNT=$(git -C .. diff --name-only "$FROM" "$TO" -- frontend/ | wc -l | tr -d ' ')
+          COMMITS=$(git -C .. log --oneline "$FROM".."$TO" -- frontend/oncourts-ui/ | head -25)
+          FILES=$(git -C .. diff --name-only "$FROM" "$TO" -- frontend/oncourts-ui/ | sed 's|^frontend/||' | head -30)
+          FILE_COUNT=$(git -C .. diff --name-only "$FROM" "$TO" -- frontend/oncourts-ui/ | wc -l | tr -d ' ')
 
           TITLE_SUFFIX=""
           if [ "$STATUS" = "conflicts" ]; then
@@ -161,8 +162,8 @@ jobs:
             --repo pucardotorg/dristi-frontend-pbhrch \
             --base main \
             --head "$BRANCH" \
-            --title "Sync: Kerala -> pbhrch frontend $(date +%Y-%m-%d) #${{ github.run_number }}${TITLE_SUFFIX}" \
-            --body "## Kerala Frontend Sync
+            --title "Sync: Kerala -> pbhrch oncourts-ui $(date +%Y-%m-%d) #${{ github.run_number }}${TITLE_SUFFIX}" \
+            --body "## Kerala oncourts-ui Sync
 
           **Kerala FROM:** ${FROM:0:7} (https://github.com/pucardotorg/dristi-solutions/commit/${FROM})
           **Kerala TO:** ${TO:0:7} (https://github.com/pucardotorg/dristi-solutions/commit/${TO})
@@ -172,8 +173,9 @@ jobs:
           ### Commits synced
           ${COMMITS}
 
-          ### Files changed
+          ### Files changed (under oncourts-ui/)
           ${FILES}
 
           ---
-          Auto-synced by Kerala Sync workflow. Review for pbhrch regressions before merging."
+          Auto-synced from dristi-solutions/frontend/oncourts-ui by Kerala Sync workflow.
+          Review for pbhrch-specific regressions before merging."


### PR DESCRIPTION
## Summary

Updates the Kerala sync workflow to only watch and sync `frontend/oncourts-ui/**` changes instead of all of `frontend/**`.

## Path mapping
```
dristi-solutions/frontend/oncourts-ui/**
        ↓  (git apply -p2 strips 'a/frontend/')
dristi-frontend-pbhrch/oncourts-ui/**
```

## Changes
- `paths` trigger: `frontend/**` → `frontend/oncourts-ui/**`
- All `git diff` filters: `-- frontend/` → `-- frontend/oncourts-ui/`
- PR title and commit message updated to say `oncourts-ui` instead of `frontend`