### PR TITLE
ci: add sync workflow for backend/ui-integration-services -> pbhrch

### DIFF
--- a/.github/workflows/sync-ui-services-to-pbhrch.yml
+++ b/.github/workflows/sync-ui-services-to-pbhrch.yml
@@ -1,0 +1,191 @@
+name: Sync Kerala UI-Integration-Services to dristi-frontend-pbhrch
+
+# Path mapping:
+#   dristi-solutions/backend/ui-integration-services/foo.js  ->  dristi-frontend-pbhrch/ui-integration-services/foo.js
+#   (git apply -p2 strips 'a/backend/', leaving ui-integration-services/foo.js directly)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'backend/ui-integration-services/**'
+  workflow_dispatch:
+    inputs:
+      from_sha:
+        description: 'Starting Kerala commit SHA (leave empty to use .last-kerala-ui-services-sync)'
+        required: false
+
+jobs:
+  sync-ui-services:
+    name: Sync backend/ui-integration-services/** to pbhrch/ui-integration-services/**
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout dristi-solutions (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout dristi-frontend-pbhrch
+        uses: actions/checkout@v4
+        with:
+          repository: pucardotorg/dristi-frontend-pbhrch
+          token: ${{ secrets.PBHRCH_SYNC_TOKEN }}
+          path: pbhrch
+          fetch-depth: 0
+
+      - name: Determine sync range
+        id: range
+        run: |
+          TO="${{ github.sha }}"
+
+          if [ -n "${{ github.event.inputs.from_sha }}" ]; then
+            FROM="${{ github.event.inputs.from_sha }}"
+            echo "Source: workflow_dispatch from_sha"
+          elif [ -f pbhrch/ui-integration-services/.last-kerala-ui-services-sync ]; then
+            FROM=$(cat pbhrch/ui-integration-services/.last-kerala-ui-services-sync | tr -d '[:space:]')
+            echo "Source: ui-integration-services/.last-kerala-ui-services-sync = $FROM"
+          else
+            echo "ERROR: No ui-integration-services/.last-kerala-ui-services-sync in dristi-frontend-pbhrch and no from_sha provided."
+            exit 1
+          fi
+
+          if ! git cat-file -e "${FROM}^{commit}" 2>/dev/null; then
+            echo "ERROR: SHA '$FROM' not found in dristi-solutions history."
+            exit 1
+          fi
+
+          echo "from=$FROM" >> $GITHUB_OUTPUT
+          echo "to=$TO" >> $GITHUB_OUTPUT
+
+          CHANGED=$(git diff --name-only "$FROM" "$TO" -- backend/ui-integration-services/ | wc -l | tr -d ' ')
+          echo "changed_count=$CHANGED" >> $GITHUB_OUTPUT
+          echo "backend/ui-integration-services/ files changed: $CHANGED"
+
+      - name: Exit - no ui-integration-services changes
+        if: steps.range.outputs.changed_count == '0'
+        run: echo "No backend/ui-integration-services/ changes in this range. Nothing to sync."
+
+      - name: Generate patch
+        if: steps.range.outputs.changed_count != '0'
+        run: |
+          FROM="${{ steps.range.outputs.from }}"
+          TO="${{ steps.range.outputs.to }}"
+          git diff --binary "$FROM" "$TO" -- backend/ui-integration-services/ > /tmp/kerala-ui-services.patch
+          echo "Patch: $(wc -l < /tmp/kerala-ui-services.patch) lines / $(wc -c < /tmp/kerala-ui-services.patch) bytes"
+
+      - name: Check for existing open sync PR
+        if: steps.range.outputs.changed_count != '0'
+        id: existing_pr
+        env:
+          GH_TOKEN: ${{ secrets.PBHRCH_SYNC_TOKEN }}
+        run: |
+          COUNT=$(gh pr list \
+            --repo pucardotorg/dristi-frontend-pbhrch \
+            --base main --state open \
+            --json title \
+            --jq '[.[] | select(.title | startswith("Sync: Kerala UI-Services"))] | length')
+          echo "open_count=$COUNT" >> $GITHUB_OUTPUT
+          echo "Open Kerala UI-Services sync PRs: $COUNT"
+
+      - name: Skip - existing sync PR is open
+        if: steps.range.outputs.changed_count != '0' && steps.existing_pr.outputs.open_count != '0'
+        run: |
+          echo "An open sync PR already exists in dristi-frontend-pbhrch."
+          echo "Merge or close it before triggering a new sync."
+
+      - name: Create sync branch and apply patch
+        if: steps.range.outputs.changed_count != '0' && steps.existing_pr.outputs.open_count == '0'
+        id: apply
+        run: |
+          cd pbhrch
+
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "Kerala Sync Bot"
+
+          BRANCH="sync/kerala-ui-services-$(date +%Y%m%d%H%M)-${{ github.run_number }}"
+          git checkout -b "$BRANCH"
+
+          # -p2 strips 'a/backend/' from patch paths
+          # Result: backend/ui-integration-services/foo.js -> ui-integration-services/foo.js
+          APPLY_STATUS="clean"
+          if ! git apply --binary -p2 /tmp/kerala-ui-services.patch 2>/tmp/apply-log.txt; then
+            echo "Clean apply failed - retrying with --reject"
+            git apply --binary --reject -p2 /tmp/kerala-ui-services.patch 2>/tmp/apply-log.txt || true
+            APPLY_STATUS="conflicts"
+          fi
+          cat /tmp/apply-log.txt || true
+
+          echo "apply_status=$APPLY_STATUS" >> $GITHUB_OUTPUT
+
+          echo "${{ steps.range.outputs.to }}" > ui-integration-services/.last-kerala-ui-services-sync
+
+          git add -A
+          if git diff --staged --quiet; then
+            echo "No staged changes after apply - patch was a no-op."
+            echo "branch=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          SHORT_FROM=$(echo "${{ steps.range.outputs.from }}" | cut -c1-7)
+          SHORT_TO=$(echo "${{ steps.range.outputs.to }}" | cut -c1-7)
+
+          git commit \
+            -m "sync: Kerala ui-integration-services ${SHORT_FROM}..${SHORT_TO}" \
+            -m "Source: pucardotorg/dristi-solutions@${{ steps.range.outputs.to }}" \
+            -m "Apply status: $APPLY_STATUS"
+
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+
+      - name: Push and create PR
+        if: |
+          steps.range.outputs.changed_count != '0' &&
+          steps.existing_pr.outputs.open_count == '0' &&
+          steps.apply.outputs.branch != ''
+        env:
+          GH_TOKEN: ${{ secrets.PBHRCH_SYNC_TOKEN }}
+        run: |
+          cd pbhrch
+
+          FROM="${{ steps.range.outputs.from }}"
+          TO="${{ steps.range.outputs.to }}"
+          BRANCH="${{ steps.apply.outputs.branch }}"
+          STATUS="${{ steps.apply.outputs.apply_status }}"
+
+          COMMITS=$(git -C .. log --oneline "$FROM".."$TO" -- backend/ui-integration-services/ | head -25)
+          FILES=$(git -C .. diff --name-only "$FROM" "$TO" -- backend/ui-integration-services/ | sed 's|^backend/||' | head -30)
+          FILE_COUNT=$(git -C .. diff --name-only "$FROM" "$TO" -- backend/ui-integration-services/ | wc -l | tr -d ' ')
+
+          TITLE_SUFFIX=""
+          if [ "$STATUS" = "conflicts" ]; then
+            TITLE_SUFFIX=" [CONFLICTS]"
+          fi
+
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --repo pucardotorg/dristi-frontend-pbhrch \
+            --base main \
+            --head "$BRANCH" \
+            --title "Sync: Kerala UI-Services -> pbhrch $(date +%Y-%m-%d) #${{ github.run_number }}${TITLE_SUFFIX}" \
+            --body "## Kerala UI-Integration-Services Sync
+
+          Mapping: dristi-solutions/backend/ui-integration-services/** -> dristi-frontend-pbhrch/ui-integration-services/**
+
+          **Kerala FROM:** ${FROM:0:7} (https://github.com/pucardotorg/dristi-solutions/commit/${FROM})
+          **Kerala TO:** ${TO:0:7} (https://github.com/pucardotorg/dristi-solutions/commit/${TO})
+          **Files changed:** ${FILE_COUNT}
+          **Apply status:** ${STATUS}
+
+          ### Commits synced
+          \`\`\`
+          ${COMMITS}
+          \`\`\`
+
+          ### Files changed (destination paths in pbhrch)
+          \`\`\`
+          ${FILES}
+          \`\`\`
+
+          ---
+          Auto-synced by Kerala UI-Services Sync workflow. Review for pbhrch-specific regressions before merging."


### PR DESCRIPTION
## Summary

Adds a new GitHub Actions workflow to automatically sync changes from `dristi-solutions/backend/ui-integration-services/**` into `dristi-frontend-pbhrch/ui-integration-services/**` as a reviewable PR.

Mirrors the existing frontend sync workflow pattern.

## Path mapping

```
dristi-solutions/backend/ui-integration-services/foo.js
    -> dristi-frontend-pbhrch/ui-integration-services/foo.js
```

**How:** `git diff -- backend/ui-integration-services/` | `git apply -p2`
- `-p2` strips the `a/backend/` prefix, leaving `ui-integration-services/foo.js` at the correct destination path.
- No `--directory` flag needed (unlike the frontend workflow).

## Sync marker

`dristi-frontend-pbhrch/ui-integration-services/.last-kerala-ui-services-sync`

Bootstrapped to the current `main` HEAD (`5af292b8`). A companion commit to `dristi-frontend-pbhrch` will add this file.

## Triggers

- Auto: push to `main` touching `backend/ui-integration-services/**`
- Manual: `workflow_dispatch` with optional `from_sha`

## Test plan
- [ ] Merge this PR (and the companion PR to `develop` for the Run Workflow button)
- [ ] Trigger `workflow_dispatch` manually — verify a sync PR appears in `dristi-frontend-pbhrch` with files under `ui-integration-services/`