### PR TITLE
Enhance 5686

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/Utils/authenticatedLink.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/Utils/authenticatedLink.js
@@ -1,7 +1,7 @@
 import React from "react";
 import axiosInstance from "@egovernments/digit-ui-module-core/src/Utils/axiosInstance";
 
-const AuthenticatedLink = ({ t, uri, displayFilename = false, pdf = false }) => {
+const AuthenticatedLink = ({ t, uri, displayFilename = false, pdf = false, name = "downloadedFile" }) => {
   const handleClick = (e) => {
     e.preventDefault();
 
@@ -21,7 +21,7 @@ const AuthenticatedLink = ({ t, uri, displayFilename = false, pdf = false }) => 
           const blobUrl = URL.createObjectURL(blob);
           const link = document.createElement("a");
           link.href = blobUrl;
-          link.download = `downloadedFile.${extension}`;
+          link.download = `${name}.${extension}`;
           document.body.appendChild(link);
           link.click();
           document.body.removeChild(link);

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/Utils/index.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/Utils/index.js
@@ -1121,3 +1121,7 @@ export const isRichTextEmpty = (html) => {
   const plainText = html?.replace(/<[^>]*>/g, "").trim();
   return plainText?.length === 0;
 };
+
+export const formatTitle = (translatedTitle) => {
+  return (translatedTitle || "").trim().replace(/\s+/g, "_");
+};

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/UploadSignatureModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/UploadSignatureModal.js
@@ -27,6 +27,7 @@ function UploadSignatureModal({
   fileUploadError,
   onCustomDownload,
   setFileUploadError,
+  downloadedFileName,
 }) {
   const [error, setError] = useState({});
   const tenantId = window?.Digit.ULBService.getCurrentTenantId();
@@ -124,7 +125,7 @@ function UploadSignatureModal({
               {t("CLICK_HERE")}
             </span>
           ) : (
-            <AuthenticatedLink uri={uri} t={t} displayFilename={"CLICK_HERE"} pdf={true} />
+            <AuthenticatedLink uri={uri} t={t} displayFilename={"CLICK_HERE"} pdf={true} name={downloadedFileName} />
           )}
         </div>
       )}

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/ComplainantSignature.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/ComplainantSignature.js
@@ -628,7 +628,11 @@ const ComplainantSignature = ({ path }) => {
   }, [litigants, loggedInUserOnBehalfOfUuid]);
 
   const handleCasePdf = () => {
-    downloadPdf(tenantId, signatureDocumentId ? signatureDocumentId : DocumentFileStoreId);
+    downloadPdf(
+      tenantId,
+      signatureDocumentId ? signatureDocumentId : DocumentFileStoreId,
+      `${caseDetails?.caseNumber || caseDetails?.filingNumber || "Case"}_Complaint`
+    );
   };
 
   const getPlaceholder = () => {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/ComplainantSignature.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/ComplainantSignature.js
@@ -628,11 +628,8 @@ const ComplainantSignature = ({ path }) => {
   }, [litigants, loggedInUserOnBehalfOfUuid]);
 
   const handleCasePdf = () => {
-    downloadPdf(
-      tenantId,
-      signatureDocumentId ? signatureDocumentId : DocumentFileStoreId,
-      `${caseDetails?.caseNumber || caseDetails?.filingNumber || "Case"}_Complaint`
-    );
+    const name = `${caseDetails?.courtCaseNumber || caseDetails?.cmpNumber || caseDetails?.filingNumber || "Case"}_Complaint`;
+    downloadPdf(tenantId, signatureDocumentId ? signatureDocumentId : DocumentFileStoreId, name);
   };
 
   const getPlaceholder = () => {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingCases.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingCases.js
@@ -2840,7 +2840,7 @@ function EFilingCases({ path }) {
     const url = window.URL.createObjectURL(blob);
     const link = document.createElement("a");
     link.href = url;
-    link.setAttribute("download", `${caseDetails?.filingNumber || "CasePdf"}.pdf`);
+    link.setAttribute("download", `${caseDetails?.caseNumber || caseDetails?.filingNumber || "Case"}_Complaint.pdf`);
     document.body.appendChild(link);
     link.click();
     link.parentNode.removeChild(link);

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingCases.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingCases.js
@@ -2840,7 +2840,8 @@ function EFilingCases({ path }) {
     const url = window.URL.createObjectURL(blob);
     const link = document.createElement("a");
     link.href = url;
-    link.setAttribute("download", `${caseDetails?.caseNumber || caseDetails?.filingNumber || "Case"}_Complaint.pdf`);
+    const name = `${caseDetails?.courtCaseNumber || caseDetails?.cmpNumber || caseDetails?.filingNumber || "Case"}_Complaint.pdf`;
+    link.setAttribute("download", name);
     document.body.appendChild(link);
     link.click();
     link.parentNode.removeChild(link);

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingPayment.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingPayment.js
@@ -282,7 +282,7 @@ function EFilingPayment({ t, submitModalInfo = mockSubmitModalInfo, path }) {
             labelClassName={"secondary-label-selector"}
             style={{ minWidth: "30%" }}
             onButtonClick={() => {
-              downloadPdf(tenantId, fileStoreIdToUse);
+              downloadPdf(tenantId, fileStoreIdToUse, `${caseDetails?.caseNumber || caseDetails?.filingNumber || "Case"}_Complaint`);
               sessionStorage.removeItem("fileStoreId");
             }}
           />
@@ -357,7 +357,16 @@ function EFilingPayment({ t, submitModalInfo = mockSubmitModalInfo, path }) {
                 variation="secondary"
                 className={"pay-online-button"}
                 icon={receiptFilstoreId && <PrintIcon />}
-                onButtonClick={receiptFilstoreId ? () => downloadPdf(tenantId, receiptFilstoreId) : onTaskPayOnline}
+                onButtonClick={
+                  receiptFilstoreId
+                    ? () =>
+                        downloadPdf(
+                          tenantId,
+                          receiptFilstoreId,
+                          `${caseDetails?.caseNumber || caseDetails?.filingNumber || "Case"}_Efiling_payment_Receipt`
+                        )
+                    : onTaskPayOnline
+                }
                 isDisabled={paymentLoader || isCaseLocked}
               />
             </div>

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingPayment.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingPayment.js
@@ -282,7 +282,11 @@ function EFilingPayment({ t, submitModalInfo = mockSubmitModalInfo, path }) {
             labelClassName={"secondary-label-selector"}
             style={{ minWidth: "30%" }}
             onButtonClick={() => {
-              downloadPdf(tenantId, fileStoreIdToUse, `${caseDetails?.caseNumber || caseDetails?.filingNumber || "Case"}_Complaint`);
+              downloadPdf(
+                tenantId,
+                fileStoreIdToUse,
+                `${caseDetails?.courtCaseNumber || caseDetails?.cmpNumber || caseDetails?.filingNumber || "Case"}_Complaint`
+              );
               sessionStorage.removeItem("fileStoreId");
             }}
           />
@@ -363,7 +367,7 @@ function EFilingPayment({ t, submitModalInfo = mockSubmitModalInfo, path }) {
                         downloadPdf(
                           tenantId,
                           receiptFilstoreId,
-                          `${caseDetails?.caseNumber || caseDetails?.filingNumber || "Case"}_Efiling_payment_Receipt`
+                          `${caseDetails?.courtCaseNumber || caseDetails?.cmpNumber || caseDetails?.filingNumber || "Case"}_Efiling_payment_Receipt`
                         )
                     : onTaskPayOnline
                 }

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCaseV2.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCaseV2.js
@@ -1556,9 +1556,9 @@ const AdmittedCaseV2 = () => {
 
   const handleDownloadClick = useCallback(() => {
     if (casePdfFileStoreId) {
-      downloadPdf(tenantId, casePdfFileStoreId);
+      downloadPdf(tenantId, casePdfFileStoreId, `${caseDetails?.caseNumber || caseDetails?.filingNumber}_CaseFile`); //here
     }
-  }, [casePdfFileStoreId, downloadPdf, tenantId]);
+  }, [casePdfFileStoreId, downloadPdf, tenantId, caseDetails]);
 
   const pipComplainants = useMemo(() => getPipComplainants(caseDetails), [caseDetails]);
 

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCaseV2.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCaseV2.js
@@ -2008,10 +2008,14 @@ const AdmittedCaseV2 = () => {
   const handleDownload = useCallback(
     (filestoreId) => {
       if (filestoreId) {
-        downloadPdf(tenantId, filestoreId);
+        const name = `${caseDetails?.courtCaseNumber || caseDetails?.cmpNumber || caseDetails?.filingNumber || "Case"}_${
+          currentOrder?.orderNumber
+        }_Order`;
+
+        downloadPdf(tenantId, filestoreId, name);
       }
     },
-    [downloadPdf, tenantId]
+    [downloadPdf, tenantId, caseDetails, currentOrder]
   );
 
   const handleOrdersTab = useCallback(() => {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCaseV2.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCaseV2.js
@@ -1556,7 +1556,8 @@ const AdmittedCaseV2 = () => {
 
   const handleDownloadClick = useCallback(() => {
     if (casePdfFileStoreId) {
-      downloadPdf(tenantId, casePdfFileStoreId, `${caseDetails?.caseNumber || caseDetails?.filingNumber}_CaseFile`); //here
+      const name = `${caseDetails?.courtCaseNumber || caseDetails?.cmpNumber || caseDetails?.filingNumber}_CaseFile`;
+      downloadPdf(tenantId, casePdfFileStoreId, name);
     }
   }, [casePdfFileStoreId, downloadPdf, tenantId, caseDetails]);
 

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/CaseBundleView.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/CaseBundleView.js
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { useQuery } from "react-query";
 import { Loader } from "@egovernments/digit-ui-react-components";
 import DocViewerWrapper from "../docViewerWrapper";
-import { modifiedEvidenceNumber } from "../../../Utils";
+import { formatTitle, modifiedEvidenceNumber } from "../../../Utils";
 import useDownloadCasePdf from "../../../hooks/dristi/useDownloadCasePdf";
 import useDownloadFiles from "../../../hooks/dristi/useDownloadFiles";
 import MarkAsEvidence from "./MarkAsEvidence";
@@ -27,6 +27,7 @@ function CaseBundleView({ caseDetails, tenantId, filingNumber }) {
 
   const [selectedDocument, setSelectedDocument] = useState(null);
   const [selectedFileStoreId, setSelectedFileStoreId] = useState(null);
+  const [currentItem, setCurrentItem] = useState(null);
   const { downloadPdf } = useDownloadCasePdf();
   const { downloadFilesAsZip } = useDownloadFiles();
   const [showEvidenceConfirmationModal, setShowEvidenceConfirmationModal] = useState(false);
@@ -84,9 +85,11 @@ function CaseBundleView({ caseDetails, tenantId, filingNumber }) {
       const firstValidNode = previewNodes.find((node) => node.fileStoreId || (node.children && node.children.length > 0));
       if (firstValidNode) {
         if (firstValidNode.fileStoreId) {
+          setCurrentItem(firstValidNode);
           setSelectedDocument(firstValidNode.id);
           setSelectedFileStoreId(firstValidNode.fileStoreId);
         } else if (firstValidNode.children?.[0]?.fileStoreId) {
+          setCurrentItem(firstValidNode.children[0]);
           setSelectedDocument(firstValidNode.children[0].id);
           setSelectedFileStoreId(firstValidNode.children[0].fileStoreId);
         }
@@ -129,7 +132,8 @@ function CaseBundleView({ caseDetails, tenantId, filingNumber }) {
     });
   };
 
-  const handleDocumentSelect = (docId, fileStoreId) => {
+  const handleDocumentSelect = (docId, fileStoreId, item) => {
+    setCurrentItem(item);
     setSelectedDocument(docId);
     setSelectedFileStoreId(fileStoreId);
   };
@@ -172,26 +176,33 @@ function CaseBundleView({ caseDetails, tenantId, filingNumber }) {
       }));
   }, [previewNodes]);
 
-  // Handle download for either single PDF or ZIP containing evidence file and seal
   const handleDownload = (fileStoreId) => {
-    if (evidenceFileStoreMap?.has(fileStoreId)) {
-      const evidenceData = evidenceFileStoreMap.get(fileStoreId);
-      // Check if evidence is marked as COMPLETED and has a seal object
-      if (evidenceData?.evidenceMarkedStatus === "COMPLETED" && evidenceData?.seal?.fileStore) {
-        // Download both evidence and seal files as a ZIP
-        const filesToDownload = [
-          { fileStoreId: fileStoreId, fileName: `Evidence_${evidenceData.evidenceNumber || "File"}` },
-          { fileStoreId: evidenceData.seal.fileStore, fileName: `Seal_${evidenceData.evidenceNumber || "File"}` },
-        ];
-        downloadFilesAsZip(tenantId, filesToDownload, `Evidence_${evidenceData.evidenceNumber || "Files"}`);
-      } else {
-        // Normal PDF download if not completed or no seal
-        downloadPdf(tenantId, fileStoreId);
-      }
-    } else {
-      // Normal PDF download for non-evidence files
-      downloadPdf(tenantId, fileStoreId);
+    const evidenceData = evidenceFileStoreMap?.get(fileStoreId);
+
+    // Check if evidence is marked as COMPLETED and has a seal object
+    const isCompletedWithSeal = evidenceData?.evidenceMarkedStatus === "COMPLETED" && evidenceData?.seal?.fileStore;
+
+    if (isCompletedWithSeal) {
+      // Download both evidence and seal files as a ZIP
+      const evidenceNumber = evidenceData.evidenceNumber || "File";
+
+      return downloadFilesAsZip(
+        tenantId,
+        [
+          { fileStoreId, fileName: `Evidence_${evidenceNumber}` },
+          { fileStoreId: evidenceData.seal.fileStore, fileName: `Seal_${evidenceNumber}` },
+        ],
+        `Evidence_${evidenceNumber}`
+      );
     }
+
+    // Normal PDF download if not completed or no seal
+    // Normal PDF download for non-evidence files
+    return downloadPdf(
+      tenantId,
+      fileStoreId,
+      `${caseDetails?.caseNumber || caseDetails?.filingNumber || "File"}_${formatTitle(t(currentItem?.title || ""))}`
+    );
   };
 
   const localizeTitle = (title) => {
@@ -278,7 +289,7 @@ function CaseBundleView({ caseDetails, tenantId, filingNumber }) {
             if (item.hasChildren) {
               toggleExpanded(item);
             } else if (item.fileStoreId && item.id !== selectedDocument) {
-              handleDocumentSelect(item.id, item.fileStoreId);
+              handleDocumentSelect(item.id, item.fileStoreId, item);
             }
           }}
           onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = isSelected ? "#E8E8E8" : "#F9FAFB")}

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/CaseBundleView.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/CaseBundleView.js
@@ -198,11 +198,10 @@ function CaseBundleView({ caseDetails, tenantId, filingNumber }) {
 
     // Normal PDF download if not completed or no seal
     // Normal PDF download for non-evidence files
-    return downloadPdf(
-      tenantId,
-      fileStoreId,
-      `${caseDetails?.caseNumber || caseDetails?.filingNumber || "File"}_${formatTitle(t(currentItem?.title || ""))}`
-    );
+    const name = `${caseDetails?.courtCaseNumber || caseDetails?.cmpNumber || caseDetails?.filingNumber || "File"}_${formatTitle(
+      t(currentItem?.title || "")
+    )}`;
+    return downloadPdf(tenantId, fileStoreId, name);
   };
 
   const localizeTitle = (title) => {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/DocumentsV2.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/DocumentsV2.js
@@ -408,7 +408,7 @@ const DocumentsV2 = ({
         setVoidReason(row?.reason);
         setShowVoidModal(true);
       } else if ("download_filing" === item.id) {
-        downloadPdf(tenantId, row?.file?.fileStore);
+        downloadPdf(tenantId, row?.file?.fileStore, `${row?.artifactNumber}_${row?.additionalDetails?.formdata?.documentTitle || row?.artifactType}`);
       } else if ("delete_evidence_draft" === item.id) {
         evidenceDeleteFunc(row);
       }

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/DocumentsV2.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/DocumentsV2.js
@@ -408,7 +408,10 @@ const DocumentsV2 = ({
         setVoidReason(row?.reason);
         setShowVoidModal(true);
       } else if ("download_filing" === item.id) {
-        downloadPdf(tenantId, row?.file?.fileStore, `${row?.artifactNumber}_${row?.additionalDetails?.formdata?.documentTitle || row?.artifactType}`);
+        const name = `${caseDetails?.courtCaseNumber || caseDetails?.cmpNumber || caseDetails?.filingNumber || "Case"}_${
+          row?.artifactNumber || ""
+        }_Document`;
+        downloadPdf(tenantId, row?.file?.fileStore, name);
       } else if ("delete_evidence_draft" === item.id) {
         evidenceDeleteFunc(row);
       }

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/EvidenceModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/EvidenceModal.js
@@ -1010,7 +1010,9 @@ const EvidenceModal = ({
 
   const actionSaveOnSubmit = async () => {
     if (actionSaveLabel === t("DOWNLOAD_SUBMISSION") && signedSubmission?.applicationContent?.fileStoreId) {
-      downloadPdf(tenantId, signedSubmission?.applicationContent?.fileStoreId);
+      const applicationNumber = signedSubmission?.applicationList?.applicationNumber;
+      const applicationType = signedSubmission?.applicationList?.applicationType;
+      downloadPdf(tenantId, signedSubmission?.applicationContent?.fileStoreId, `${applicationNumber}_${applicationType}`);
       return;
     }
     setIsActionLoading(true);

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/EvidenceModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/EvidenceModal.js
@@ -1010,9 +1010,10 @@ const EvidenceModal = ({
 
   const actionSaveOnSubmit = async () => {
     if (actionSaveLabel === t("DOWNLOAD_SUBMISSION") && signedSubmission?.applicationContent?.fileStoreId) {
-      const applicationNumber = signedSubmission?.applicationList?.applicationNumber;
-      const applicationType = signedSubmission?.applicationList?.applicationType;
-      downloadPdf(tenantId, signedSubmission?.applicationContent?.fileStoreId, `${applicationNumber}_${applicationType}`);
+      const name = `${caseData?.courtCaseNumber || caseData?.cmpNumber || caseData?.filingNumber || "Case"}_${
+        signedSubmission?.applicationList?.applicationNumber || ""
+      }_Application`;
+      downloadPdf(tenantId, signedSubmission?.applicationContent?.fileStoreId, name);
       return;
     }
     setIsActionLoading(true);

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/MediationFormSignaturePage.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/MediationFormSignaturePage.js
@@ -621,7 +621,10 @@ const MediationFormSignaturePage = () => {
                       textAlign: "center",
                       color: "#007E7E",
                     }}
-                    onButtonClick={() => downloadPdf(tenantId, signatureDocumentId || mediationFileStoreId)}
+                    onButtonClick={() => {
+                      const name = `${digitalizationServiceDetails?.mediationDetails?.mediationId}_mediation`;
+                      downloadPdf(tenantId, signatureDocumentId || mediationFileStoreId, name);
+                    }}
                   />
                 )}
                 {isUserLoggedIn &&
@@ -741,6 +744,7 @@ const MediationFormSignaturePage = () => {
           isDisabled={uploadLoader}
           fileUploadError={fileUploadError}
           setFileUploadError={setFileUploadError}
+          downloadedFileName={`${digitalizationServiceDetails?.mediationDetails?.mediationId}_mediation`}
         />
       )}
       {showSkipConfirmModal && (

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/WitnessDepositionSignatureModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/WitnessDepositionSignatureModal.js
@@ -12,6 +12,8 @@ const WitnessDepositionSignatureModal = ({
   setLoader,
   loader,
   witnessDepositionFileStoreId,
+  caseDetails,
+  currentArtifactNumber,
 }) => {
   const tenantId = Digit.ULBService.getCurrentTenantId();
   const { uploadDocuments } = Digit.Hooks.orders.useDocumentUpload();
@@ -163,6 +165,9 @@ const WitnessDepositionSignatureModal = ({
           cancelLabel={"SUBMIT"}
           fileUploadError={fileUploadError}
           setFileUploadError={setFileUploadError}
+          downloadedFileName={`${
+            caseDetails?.courtCaseNumber || caseDetails?.cmpNumber || caseDetails?.filingNumber || "Case"
+          }_${currentArtifactNumber}_Witness_Deposition_draft`}
         />
       )}
     </React.Fragment>

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/WitnessDrawerV2.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/WitnessDrawerV2.js
@@ -809,7 +809,10 @@ const WitnessDrawerV2 = ({
   };
 
   const handleDownload = () => {
-    downloadPdf(tenantId, witnessDepositionFileStoreId);
+    const name = `${
+      caseDetails?.courtCaseNumber || caseDetails?.cmpNumber || caseDetails?.filingNumber || "Case"
+    }_${currentArtifactNumber}_Witness_Deposition_draft`;
+    downloadPdf(tenantId, witnessDepositionFileStoreId, name);
   };
 
   const updateWitnessDepositionDocument = async (fileStoreId = null, action, witnessMobileNumbers) => {
@@ -1400,6 +1403,8 @@ const WitnessDrawerV2 = ({
             setLoader={setWitnessDepositionUploadLoader}
             loader={witnessDepositionUploadLoader}
             witnessDepositionFileStoreId={witnessDepositionFileStoreId}
+            caseDetails={caseDetails}
+            currentArtifactNumber={currentArtifactNumber}
           />
         )}
         {showAddWitnessMobileNumberModal && (

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/admission/CaseFileAdmission.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/admission/CaseFileAdmission.js
@@ -977,7 +977,7 @@ function CaseFileAdmission({ t, path }) {
       caseDetails?.documents?.find((doc) => doc?.key === "case.complaint.signed")?.fileStore || caseDetails?.additionalDetails?.signedCaseDocument;
 
     if (fileStoreId) {
-      downloadPdf(tenantId, fileStoreId);
+      downloadPdf(tenantId, fileStoreId, `${caseDetails?.caseNumber || caseDetails?.filingNumber || "Case"}_Complaint`);
       return;
     } else {
       console.error("No fileStoreId available for download.");

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/admission/CaseFileAdmission.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/admission/CaseFileAdmission.js
@@ -977,7 +977,8 @@ function CaseFileAdmission({ t, path }) {
       caseDetails?.documents?.find((doc) => doc?.key === "case.complaint.signed")?.fileStore || caseDetails?.additionalDetails?.signedCaseDocument;
 
     if (fileStoreId) {
-      downloadPdf(tenantId, fileStoreId, `${caseDetails?.caseNumber || caseDetails?.filingNumber || "Case"}_Complaint`);
+      const name = `${caseDetails?.courtCaseNumber || caseDetails?.cmpNumber || caseDetails?.filingNumber || "Case"}_Complaint`;
+      downloadPdf(tenantId, fileStoreId, name);
       return;
     } else {
       console.error("No fileStoreId available for download.");

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/scrutiny/ViewCaseFile.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/scrutiny/ViewCaseFile.js
@@ -739,7 +739,9 @@ function ViewCaseFile({ t, inViewCase = false, caseDetailsAdmitted }) {
                       icon={<FileDownloadIcon svgStyle={downloadSvgStyle} pathStyle={downloadPathStyle} />}
                       className="download-button"
                       label={t("CS_COMMON_DOWNLOAD")}
-                      onButtonClick={() => downloadPdf(tenantId, fileStoreId)}
+                      onButtonClick={() =>
+                        downloadPdf(tenantId, fileStoreId, `${caseDetails?.caseNumber || caseDetails?.filingNumber || "Case"}_Complaint`)
+                      }
                     />
                   </div>
                   <div className="header-content">

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/scrutiny/ViewCaseFile.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/scrutiny/ViewCaseFile.js
@@ -740,7 +740,11 @@ function ViewCaseFile({ t, inViewCase = false, caseDetailsAdmitted }) {
                       className="download-button"
                       label={t("CS_COMMON_DOWNLOAD")}
                       onButtonClick={() =>
-                        downloadPdf(tenantId, fileStoreId, `${caseDetails?.caseNumber || caseDetails?.filingNumber || "Case"}_Complaint`)
+                        downloadPdf(
+                          tenantId,
+                          fileStoreId,
+                          `${caseDetails?.courtCaseNumber || caseDetails?.cmpNumber || caseDetails?.filingNumber || "Case"}_Complaint`
+                        )
                       }
                     />
                   </div>

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/BailBondSignModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/BailBondSignModal.js
@@ -487,6 +487,7 @@ export const BailBondSignModal = ({ selectedBailBond, setShowBulkSignModal = () 
                   displayFilename={"CLICK_HERE"}
                   t={t}
                   pdf={true}
+                  name={`${effectiveRowData?.bailId}_Bail_Bond`}
                 />
               </div>
             </div>
@@ -507,6 +508,7 @@ export const BailBondSignModal = ({ selectedBailBond, setShowBulkSignModal = () 
           isDisabled={loader}
           fileUploadError={fileUploadError}
           setFileUploadError={setFileUploadError}
+          downloadedFileName={`${effectiveRowData?.bailId}_Bail_Bond`}
         />
       )}
       {/* after signing showing signed modal */}
@@ -567,7 +569,8 @@ export const BailBondSignModal = ({ selectedBailBond, setShowBulkSignModal = () 
         <Modal
           actionCancelLabel={t("DOWNLOAD_BAIL_BOND")}
           actionCancelOnSubmit={() => {
-            downloadPdf(tenantId, bailBondSignedPdf || sessionStorage.getItem("fileStoreId"));
+            const name = `${effectiveRowData?.bailId}_Bail_Bond`;
+            downloadPdf(tenantId, bailBondSignedPdf || sessionStorage.getItem("fileStoreId"), name);
           }}
           actionSaveLabel={t("BULK_SUCCESS_CLOSE")}
           actionSaveOnSubmit={() => {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/BulkSignADiaryView.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/BulkSignADiaryView.js
@@ -432,7 +432,8 @@ function BulkSignADiaryView() {
           const blobUrl = URL.createObjectURL(blob);
           const link = document.createElement("a");
           link.href = blobUrl;
-          link.download = `downloadedFile.${extension}`;
+          const name = `${entryDate}_ADiary_signed`;
+          link.download = `${name}.${extension}`;
           document.body.appendChild(link);
           link.click();
           document.body.removeChild(link);
@@ -576,6 +577,7 @@ function BulkSignADiaryView() {
                     displayFilename={"CLICK_HERE"}
                     t={t}
                     pdf={true}
+                    name={`${entryDate}_ADiary_unsigned`}
                   />
                 </div>
               </div>
@@ -596,6 +598,7 @@ function BulkSignADiaryView() {
             isDisabled={loader}
             fileUploadError={fileUploadError}
             setFileUploadError={setFileUploadError}
+            downloadedFileName={`${entryDate}_ADiary_unsigned`}
           />
         )}
 

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/DigitalDocumentSignModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/DigitalDocumentSignModal.js
@@ -456,7 +456,8 @@ export const DigitalDocumentSignModal = ({
   const handleDownload = async () => {
     try {
       const fileStoreId = effectiveRowData?.documents?.[0]?.fileStore;
-      await downloadPdf(tenantId, fileStoreId);
+      const name = `${queryStrings?.documentNumber || effectiveRowData?.documentNumber}_${effectiveRowData?.type || "Digitalized_Document"}`;
+      await downloadPdf(tenantId, fileStoreId, name);
     } catch (error) {
       console.error("Error: ", error);
     }

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/WitnessDepositionSignModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/WitnessDepositionSignModal.js
@@ -516,6 +516,7 @@ export const WitnessDepositionSignModal = ({
                   displayFilename={"CLICK_HERE"}
                   t={t}
                   pdf={true}
+                  name={`${effectiveRowData?.artifactNumber}_Witness_Deposition`}
                 />
               </div>
             </div>
@@ -536,6 +537,7 @@ export const WitnessDepositionSignModal = ({
           isDisabled={loader}
           fileUploadError={fileUploadError}
           setFileUploadError={setFileUploadError}
+          downloadedFileName={`${effectiveRowData?.artifactNumber}_Witness_Deposition`}
         />
       )}
       {/* after signing showing signed modal */}
@@ -601,7 +603,8 @@ export const WitnessDepositionSignModal = ({
         <Modal
           actionCancelLabel={t("DOWNLOAD_WITNESS_DEPOSITION")}
           actionCancelOnSubmit={() => {
-            downloadPdf(tenantId, witnessDepositionSignedPdf || sessionStorage.getItem("fileStoreId"));
+            const name = `${effectiveRowData?.artifactNumber}_Witness_Deposition`;
+            downloadPdf(tenantId, witnessDepositionSignedPdf || sessionStorage.getItem("fileStoreId"), name);
           }}
           actionSaveLabel={t("BULK_SUCCESS_CLOSE")}
           actionSaveOnSubmit={() => {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/components/AddSignatureComponent.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/components/AddSignatureComponent.js
@@ -191,6 +191,7 @@ const AddSignatureComponent = ({ t, isSigned, setIsSigned, handleSigned, rowData
                   t={t}
                   displayFilename={"CLICK_HERE"}
                   pdf={true}
+                  name={`${rowData?.courtCaseNumber || rowData?.cmpNumber || rowData?.filingNumber}_${rowData?.taskNumber}_${rowData?.taskType}`}
                 />
               </div>
             </div>
@@ -242,6 +243,9 @@ const AddSignatureComponent = ({ t, isSigned, setIsSigned, handleSigned, rowData
                           t={t}
                           style={{ marginLeft: "0.5rem", color: "#007E7E" }}
                           displayFilename={"PRINT"}
+                          name={`${rowData?.courtCaseNumber || rowData?.cmpNumber || rowData?.filingNumber}_${rowData?.taskNumber}_${
+                            rowData?.taskType
+                          }`}
                         />
                       ) : (
                         <span style={{ marginLeft: "0.5rem", color: "grey" }}>Print</span>

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pageComponents/OrderSignatureModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pageComponents/OrderSignatureModal.js
@@ -18,6 +18,7 @@ function OrderSignatureModal({
   setSignedDocumentUploadID,
   orderPdfFileStoreID,
   setSignedOrderPdfFileName,
+  caseDetails,
 }) {
   const [isSigned, setIsSigned] = useState(false);
   const { handleEsign, checkSignStatus } = useESign();
@@ -158,6 +159,9 @@ function OrderSignatureModal({
                     t={t}
                     displayFilename={"CLICK_HERE"}
                     pdf={true}
+                    name={`${caseDetails?.courtCaseNumber || caseDetails?.cmpNumber || caseDetails?.filingNumber || "Case"}_${
+                      order?.orderNumber
+                    }_Order`}
                   />
                 </div>
               </div>

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrdersV2.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/GenerateOrdersV2.js
@@ -2458,12 +2458,16 @@ const GenerateOrdersV2 = () => {
 
   const handleDownloadOrders = () => {
     const fileStoreId = sessionStorage.getItem("fileStoreId");
-    downloadPdf(tenantId, signedDoucumentUploadedID || fileStoreId);
+    const name = `${caseDetails?.courtCaseNumber || caseDetails?.cmpNumber || caseDetails?.filingNumber || "Case"}_${prevOrder?.orderNumber}_Order`;
+    downloadPdf(tenantId, signedDoucumentUploadedID || fileStoreId, name);
   };
 
   const handleBulkDownloadOrder = () => {
     const fileStoreId = prevOrder?.documents?.find((doc) => doc?.documentType === "UNSIGNED")?.fileStore;
-    downloadPdf(tenantId, fileStoreId);
+    const name = `${caseDetails?.courtCaseNumber || caseDetails?.cmpNumber || caseDetails?.filingNumber || "Case"}_${
+      currentOrder?.orderNumber
+    }_Order`;
+    downloadPdf(tenantId, fileStoreId, name);
   };
 
   const handleBulkGoToSignList = () => {
@@ -3199,6 +3203,7 @@ const GenerateOrdersV2 = () => {
           orderPdfFileStoreID={orderPdfFileStoreID}
           saveOnsubmitLabel={"ISSUE_ORDER"}
           businessOfDay={businessOfTheDay}
+          caseDetails={caseDetails}
         />
       )}
       {showSuccessModal && (

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/ReviewSummonsNoticeAndWarrant.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/ReviewSummonsNoticeAndWarrant.js
@@ -265,13 +265,14 @@ const ReviewSummonsNoticeAndWarrant = () => {
           const extension = mimeType.includes("/") ? mimeType.split("/")[1] : "bin";
           const link = document.createElement("a");
           link.href = blobUrl;
-          link.download = `downloadedFile.${extension}`;
+          const fileName = `${rowData?.courtCaseNumber || rowData?.cmpNumber || rowData?.filingNumber}_${rowData?.taskNumber}_${rowData?.taskType}`;
+          link.download = `${fileName}.${extension}`;
           document.body.appendChild(link);
           link.click();
           document.body.removeChild(link);
           URL.revokeObjectURL(blobUrl);
         } else {
-          console.error("Failed to fetch the PDF:", response.statusText);
+          console.error("Failed to fetch the file:", response.statusText);
         }
       })
       .catch((error) => {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/components/GenericUploadSignatureModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/components/GenericUploadSignatureModal.js
@@ -18,6 +18,7 @@ const GenericUploadSignatureModal = ({
   infoText = "BAIL_SIGN_INFO",
   customUploadDocuments,
   onCustomDownload,
+  downloadedFileName,
 }) => {
   const tenantId = Digit.ULBService.getCurrentTenantId();
   const { uploadDocuments: defaultUploadDocuments } = Digit.Hooks.orders.useDocumentUpload();
@@ -129,6 +130,7 @@ const GenericUploadSignatureModal = ({
           fileUploadError={fileUploadError}
           onCustomDownload={onCustomDownload}
           setFileUploadError={setFileUploadError}
+          downloadedFileName={downloadedFileName}
         />
       )}
       {showToast && (

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/components/SubmissionSignatureModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/components/SubmissionSignatureModal.js
@@ -15,6 +15,7 @@ function SubmissionSignatureModal({
   setSignedDocumentUploadID,
   applicationPdfFileStoreId,
   applicationType,
+  applicationNumber,
 }) {
   const [isSigned, setIsSigned] = useState(false);
   const { handleEsign, checkSignStatus } = Digit.Hooks.orders.useESign();
@@ -158,6 +159,7 @@ function SubmissionSignatureModal({
                     t={t}
                     displayFilename={"CLICK_HERE"}
                     pdf={true}
+                    name={`${applicationNumber}_${applicationType}_draft`}
                   />
                 </div>
               </div>

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/components/SubmissionSignatureModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/components/SubmissionSignatureModal.js
@@ -16,6 +16,7 @@ function SubmissionSignatureModal({
   applicationPdfFileStoreId,
   applicationType,
   applicationNumber,
+  caseDetails,
 }) {
   const [isSigned, setIsSigned] = useState(false);
   const { handleEsign, checkSignStatus } = Digit.Hooks.orders.useESign();
@@ -159,7 +160,9 @@ function SubmissionSignatureModal({
                     t={t}
                     displayFilename={"CLICK_HERE"}
                     pdf={true}
-                    name={`${applicationNumber}_${applicationType}_draft`}
+                    name={`${caseDetails?.courtCaseNumber || caseDetails?.cmpNumber || caseDetails?.filingNumber || "Case"}_${
+                      applicationNumber || ""
+                    }_Application_draft`}
                   />
                 </div>
               </div>

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/pages/employee/DigitizedDocumentsSignaturePage.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/pages/employee/DigitizedDocumentsSignaturePage.js
@@ -190,15 +190,16 @@ const DigitizedDocumentsSignaturePage = () => {
   const handleDownloadPdf = () => {
     if (!fileStoreId) return;
 
+    const name = `${documentNumber}_${type || "Digitalized_Document"}`;
     if (isUserLoggedIn) {
-      downloadPdf(tenantId, fileStoreId);
+      downloadPdf(tenantId, fileStoreId, name);
     } else if (documentPreviewPdf) {
       // For unauthenticated SMS users, use the already-fetched blob from the open API
       const blob = new Blob([documentPreviewPdf], { type: documentPreviewPdf.type || "application/pdf" });
       const blobUrl = URL.createObjectURL(blob);
       const link = document.createElement("a");
       link.href = blobUrl;
-      link.download = "downloadedFile.pdf";
+      link.download = `${name}.pdf`;
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/pages/employee/GenerateBailBondV2.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/pages/employee/GenerateBailBondV2.js
@@ -1143,7 +1143,8 @@ const GenerateBailBondV2 = () => {
   };
 
   const handleDownload = () => {
-    downloadPdf(tenantId, bailBondFileStoreId);
+    const name = `${caseDetails?.courtCaseNumber || caseDetails?.cmpNumber || caseDetails?.filingNumber || "Case"}_${bailBondId}_Bail_Bond_draft`;
+    downloadPdf(tenantId, bailBondFileStoreId, name);
   };
 
   const handleESign = async () => {
@@ -1343,6 +1344,9 @@ const GenerateBailBondV2 = () => {
             setLoader={setBailUploadLoader}
             loader={bailUploadLoader}
             fileStoreId={bailBondFileStoreId}
+            downloadedFileName={`${
+              caseDetails?.courtCaseNumber || caseDetails?.cmpNumber || caseDetails?.filingNumber || "Case"
+            }_${bailBondId}_Bail_Bond_draft`}
           />
         )}
 

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/pages/employee/SubmissionDocuments.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/pages/employee/SubmissionDocuments.js
@@ -191,7 +191,7 @@ const SubmissionDocuments = ({ path }) => {
   };
 
   const handleSuccessDownloadSubmission = () => {
-    downloadPdf(tenantId, signedDocumentUploadedID);
+    downloadPdf(tenantId, signedDocumentUploadedID, `${evidenceDetails?.artifactNumber || evidenceId}_${formdata?.documentTitle}`);
   };
 
   const handleDownloadReviewModal = async () => {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/pages/employee/SubmissionDocuments.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/pages/employee/SubmissionDocuments.js
@@ -191,7 +191,11 @@ const SubmissionDocuments = ({ path }) => {
   };
 
   const handleSuccessDownloadSubmission = () => {
-    downloadPdf(tenantId, signedDocumentUploadedID, `${evidenceDetails?.artifactNumber || evidenceId}_${formdata?.documentTitle}`);
+    //
+    const name = `${caseDetails?.courtCaseNumber || caseDetails?.cmpNumber || caseDetails?.filingNumber || "Case"}_${
+      evidenceDetails?.artifactNumber || evidenceId
+    }_Document`;
+    downloadPdf(tenantId, signedDocumentUploadedID, name);
   };
 
   const handleDownloadReviewModal = async () => {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/pages/employee/SubmissionsCreate.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/pages/employee/SubmissionsCreate.js
@@ -1964,7 +1964,11 @@ const SubmissionsCreate = ({ path }) => {
   };
 
   const handleDownloadSubmission = () => {
-    downloadPdf(tenantId, applicationDetails?.documents?.filter((doc) => doc?.documentType === "SIGNED")?.[0]?.fileStore);
+    downloadPdf(
+      tenantId,
+      applicationDetails?.documents?.filter((doc) => doc?.documentType === "SIGNED")?.[0]?.fileStore,
+      `${applicationNumber}_${applicationType}`
+    );
   };
 
   useEffect(() => {
@@ -2059,6 +2063,7 @@ const SubmissionsCreate = ({ path }) => {
             setSignedDocumentUploadID={setSignedDocumentUploadID}
             applicationPdfFileStoreId={applicationPdfFileStoreId}
             applicationType={applicationType}
+            applicationNumber={applicationNumber}
           />
         )}
         {showPaymentModal && (

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/pages/employee/SubmissionsCreate.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/pages/employee/SubmissionsCreate.js
@@ -1964,11 +1964,10 @@ const SubmissionsCreate = ({ path }) => {
   };
 
   const handleDownloadSubmission = () => {
-    downloadPdf(
-      tenantId,
-      applicationDetails?.documents?.filter((doc) => doc?.documentType === "SIGNED")?.[0]?.fileStore,
-      `${applicationNumber}_${applicationType}`
-    );
+    const name = `${caseDetails?.courtCaseNumber || caseDetails?.cmpNumber || caseDetails?.filingNumber || "Case"}_${
+      applicationNumber || ""
+    }_Application`;
+    downloadPdf(tenantId, applicationDetails?.documents?.filter((doc) => doc?.documentType === "SIGNED")?.[0]?.fileStore, name);
   };
 
   useEffect(() => {
@@ -2064,6 +2063,7 @@ const SubmissionsCreate = ({ path }) => {
             applicationPdfFileStoreId={applicationPdfFileStoreId}
             applicationType={applicationType}
             applicationNumber={applicationNumber}
+            caseDetails={caseDetails}
           />
         )}
         {showPaymentModal && (


### PR DESCRIPTION

https://github.com/pucardotorg/dristi/issues/5686

## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Downloads now use descriptive, context-aware filenames for PDFs and other documents (case/filing/order/artifact identifiers), improving organization.
  * Evidence downloads can include both evidence and its seal as a ZIP when available.

* **Refactor**
  * Download and signature modals/components updated to accept and propagate custom download names across workflows for consistent file naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->