### PR TITLE
fix: resolve infinite recursion in isLPRCase utility function

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/Utils/index.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/Utils/index.js
@@ -125,7 +125,7 @@ export const isLPRCase = (caseObj) => {
   if (caseObj.lifecycleStatus !== undefined && caseObj.lifecycleStatus !== null) {
     return caseObj.lifecycleStatus === "LPR";
   }
-  return Boolean(isLPRCase(caseObj));
+  return Boolean(caseObj?.isLPRCase);
 };
 
 // Returns the case-number to display, taking LPR cases into account.


### PR DESCRIPTION
## Summary

- Fixes infinite recursion in `isLPRCase()` utility function in `dristi/src/Utils/index.js`
- The function was calling itself recursively (`isLPRCase(caseObj)`) as a fallback, causing a stack overflow whenever `lifecycleStatus` was not defined
- Replaced with a direct property access `caseObj?.isLPRCase` which is the intended behavior

## Test plan

- [ ] Verify `isLPRCase` returns correct result when `lifecycleStatus === "LPR"`
- [ ] Verify `isLPRCase` returns correct result when `lifecycleStatus` is undefined/null (should fall back to `caseObj?.isLPRCase`)
- [ ] Confirm no stack overflow errors in browser console for LPR-related case flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a critical issue in case handling logic where improper fallback behavior could cause the application to become unresponsive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->