### PR TITLE
fix: use includes() for witness type checks to handle prefixed value(PW1, DW1, etc.)

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/WitnessDrawerV2.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/WitnessDrawerV2.js
@@ -452,7 +452,7 @@ const WitnessDrawerV2 = ({
         const newTab = {
           artifactNumber: null, // Will be set after saving
           sourceName: "Deposition", // Default name until saved
-          sourceType: selectedWitnessType?.value === "PW" ? "COMPLAINANT" : selectedWitnessType?.value === "DW" ? "ACCUSED" : "COURT",
+          sourceType: selectedWitnessType?.value?.includes("PW") ? "COMPLAINANT" : selectedWitnessType?.value?.includes("DW") ? "ACCUSED" : "COURT",
           sourceID: selectedWitness?.value,
           content: "",
           artifactType: "WITNESS_DEPOSITION",
@@ -524,7 +524,7 @@ const WitnessDrawerV2 = ({
         const newTab = {
           artifactNumber: null, // Will be set after saving
           sourceName: "Deposition", // Default name until saved
-          sourceType: selectedWitnessType?.value === "PW" ? "COMPLAINANT" : selectedWitnessType?.value === "DW" ? "ACCUSED" : "COURT",
+          sourceType: selectedWitnessType?.value?.includes("PW") ? "COMPLAINANT" : selectedWitnessType?.value?.includes("DW") ? "ACCUSED" : "COURT",
           sourceID: selectedWitness?.value,
           content: "",
           artifactType: "WITNESS_DEPOSITION",
@@ -651,7 +651,11 @@ const WitnessDrawerV2 = ({
           const updateEvidenceReqBody = {
             artifact: {
               ...evidence,
-              sourceType: selectedWitnessType.value === "PW" ? "COMPLAINANT" : selectedWitnessType.value === "DW" ? "ACCUSED" : "COURT",
+              sourceType: selectedWitnessType?.value?.includes("PW")
+                ? "COMPLAINANT"
+                : selectedWitnessType?.value?.includes("DW")
+                ? "ACCUSED"
+                : "COURT",
               tag: selectedWitnessType?.value,
               sourceID: selectedWitness.value,
               sourceName: party?.sourceName,
@@ -696,7 +700,7 @@ const WitnessDrawerV2 = ({
             caseId: caseDetails?.id,
             filingNumber: caseDetails?.filingNumber,
             tenantId,
-            sourceType: selectedWitnessType?.value === "PW" ? "COMPLAINANT" : selectedWitnessType?.value === "DW" ? "ACCUSED" : "COURT",
+            sourceType: selectedWitnessType?.value?.includes("PW") ? "COMPLAINANT" : selectedWitnessType?.value?.includes("DW") ? "ACCUSED" : "COURT",
             tag: selectedWitnessType?.value,
             sourceID: selectedWitness?.value,
             asUser: selectedWitness?.value, // This field is added as part of advocate office management feature requirement.
@@ -1050,7 +1054,11 @@ const WitnessDrawerV2 = ({
           const updateEvidenceReqBody = {
             artifact: {
               ...evidence,
-              sourceType: selectedWitnessType.value === "PW" ? "COMPLAINANT" : selectedWitnessType.value === "DW" ? "ACCUSED" : "COURT",
+              sourceType: selectedWitnessType?.value?.includes("PW")
+                ? "COMPLAINANT"
+                : selectedWitnessType?.value?.includes("DW")
+                ? "ACCUSED"
+                : "COURT",
               tag: selectedWitnessType?.value,
               sourceID: selectedWitness.value,
               sourceName: party?.sourceName,
@@ -1099,7 +1107,7 @@ const WitnessDrawerV2 = ({
             caseId: caseDetails?.id,
             filingNumber: caseDetails?.filingNumber,
             tenantId,
-            sourceType: selectedWitnessType?.value === "PW" ? "COMPLAINANT" : selectedWitnessType?.value === "DW" ? "ACCUSED" : "COURT",
+            sourceType: selectedWitnessType?.value?.includes("PW") ? "COMPLAINANT" : selectedWitnessType?.value?.includes("DW") ? "ACCUSED" : "COURT",
             tag: selectedWitnessType?.value,
             sourceID: selectedWitness?.value,
             asUser: selectedWitness?.value, // This field is added as part of advocate office management feature requirement.


### PR DESCRIPTION




Replaces exact equality checks (=== "PW", === "DW") with includes() method to properly match witness types that may have numeric suffixes like "PW1", "PW2", "DW1", etc. when determining sourceType (COMPLAINANT/ACCUSED/COURT) in WitnessDrawerV2.

## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->
