### PR TITLE
fix: move .last-kerala-sync marker to oncourts-ui/ in sync workflow (develop)

### DIFF
--- a/.github/workflows/sync-frontend-to-pbhrch.yml
+++ b/.github/workflows/sync-frontend-to-pbhrch.yml
@@ -42,11 +42,11 @@ jobs:
           if [ -n "${{ github.event.inputs.from_sha }}" ]; then
             FROM="${{ github.event.inputs.from_sha }}"
             echo "Source: workflow_dispatch from_sha"
-          elif [ -f pbhrch/.last-kerala-sync ]; then
-            FROM=$(cat pbhrch/.last-kerala-sync | tr -d '[:space:]')
-            echo "Source: .last-kerala-sync = $FROM"
+          elif [ -f pbhrch/oncourts-ui/.last-kerala-sync ]; then
+            FROM=$(cat pbhrch/oncourts-ui/.last-kerala-sync | tr -d '[:space:]')
+            echo "Source: oncourts-ui/.last-kerala-sync = $FROM"
           else
-            echo "ERROR: No .last-kerala-sync file in dristi-frontend-pbhrch and no from_sha provided."
+            echo "ERROR: No oncourts-ui/.last-kerala-sync file in dristi-frontend-pbhrch and no from_sha provided."
             exit 1
           fi
 
@@ -107,7 +107,7 @@ jobs:
           git checkout -b "$BRANCH"
 
           # -p2 strips 'a/frontend/' from patch paths
-          # --directory=oncourts-ui prepends destination: frontend/src/foo.js → oncourts-ui/src/foo.js
+          # --directory=oncourts-ui prepends destination: frontend/src/foo.js -> oncourts-ui/src/foo.js
           APPLY_STATUS="clean"
           if ! git apply --binary -p2 --directory=oncourts-ui /tmp/kerala-frontend.patch 2>/tmp/apply-log.txt; then
             echo "Clean apply failed - retrying with --reject"
@@ -118,7 +118,7 @@ jobs:
 
           echo "apply_status=$APPLY_STATUS" >> $GITHUB_OUTPUT
 
-          echo "${{ steps.range.outputs.to }}" > .last-kerala-sync
+          echo "${{ steps.range.outputs.to }}" > oncourts-ui/.last-kerala-sync
 
           git add -A
           if git diff --staged --quiet; then


### PR DESCRIPTION
## Summary

Updates the sync workflow on `develop` to match the fix already applied to `main` (commit `29b4b8aa`).

**3 lines changed** in `.github/workflows/sync-frontend-to-pbhrch.yml`:

| Before | After |
|--------|-------|
| `elif [ -f pbhrch/.last-kerala-sync ]` | `elif [ -f pbhrch/oncourts-ui/.last-kerala-sync ]` |
| `FROM=$(cat pbhrch/.last-kerala-sync \| ...)` | `FROM=$(cat pbhrch/oncourts-ui/.last-kerala-sync \| ...)` |
| `echo "..." > .last-kerala-sync` | `echo "..." > oncourts-ui/.last-kerala-sync` |

## Why

The sync marker file was moved from the repo root to `oncourts-ui/.last-kerala-sync` in `dristi-frontend-pbhrch` (commit `0ae8862`). Without this fix the workflow on `develop` (the default branch) reads from the wrong path and would fail with "No .last-kerala-sync file found" on the next `workflow_dispatch` run.

## Test plan
- [ ] Merge this PR
- [ ] Trigger "Sync Kerala Frontend" via workflow_dispatch on `develop`
- [ ] Verify workflow reads `oncourts-ui/.last-kerala-sync` correctly and creates a sync PR in `dristi-frontend-pbhrch`