### PR TITLE
feat: add loading indicator to EvidenceModal during actions

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/EvidenceModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/EvidenceModal.js
@@ -1220,6 +1220,25 @@ const EvidenceModal = ({
         margin: 0;
       }`}
       </style>
+      {isActionLoading && (
+        <div
+          style={{
+            width: "100vw",
+            height: "100vh",
+            zIndex: "10001",
+            position: "fixed",
+            right: "0",
+            display: "flex",
+            top: "0",
+            background: "rgb(234 234 245 / 50%)",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+          className="submit-loader"
+        >
+          <Loader />
+        </div>
+      )}
       {!showConfirmationModal && !showSuccessModal && (
         <Modal
           hideModalActionbar={actionSaveLabel === t("UNMARK_AS_EVIDENCE")}
@@ -1271,11 +1290,6 @@ const EvidenceModal = ({
           //     : {}
           // }
         >
-          {isActionLoading && (
-            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", padding: "2rem" }}>
-              <Loader />
-            </div>
-          )}
           {(documentSubmission?.[0]?.artifactList?.evidenceMarkedStatus || documentSubmission?.[0]?.artifactList?.isEvidence) &&
             userType === "employee" && (
               <div style={{ margin: "16px 24px" }}>


### PR DESCRIPTION
## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the loading state in Evidence modal to display as a full-screen overlay with higher visual prominence, ensuring clear feedback to users while preventing interactions during actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->