### PR TITLE
fix: fetch judge designation from MDMS and remove duplicate footer in witness deposition #5688

### DIFF
--- a/backend/ui-integration-services/dristi-pdf/src/hearingHandlers/witnessDeposition.js
+++ b/backend/ui-integration-services/dristi-pdf/src/hearingHandlers/witnessDeposition.js
@@ -183,7 +183,7 @@ const witnessDeposition = async (req, res, qrCode) => {
           depositionType: "",
           witnessDeposition: witnessDepositionText,
           witnessPlaceholder: "Deponent",
-          judgePlaceholder: "Judicial Magistrate of First Class",
+          judgePlaceholder: courtCaseJudgeDetails.judgeDetails?.designation,
           qrCodeUrl: base64Url,
           designation:
             witnessEvidence.additionalDetails.witnessDetails.designation,

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/BulkWitnessDepositionView.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/BulkWitnessDepositionView.js
@@ -51,6 +51,12 @@ function BulkWitnessDepositionView({ showToast = () => {} }) {
   const hasEvidenceEsignAccess = useMemo(() => roles?.some((role) => role.code === "EVIDENCE_ESIGN"), [roles]);
   const [needConfigRefresh, setNeedConfigRefresh] = useState(false);
   const [counter, setCounter] = useState(0);
+
+  const { data: designationData } = Digit.Hooks.useCustomMDMS(tenantId, "common-masters", [{ name: "Designation" }]);
+  const judgeDesignation = useMemo(
+    () => designationData?.["common-masters"]?.Designation?.find((d) => d.code === "JUDICIAL_MAGISTRATE")?.name || "",
+    [designationData]
+  );
   const config = useMemo(() => {
     const setWitnessDepositionFunc = async (deposition) => {
       setShowBulkSignModal(true);
@@ -215,7 +221,7 @@ function BulkWitnessDepositionView({ showToast = () => {} }) {
             return {
               fileStoreId: deposition?.businessObject?.artifactDetails?.file?.fileStore,
               artifactNumber: deposition?.businessObject?.artifactDetails?.artifactNumber,
-              placeholder: "Judicial Magistrate of First Class",
+              placeholder: judgeDesignation,
               tenantId: tenantId,
             };
           });

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/WitnessDepositionSignModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/WitnessDepositionSignModal.js
@@ -83,6 +83,12 @@ export const WitnessDepositionSignModal = ({
   const { uploadDocuments } = Digit.Hooks.orders.useDocumentUpload();
   const mockESignEnabled = window?.globalConfigs?.getConfig("mockESignEnabled") === "true" ? true : false;
 
+  const { data: designationData } = Digit.Hooks.useCustomMDMS(tenantId, "common-masters", [{ name: "Designation" }]);
+  const judgeDesignation = useMemo(
+    () => designationData?.["common-masters"]?.Designation?.find((d) => d.code === "JUDICIAL_MAGISTRATE")?.name || "",
+    [designationData]
+  );
+
   const witnessDepositionDocuments = useMemo(() => {
     return effectiveRowData?.businessObject?.artifactDetails?.file || effectiveRowData?.file || docObj?.artifactList.file
       ? [effectiveRowData?.businessObject?.artifactDetails?.file || effectiveRowData?.file || docObj?.artifactList.file]
@@ -321,7 +327,7 @@ export const WitnessDepositionSignModal = ({
           sessionStorage.setItem("bulkWitnessDepositionSignCaseTitle", witnessDepositionPaginationData?.caseTitle);
         if (witnessDepositionPaginationData?.offset)
           sessionStorage.setItem("bulkWitnessDepositionSignoffset", witnessDepositionPaginationData?.offset);
-        handleEsign(name, pageModule, selectedWitnessDepositionFilestoreid, "Judicial Magistrate of First Class");
+        handleEsign(name, pageModule, selectedWitnessDepositionFilestoreid, judgeDesignation);
       } catch (error) {
         console.error("E-sign navigation error:", error);
         setLoader(false);

--- a/support/v1.18.0-sprint-32/deployment.md
+++ b/support/v1.18.0-sprint-32/deployment.md
@@ -1,2 +1,7 @@
 need to restart egov-accesscontrol service
 'need to restart egov-encrption service and case service
+
+## Fix #5688 - Judge Designation MDMS Update
+- Run MDMS data update: `support/v1.18.0-sprint-32/mdms-data/fix-5688-designation-update.json5`
+- Updates `common-masters.Designation` entry with code `JUDICIAL_MAGISTRATE` — changes `name` to "Judicial Magistrate of First Class"
+- Restart dristi-pdf service after deploying

--- a/support/v1.18.0-sprint-32/mdms-data/fix-5688-designation-update.json5
+++ b/support/v1.18.0-sprint-32/mdms-data/fix-5688-designation-update.json5
@@ -1,0 +1,15 @@
+[
+  {
+    "id": "2dfa01a4-c780-462e-9e6e-b10f8814e259",
+    "tenantId": "kl",
+    "schemaCode": "common-masters.Designation",
+    "uniqueIdentifier": "JUDICIAL_MAGISTRATE",
+    "data": {
+      "code": "JUDICIAL_MAGISTRATE",
+      "name": "Judicial Magistrate of First Class",
+      "active": true,
+      "description": "Judicial Magistrate of First Class"
+    },
+    "isActive": true
+  }
+]


### PR DESCRIPTION
## Requirements

- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the github issues('s)
- [x] I performed a self-review of my own code
- [x] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [x] I have added MDMS data changes to `support/v1.18.0-sprint-32/mdms-data/fix-5688-designation-update.json5`
  - [x] I have added deployment configuration steps to `support/v1.18.0-sprint-32/deployment.md`

## Summary

Cherry-pick of [#6534](https://github.com/pucardotorg/dristi-solutions/pull/6534) and [#6535](https://github.com/pucardotorg/dristi-solutions/pull/6535) from `develop` → `main`.

Closes https://github.com/pucardotorg/dristi/issues/5688

**Code fix (from #6534):**
- `backend/ui-integration-services/dristi-pdf/src/hearingHandlers/witnessDeposition.js` — uses `courtCaseJudgeDetails.judgeDetails?.designation` fetched from MDMS via `getCourtAndJudgeDetails`
- `frontend/.../home/src/pages/employee/WitnessDepositionSignModal.js` — fetches designation via `Digit.Hooks.useCustomMDMS` and passes it to `handleEsign`
- `frontend/.../home/src/pages/employee/BulkWitnessDepositionView.js` — fetches designation via `Digit.Hooks.useCustomMDMS` and passes it as `placeholder` in the bulk sign payload

**MDMS data fix (from #6535):**
- Updates `common-masters.Designation` record `JUDICIAL_MAGISTRATE` — changes `name` from `"Judicial Magistrate 1st Class"` to `"Judicial Magistrate of First Class"`
- **Post-deploy:** Restart dristi-pdf service

## Data Changes

- **File:** `support/v1.18.0-sprint-32/mdms-data/fix-5688-designation-update.json5`
- **Schema:** `common-masters.Designation`
- **Record:** `JUDICIAL_MAGISTRATE` (id: `2dfa01a4-c780-462e-9e6e-b10f8814e259`)
- **Change:** `name` updated to `"Judicial Magistrate of First Class"`

## Other

No breaking changes. No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)