### PR TITLE
ci: map frontend/** to oncourts-ui/** in pbhrch via --directory flag

### DIFF
--- a/.github/workflows/sync-frontend-to-pbhrch.yml
+++ b/.github/workflows/sync-frontend-to-pbhrch.yml
@@ -1,5 +1,9 @@
 name: Sync Kerala Frontend to dristi-frontend-pbhrch
 
+# Path mapping:
+#   dristi-solutions/frontend/src/foo.js  -->  dristi-frontend-pbhrch/oncourts-ui/src/foo.js
+#   (git apply -p2 strips 'a/frontend/', --directory=oncourts-ui prepends destination)
+
 on:
   push:
     branches: [main]
@@ -13,7 +17,7 @@ on:
 
 jobs:
   sync-frontend:
-    name: Sync frontend to dristi-frontend-pbhrch
+    name: Sync frontend/** to pbhrch/oncourts-ui/**
     runs-on: ubuntu-latest
 
     steps:
@@ -56,7 +60,7 @@ jobs:
 
           CHANGED=$(git diff --name-only "$FROM" "$TO" -- frontend/ | wc -l | tr -d ' ')
           echo "changed_count=$CHANGED" >> $GITHUB_OUTPUT
-          echo "Frontend files changed: $CHANGED"
+          echo "frontend/ files changed: $CHANGED"
 
       - name: Exit - no frontend changes
         if: steps.range.outputs.changed_count == '0'
@@ -102,10 +106,12 @@ jobs:
           BRANCH="sync/kerala-$(date +%Y%m%d%H%M)-${{ github.run_number }}"
           git checkout -b "$BRANCH"
 
+          # -p2 strips 'a/frontend/' from patch paths
+          # --directory=oncourts-ui prepends destination: frontend/src/foo.js → oncourts-ui/src/foo.js
           APPLY_STATUS="clean"
-          if ! git apply --binary -p2 /tmp/kerala-frontend.patch 2>/tmp/apply-log.txt; then
+          if ! git apply --binary -p2 --directory=oncourts-ui /tmp/kerala-frontend.patch 2>/tmp/apply-log.txt; then
             echo "Clean apply failed - retrying with --reject"
-            git apply --binary --reject -p2 /tmp/kerala-frontend.patch 2>/tmp/apply-log.txt || true
+            git apply --binary --reject -p2 --directory=oncourts-ui /tmp/kerala-frontend.patch 2>/tmp/apply-log.txt || true
             APPLY_STATUS="conflicts"
           fi
           cat /tmp/apply-log.txt || true
@@ -147,7 +153,7 @@ jobs:
           STATUS="${{ steps.apply.outputs.apply_status }}"
 
           COMMITS=$(git -C .. log --oneline "$FROM".."$TO" -- frontend/ | head -25)
-          FILES=$(git -C .. diff --name-only "$FROM" "$TO" -- frontend/ | sed 's|^frontend/||' | head -30)
+          FILES=$(git -C .. diff --name-only "$FROM" "$TO" -- frontend/ | sed 's|^frontend/|oncourts-ui/|' | head -30)
           FILE_COUNT=$(git -C .. diff --name-only "$FROM" "$TO" -- frontend/ | wc -l | tr -d ' ')
 
           TITLE_SUFFIX=""
@@ -161,8 +167,10 @@ jobs:
             --repo pucardotorg/dristi-frontend-pbhrch \
             --base main \
             --head "$BRANCH" \
-            --title "Sync: Kerala -> pbhrch frontend $(date +%Y-%m-%d) #${{ github.run_number }}${TITLE_SUFFIX}" \
+            --title "Sync: Kerala -> pbhrch oncourts-ui $(date +%Y-%m-%d) #${{ github.run_number }}${TITLE_SUFFIX}" \
             --body "## Kerala Frontend Sync
+
+          Mapping: dristi-solutions/frontend/** -> dristi-frontend-pbhrch/oncourts-ui/**
 
           **Kerala FROM:** ${FROM:0:7} (https://github.com/pucardotorg/dristi-solutions/commit/${FROM})
           **Kerala TO:** ${TO:0:7} (https://github.com/pucardotorg/dristi-solutions/commit/${TO})
@@ -172,8 +180,8 @@ jobs:
           ### Commits synced
           ${COMMITS}
 
-          ### Files changed
+          ### Files changed (destination paths in pbhrch)
           ${FILES}
 
           ---
-          Auto-synced by Kerala Sync workflow. Review for pbhrch regressions before merging."
+          Auto-synced by Kerala Sync workflow. Review for pbhrch-specific regressions before merging."


### PR DESCRIPTION
## Summary

Fixes the destination path mapping in the Kerala sync workflow.

## Path mapping (before vs after)

| | Source (dristi-solutions) | Destination (dristi-frontend-pbhrch) |
|---|---|---|
| **Before** | `frontend/src/foo.js` | `src/foo.js` (root) |
| **After** | `frontend/src/foo.js` | `oncourts-ui/src/foo.js` |

## How it works

```
git apply -p2             → strips 'a/frontend/'  → src/foo.js
         --directory=oncourts-ui → prepends prefix → oncourts-ui/src/foo.js
```

## Changes
- Added `--directory=oncourts-ui` to both `git apply` calls (clean + reject fallback)
- Updated `sed 's|^frontend/||'` → `sed 's|^frontend/|oncourts-ui/|'` so PR body shows correct destination paths