### PR TITLE
feat(dristi-pdf): improve case bundle logging for easier debugging (#5725)

### DIFF
--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/buildCasePdf.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/buildCasePdf.js
@@ -5,6 +5,7 @@ const path = require("path");
 const {
   convertFileStoreToDocument,
 } = require("./utils/convertFileStoreToDocument");
+const { logger } = require("../logger");
 
 /**
  * @typedef CaseBundleMaster
@@ -20,10 +21,12 @@ const {
  */
 
 async function buildCasePdf(caseNumber, index, requestInfo, tenantId) {
+  logger.info(`[buildCasePdf] Started | caseNumber: ${caseNumber}, tenantId: ${tenantId}`);
   try {
     /**
      * @type {CaseBundleMaster[]}
      */
+    logger.info(`[buildCasePdf] Fetching MDMS case_bundle_master | tenantId: ${tenantId}`);
     const caseBundleDesign = await search_mdms(
       null,
       "CaseManagement.case_bundle_master",
@@ -36,14 +39,16 @@ async function buildCasePdf(caseNumber, index, requestInfo, tenantId) {
     if (!caseBundleDesign || caseBundleDesign.length === 0) {
       throw new Error("No case bundle design found in MDMS.");
     }
+    logger.info(`[buildCasePdf] MDMS design fetched | sections: ${caseBundleDesign.length}`);
 
     // Create a new PDF document to merge all sections
     const mergedPdf = await PDFDocument.create();
+    let totalPagesAdded = 0;
 
     // Iterate through sections in the index
     for (const section of index.sections) {
       if (!section || !section.name) {
-        console.warn("Skipping section with no name");
+        logger.warn(`[buildCasePdf] Skipping section with no name`);
         continue;
       }
 
@@ -52,23 +57,27 @@ async function buildCasePdf(caseNumber, index, requestInfo, tenantId) {
       );
 
       if (!sectionConfig) {
-        console.warn(`Section '${section.name}' is not enabled in the design`);
+        logger.warn(`[buildCasePdf] Section '${section.name}' is not enabled in the design, skipping`);
         continue;
       }
 
       if (!section.lineItems || section.lineItems.length === 0) {
-        console.warn(`Section '${section.name}' has no line items.`);
+        logger.info(`[buildCasePdf] Section '${section.name}' has no line items, skipping`);
         continue;
       }
 
+      logger.info(`[buildCasePdf] Processing section: '${section.name}' | lineItems: ${section.lineItems.length}`);
+
       // Process each line item
-      for (const item of section.lineItems) {
+      for (let itemIdx = 0; itemIdx < section.lineItems.length; itemIdx++) {
+        const item = section.lineItems[itemIdx];
         if (!item || !item.fileStoreId || !item.content) {
-          console.warn("Skipping invalid line item");
+          logger.warn(`[buildCasePdf] Skipping invalid line item at index ${itemIdx} in section '${section.name}'`);
           continue;
         }
 
         try {
+          logger.info(`[buildCasePdf] Fetching document | section: '${section.name}', item: ${itemIdx + 1}/${section.lineItems.length}, fileStoreId: ${item.fileStoreId}`);
           // Fetch PDF from fileStoreId
           const itemPdf = await convertFileStoreToDocument(
             tenantId,
@@ -94,9 +103,11 @@ async function buildCasePdf(caseNumber, index, requestInfo, tenantId) {
             itemPdf.getPageIndices()
           );
           copiedPages.forEach((page) => mergedPdf.addPage(page));
+          totalPagesAdded += pages.length;
+          logger.info(`[buildCasePdf] Merged ${pages.length} page(s) | section: '${section.name}', fileStoreId: ${item.fileStoreId}, totalPages: ${totalPagesAdded}`);
         } catch (error) {
-          console.error(
-            `Error processing fileStoreId '${item.fileStoreId}': ${error.message}`
+          logger.error(
+            `[buildCasePdf] Failed to process item | section: '${section.name}', item: ${itemIdx + 1}/${section.lineItems.length}, fileStoreId: '${item.fileStoreId}' | error: ${error.message}`
           );
         }
       }
@@ -128,10 +139,12 @@ async function buildCasePdf(caseNumber, index, requestInfo, tenantId) {
     const filePath = path.join(directoryPath, tempFileName);
 
     try {
+      logger.info(`[buildCasePdf] Saving merged PDF | totalPages: ${mergedPages.length}, tempFile: ${tempFileName}`);
       // Save the merged PDF
       const pdfBytes = await mergedPdf.save();
       fs.writeFileSync(filePath, pdfBytes);
 
+      logger.info(`[buildCasePdf] Uploading merged PDF to FileStore | tenantId: ${tenantId}`);
       // Upload the merged PDF and update the index
       const fileStoreResponse = await create_file(
         filePath,
@@ -141,9 +154,14 @@ async function buildCasePdf(caseNumber, index, requestInfo, tenantId) {
       );
       const fileStoreId = fileStoreResponse?.data?.files?.[0].fileStoreId;
 
+      if (!fileStoreId) {
+        throw new Error("FileStore upload returned no fileStoreId");
+      }
+
       index.fileStoreId = fileStoreId;
       index.pdfCreatedDate = Date.now();
 
+      logger.info(`[buildCasePdf] Completed | caseNumber: ${caseNumber}, fileStoreId: ${fileStoreId}, totalPages: ${mergedPages.length}`);
       return { ...index, pageCount: mergedPages.length };
     } finally {
       // Ensure cleanup of the temporary file
@@ -152,7 +170,7 @@ async function buildCasePdf(caseNumber, index, requestInfo, tenantId) {
       }
     }
   } catch (error) {
-    console.error("Error processing case bundle:", error.message);
+    logger.error(`[buildCasePdf] Failed | caseNumber: ${caseNumber}, tenantId: ${tenantId} | error: ${error.message}`);
     throw error;
   }
 }

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/generateIndex.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/generateIndex.js
@@ -12,19 +12,21 @@ if (!fs.existsSync(TEMP_FILES_DIR)) {
 }
 
 async function processCaseBundle(tenantId, caseId, index, state, requestInfo) {
-  logger.info(`Processing caseId: ${caseId}, state: ${state}`);
-
-  let updatedIndex;
-
-  updatedIndex = await processPendingAdmissionCase({
-    tenantId,
-    caseId,
-    index,
-    requestInfo,
-    TEMP_FILES_DIR,
-  });
-
-  return updatedIndex;
+  logger.info(`[CaseBundle] processCaseBundle started | caseId: ${caseId}, tenantId: ${tenantId}, state: ${state}`);
+  try {
+    const updatedIndex = await processPendingAdmissionCase({
+      tenantId,
+      caseId,
+      index,
+      requestInfo,
+      TEMP_FILES_DIR,
+    });
+    logger.info(`[CaseBundle] processCaseBundle completed | caseId: ${caseId}`);
+    return updatedIndex;
+  } catch (err) {
+    logger.error(`[CaseBundle] processCaseBundle failed | caseId: ${caseId}, tenantId: ${tenantId} | error: ${err.message}`);
+    throw err;
+  }
 }
 
 module.exports = processCaseBundle;

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processAccusedEvidence.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processAccusedEvidence.js
@@ -1,15 +1,10 @@
 const { search_evidence_v2 } = require("../../api");
-const {
-  filterCaseBundleBySection,
-} = require("../utils/filterCaseBundleBySection");
+const { filterCaseBundleBySection } = require("../utils/filterCaseBundleBySection");
 const { applyDocketToDocument } = require("../utils/applyDocketToDocument");
-const {
-  duplicateExistingFileStore,
-} = require("../utils/duplicateExistingFileStore");
+const { duplicateExistingFileStore } = require("../utils/duplicateExistingFileStore");
 const { getDynamicSectionNumber } = require("../utils/getDynamicSectionNumber");
-const {
-  combineMultipleFilestores,
-} = require("../utils/combineMultipleFilestores");
+const { combineMultipleFilestores } = require("../utils/combineMultipleFilestores");
+const { logger } = require("../../logger");
 
 async function processAccusedEvidence(
   courtCase,
@@ -20,6 +15,7 @@ async function processAccusedEvidence(
   indexCopy,
   messagesMap
 ) {
+  logger.info(`[processAccusedEvidence] Started | filingNumber: ${courtCase?.filingNumber}`);
   const complainantDepositionSection = filterCaseBundleBySection(
     caseBundleMaster,
     "accusedevidencedepositions"

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processAdditionalFilings.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processAdditionalFilings.js
@@ -1,12 +1,9 @@
 const { search_evidence_v2 } = require("../../api");
-const {
-  filterCaseBundleBySection,
-} = require("../utils/filterCaseBundleBySection");
+const { filterCaseBundleBySection } = require("../utils/filterCaseBundleBySection");
 const { applyDocketToDocument } = require("../utils/applyDocketToDocument");
-const {
-  duplicateExistingFileStore,
-} = require("../utils/duplicateExistingFileStore");
+const { duplicateExistingFileStore } = require("../utils/duplicateExistingFileStore");
 const { getDynamicSectionNumber } = require("../utils/getDynamicSectionNumber");
+const { logger } = require("../../logger");
 
 async function processAdditionalFilings(
   courtCase,
@@ -17,6 +14,7 @@ async function processAdditionalFilings(
   indexCopy,
   messagesMap
 ) {
+  logger.info(`[processAdditionalFilings] Started | filingNumber: ${courtCase?.filingNumber}`);
   const additionalFilingsSection = filterCaseBundleBySection(
     caseBundleMaster,
     "additionalfilings"

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processAffidavitSection.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processAffidavitSection.js
@@ -1,8 +1,7 @@
 const { applyDocketToDocument } = require("../utils/applyDocketToDocument");
-const {
-  filterCaseBundleBySection,
-} = require("../utils/filterCaseBundleBySection");
+const { filterCaseBundleBySection } = require("../utils/filterCaseBundleBySection");
 const { getDynamicSectionNumber } = require("../utils/getDynamicSectionNumber");
+const { logger } = require("../../logger");
 
 async function processAffidavitSection(
   courtCase,
@@ -12,7 +11,7 @@ async function processAffidavitSection(
   TEMP_FILES_DIR,
   indexCopy
 ) {
-  // update affidavits
+  logger.info(`[processAffidavitSection] Started | filingNumber: ${courtCase?.filingNumber}`);
   const affidavitsSection = filterCaseBundleBySection(
     caseBundleMaster,
     "affidavit"

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processBailDocuments.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processBailDocuments.js
@@ -1,16 +1,9 @@
-const {
-  search_application_v2,
-  search_order_v2,
-  search_bailBond_v2,
-} = require("../../api");
-const {
-  filterCaseBundleBySection,
-} = require("../utils/filterCaseBundleBySection");
+const { search_application_v2, search_order_v2, search_bailBond_v2 } = require("../../api");
+const { filterCaseBundleBySection } = require("../utils/filterCaseBundleBySection");
 const { applyDocketToDocument } = require("../utils/applyDocketToDocument");
-const {
-  combineMultipleFilestores,
-} = require("../utils/combineMultipleFilestores");
+const { combineMultipleFilestores } = require("../utils/combineMultipleFilestores");
 const { getDynamicSectionNumber } = require("../utils/getDynamicSectionNumber");
+const { logger } = require("../../logger");
 
 async function processBailDocuments(
   courtCase,
@@ -21,6 +14,7 @@ async function processBailDocuments(
   indexCopy,
   messagesMap
 ) {
+  logger.info(`[processBailDocuments] Started | filingNumber: ${courtCase?.filingNumber}`);
   const bailApplicationSection = filterCaseBundleBySection(
     caseBundleMaster,
     "baildocument"

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processComplainantEvidence.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processComplainantEvidence.js
@@ -1,15 +1,10 @@
 const { search_evidence_v2 } = require("../../api");
-const {
-  filterCaseBundleBySection,
-} = require("../utils/filterCaseBundleBySection");
+const { filterCaseBundleBySection } = require("../utils/filterCaseBundleBySection");
 const { applyDocketToDocument } = require("../utils/applyDocketToDocument");
-const {
-  duplicateExistingFileStore,
-} = require("../utils/duplicateExistingFileStore");
+const { duplicateExistingFileStore } = require("../utils/duplicateExistingFileStore");
 const { getDynamicSectionNumber } = require("../utils/getDynamicSectionNumber");
-const {
-  combineMultipleFilestores,
-} = require("../utils/combineMultipleFilestores");
+const { combineMultipleFilestores } = require("../utils/combineMultipleFilestores");
+const { logger } = require("../../logger");
 
 async function processComplainantEvidence(
   courtCase,
@@ -20,6 +15,7 @@ async function processComplainantEvidence(
   indexCopy,
   messagesMap
 ) {
+  logger.info(`[processComplainantEvidence] Started | filingNumber: ${courtCase?.filingNumber}`);
   const complainantDepositionSection = filterCaseBundleBySection(
     caseBundleMaster,
     "complainantevidencedepositions"

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processComplaintSection.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processComplaintSection.js
@@ -1,8 +1,7 @@
-const {
-  filterCaseBundleBySection,
-} = require("../utils/filterCaseBundleBySection");
+const { filterCaseBundleBySection } = require("../utils/filterCaseBundleBySection");
 const { applyDocketToDocument } = require("../utils/applyDocketToDocument");
 const { getDynamicSectionNumber } = require("../utils/getDynamicSectionNumber");
+const { logger } = require("../../logger");
 
 async function processComplaintSection(
   courtCase,
@@ -12,6 +11,7 @@ async function processComplaintSection(
   TEMP_FILES_DIR,
   indexCopy
 ) {
+  logger.info(`[processComplaintSection] Started | filingNumber: ${courtCase?.filingNumber}`);
   const complaintSection = filterCaseBundleBySection(
     caseBundleMaster,
     "complaint"
@@ -33,6 +33,7 @@ async function processComplaintSection(
       (doc) => doc.documentType === "case.complaint.signed"
     )?.fileStore;
     if (!complaintFileStoreId) {
+      logger.error(`[processComplaintSection] No complaint document found | filingNumber: ${courtCase?.filingNumber}, expected documentType: case.complaint.signed`);
       throw new Error("no case complaint");
     }
 

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processCourtEvidence.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processCourtEvidence.js
@@ -1,13 +1,8 @@
 const { search_evidence_v2 } = require("../../api");
-const {
-  combineMultipleFilestores,
-} = require("../utils/combineMultipleFilestores");
-const {
-  duplicateExistingFileStore,
-} = require("../utils/duplicateExistingFileStore");
-const {
-  filterCaseBundleBySection,
-} = require("../utils/filterCaseBundleBySection");
+const { combineMultipleFilestores } = require("../utils/combineMultipleFilestores");
+const { duplicateExistingFileStore } = require("../utils/duplicateExistingFileStore");
+const { filterCaseBundleBySection } = require("../utils/filterCaseBundleBySection");
+const { logger } = require("../../logger");
 
 async function processCourtEvidence(
   courtCase,
@@ -17,6 +12,7 @@ async function processCourtEvidence(
   TEMP_FILES_DIR,
   indexCopy
 ) {
+  logger.info(`[processCourtEvidence] Started | filingNumber: ${courtCase?.filingNumber}`);
   const courtEvidenceDepositionSection = filterCaseBundleBySection(
     caseBundleMaster,
     "courtevidencedepositions"

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processDisposedApplications.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processDisposedApplications.js
@@ -1,15 +1,10 @@
 const { search_application_v2, search_order_v2 } = require("../../api");
-const {
-  filterCaseBundleBySection,
-} = require("../utils/filterCaseBundleBySection");
+const { filterCaseBundleBySection } = require("../utils/filterCaseBundleBySection");
 const { applyDocketToDocument } = require("../utils/applyDocketToDocument");
-const {
-  combineMultipleFilestores,
-} = require("../utils/combineMultipleFilestores");
-const {
-  duplicateExistingFileStore,
-} = require("../utils/duplicateExistingFileStore");
+const { combineMultipleFilestores } = require("../utils/combineMultipleFilestores");
+const { duplicateExistingFileStore } = require("../utils/duplicateExistingFileStore");
 const { getDynamicSectionNumber } = require("../utils/getDynamicSectionNumber");
+const { logger } = require("../../logger");
 
 const extractNumber = (cmpNumber) => {
   const parts = cmpNumber.split("/");
@@ -25,6 +20,7 @@ async function processDisposedApplications(
   indexCopy,
   messagesMap
 ) {
+  logger.info(`[processDisposedApplications] Started | filingNumber: ${courtCase?.filingNumber}`);
   const applicationSection = filterCaseBundleBySection(
     caseBundleMaster,
     "applications"

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processExamination.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processExamination.js
@@ -1,9 +1,8 @@
-const {
-  filterCaseBundleBySection,
-} = require("../utils/filterCaseBundleBySection");
+const { filterCaseBundleBySection } = require("../utils/filterCaseBundleBySection");
 const { search_digitalizedDocuments } = require("../../api");
 const { applyDocketToDocument } = require("../utils/applyDocketToDocument");
 const { getDynamicSectionNumber } = require("../utils/getDynamicSectionNumber");
+const { logger } = require("../../logger");
 
 async function processExamination(
   courtCase,
@@ -13,6 +12,7 @@ async function processExamination(
   TEMP_FILES_DIR,
   indexCopy
 ) {
+  logger.info(`[processExamination] Started | filingNumber: ${courtCase?.filingNumber}`);
   const section = filterCaseBundleBySection(
     caseBundleMaster,
     "digitalizedDocuments"

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processFilingsSection.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processFilingsSection.js
@@ -13,8 +13,7 @@ async function processFilingsSection(
   TEMP_FILES_DIR,
   indexCopy
 ) {
-  // move to filings section of case complaint
-  logger.info(caseBundleMaster);
+  logger.info(`[processFilingsSection] Started | filingNumber: ${courtCase?.filingNumber}`);
   const sectionPosition = indexCopy.sections?.findIndex(
     (s) => s.name === "filings"
   );

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processMandatorySubmissions.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processMandatorySubmissions.js
@@ -1,12 +1,9 @@
 const { search_application_v2, search_order_v2 } = require("../../api");
-const {
-  filterCaseBundleBySection,
-} = require("../utils/filterCaseBundleBySection");
+const { filterCaseBundleBySection } = require("../utils/filterCaseBundleBySection");
 const { applyDocketToDocument } = require("../utils/applyDocketToDocument");
-const {
-  combineMultipleFilestores,
-} = require("../utils/combineMultipleFilestores");
+const { combineMultipleFilestores } = require("../utils/combineMultipleFilestores");
 const { getDynamicSectionNumber } = require("../utils/getDynamicSectionNumber");
+const { logger } = require("../../logger");
 
 async function processMandatorySubmissions(
   courtCase,
@@ -17,6 +14,7 @@ async function processMandatorySubmissions(
   indexCopy,
   messagesMap
 ) {
+  logger.info(`[processMandatorySubmissions] Started | filingNumber: ${courtCase?.filingNumber}`);
   const mandatorySubmissionsSection = filterCaseBundleBySection(
     caseBundleMaster,
     "mandatorysubmissions"

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processOrders.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processOrders.js
@@ -1,7 +1,6 @@
-const {
-  filterCaseBundleBySection,
-} = require("../utils/filterCaseBundleBySection");
+const { filterCaseBundleBySection } = require("../utils/filterCaseBundleBySection");
 const { search_order_v2 } = require("../../api");
+const { logger } = require("../../logger");
 
 async function processOrders(
   courtCase,
@@ -11,6 +10,7 @@ async function processOrders(
   TEMP_FILES_DIR,
   indexCopy
 ) {
+  logger.info(`[processOrders] Started | filingNumber: ${courtCase?.filingNumber}`);
   const processesSection = filterCaseBundleBySection(
     caseBundleMaster,
     "orders"

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processOthersSection.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processOthersSection.js
@@ -1,9 +1,8 @@
-const {
-  filterCaseBundleBySection,
-} = require("../utils/filterCaseBundleBySection");
+const { filterCaseBundleBySection } = require("../utils/filterCaseBundleBySection");
 const { search_digitalizedDocuments } = require("../../api");
 const { applyDocketToDocument } = require("../utils/applyDocketToDocument");
 const { getDynamicSectionNumber } = require("../utils/getDynamicSectionNumber");
+const { logger } = require("../../logger");
 
 async function processOthersSection(
   courtCase,
@@ -13,6 +12,7 @@ async function processOthersSection(
   TEMP_FILES_DIR,
   indexCopy
 ) {
+  logger.info(`[processOthersSection] Started | filingNumber: ${courtCase?.filingNumber}`);
   const section = filterCaseBundleBySection(caseBundleMaster, "others");
   const sortedSection = [...section].sort(
     (secA, secB) => secA.sorton - secB.sorton

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processPaymentReceipts.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processPaymentReceipts.js
@@ -1,12 +1,9 @@
-const {
-  filterCaseBundleBySection,
-} = require("../utils/filterCaseBundleBySection");
+const { filterCaseBundleBySection } = require("../utils/filterCaseBundleBySection");
 const { applyDocketToDocument } = require("../utils/applyDocketToDocument");
 const { getDynamicSectionNumber } = require("../utils/getDynamicSectionNumber");
 const { search_task_v2, search_task_mangement } = require("../../api");
-const {
-  duplicateExistingFileStore,
-} = require("../utils/duplicateExistingFileStore");
+const { duplicateExistingFileStore } = require("../utils/duplicateExistingFileStore");
+const { logger } = require("../../logger");
 
 async function processPaymentReceipts(
   courtCase,
@@ -16,6 +13,7 @@ async function processPaymentReceipts(
   TEMP_FILES_DIR,
   indexCopy
 ) {
+  logger.info(`[processPaymentReceipts] Started | filingNumber: ${courtCase?.filingNumber}`);
   const paymentReceiptSection = filterCaseBundleBySection(
     caseBundleMaster,
     "paymentreceipts"

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processPendingAdmissionCase.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processPendingAdmissionCase.js
@@ -26,6 +26,22 @@ const { processOrders } = require("./processOrders");
 const { processExamination } = require("./processExamination");
 const { processOthersSection } = require("./processOthersSection");
 
+async function runSection(sectionName, fn, context = {}) {
+  const ctxStr = Object.entries(context)
+    .map(([k, v]) => `${k}=${v}`)
+    .join(", ");
+  logger.info(`[CaseBundle] Starting section: ${sectionName}${ctxStr ? ` | ${ctxStr}` : ""}`);
+  try {
+    await fn();
+    logger.info(`[CaseBundle] Completed section: ${sectionName}`);
+  } catch (err) {
+    logger.error(
+      `[CaseBundle] Failed section: ${sectionName}${ctxStr ? ` | ${ctxStr}` : ""} | error: ${err.message}`
+    );
+    throw new Error(`Section '${sectionName}' failed: ${err.message}`);
+  }
+}
+
 async function processPendingAdmissionCase({
   tenantId,
   caseId,
@@ -33,229 +49,112 @@ async function processPendingAdmissionCase({
   requestInfo,
   TEMP_FILES_DIR,
 }) {
+  logger.info(`[CaseBundle] processPendingAdmissionCase started | caseId: ${caseId}, tenantId: ${tenantId}`);
   const indexCopy = cloneDeep(index);
-  const caseBundleMaster = await search_mdms(
-    null,
-    "CaseManagement.case_bundle_master",
-    tenantId,
-    requestInfo
-  ).then((mdmsRes) => {
-    return mdmsRes.data.mdms.filter((x) => x.isActive).map((x) => x.data);
-  });
 
-  const caseResponse = await search_case_v2(
-    [
-      {
-        caseId,
-      },
-    ],
-    tenantId,
-    requestInfo
-  );
-  logger.info("recd case response", JSON.stringify(caseResponse?.data));
-  const courtCase = caseResponse?.data?.criteria[0]?.responseList[0];
+  logger.info(`[CaseBundle] Fetching MDMS case_bundle_master | tenantId: ${tenantId}`);
+  let caseBundleMaster;
+  try {
+    caseBundleMaster = await search_mdms(
+      null,
+      "CaseManagement.case_bundle_master",
+      tenantId,
+      requestInfo
+    ).then((mdmsRes) => {
+      return mdmsRes.data.mdms.filter((x) => x.isActive).map((x) => x.data);
+    });
+    logger.info(`[CaseBundle] MDMS case_bundle_master fetched | sections: ${caseBundleMaster.length}`);
+  } catch (err) {
+    logger.error(`[CaseBundle] Failed to fetch MDMS case_bundle_master | caseId: ${caseId} | error: ${err.message}`);
+    throw err;
+  }
 
-  console.debug(caseBundleMaster);
+  logger.info(`[CaseBundle] Fetching case details | caseId: ${caseId}`);
+  let courtCase;
+  try {
+    const caseResponse = await search_case_v2(
+      [{ caseId }],
+      tenantId,
+      requestInfo
+    );
+    courtCase = caseResponse?.data?.criteria[0]?.responseList[0];
+    if (!courtCase) {
+      throw new Error(`No case found for caseId: ${caseId}`);
+    }
+    logger.info(`[CaseBundle] Case fetched | caseId: ${caseId}, filingNumber: ${courtCase.filingNumber}`);
+  } catch (err) {
+    logger.error(`[CaseBundle] Failed to fetch case | caseId: ${caseId} | error: ${err.message}`);
+    throw err;
+  }
 
-  const resMessage = await search_message(
-    tenantId,
-    "rainmaker-case,rainmaker-orders,rainmaker-submissions,rainmaker-hearings,rainmaker-home,rainmaker-common",
-    "en_IN",
-    requestInfo
-  );
+  logger.info(`[CaseBundle] Fetching localization messages | tenantId: ${tenantId}`);
+  let messagesMap = {};
+  try {
+    const resMessage = await search_message(
+      tenantId,
+      "rainmaker-case,rainmaker-orders,rainmaker-submissions,rainmaker-hearings,rainmaker-home,rainmaker-common",
+      "en_IN",
+      requestInfo
+    );
+    const messages = resMessage?.data?.messages || [];
+    messagesMap =
+      messages?.length > 0
+        ? Object.fromEntries(messages.map(({ code, message }) => [code, message]))
+        : {};
+    logger.info(`[CaseBundle] Localization messages fetched | count: ${messages.length}`);
+  } catch (err) {
+    logger.error(`[CaseBundle] Failed to fetch localization messages | caseId: ${caseId} | error: ${err.message}`);
+    throw err;
+  }
 
-  const messages = resMessage?.data?.messages || [];
-  const messagesMap =
-    messages?.length > 0
-      ? Object.fromEntries(messages.map(({ code, message }) => [code, message]))
-      : {};
+  const ctx = { caseId, filingNumber: courtCase.filingNumber };
 
-  // Create an array of promises for all processing functions
-  const complaintPromises = [
-    processTitlePageSection(
-      courtCase,
-      caseBundleMaster,
-      tenantId,
-      requestInfo,
-      TEMP_FILES_DIR,
-      indexCopy
-    ),
-    processComplaintSection(
-      courtCase,
-      caseBundleMaster,
-      tenantId,
-      requestInfo,
-      TEMP_FILES_DIR,
-      indexCopy
-    ),
-    processPendingApplicationsSection(
-      courtCase,
-      caseBundleMaster,
-      tenantId,
-      requestInfo,
-      TEMP_FILES_DIR,
-      indexCopy,
-      messagesMap
-    ),
-  ];
+  logger.info(`[CaseBundle] Processing group 1: titlepage, complaint, pendingapplications`);
+  await Promise.all([
+    runSection("titlepage", () => processTitlePageSection(courtCase, caseBundleMaster, tenantId, requestInfo, TEMP_FILES_DIR, indexCopy), ctx),
+    runSection("complaint", () => processComplaintSection(courtCase, caseBundleMaster, tenantId, requestInfo, TEMP_FILES_DIR, indexCopy), ctx),
+    runSection("pendingapplications", () => processPendingApplicationsSection(courtCase, caseBundleMaster, tenantId, requestInfo, TEMP_FILES_DIR, indexCopy, messagesMap), ctx),
+  ]);
 
-  await Promise.all(complaintPromises);
+  logger.info(`[CaseBundle] Processing group 2: filings, affidavit, vakalat, additionalfilings`);
+  await Promise.all([
+    runSection("filings", () => processFilingsSection(courtCase, caseBundleMaster, tenantId, requestInfo, TEMP_FILES_DIR, indexCopy), ctx),
+    runSection("affidavit", () => processAffidavitSection(courtCase, caseBundleMaster, tenantId, requestInfo, TEMP_FILES_DIR, indexCopy), ctx),
+    runSection("vakalat", () => processVakalatSection(courtCase, caseBundleMaster, tenantId, requestInfo, TEMP_FILES_DIR, indexCopy, messagesMap), ctx),
+    runSection("additionalfilings", () => processAdditionalFilings(courtCase, caseBundleMaster, tenantId, requestInfo, TEMP_FILES_DIR, indexCopy, messagesMap), ctx),
+  ]);
 
-  const filingPromises = [
-    processFilingsSection(
-      courtCase,
-      caseBundleMaster,
-      tenantId,
-      requestInfo,
-      TEMP_FILES_DIR,
-      indexCopy
-    ),
-    processAffidavitSection(
-      courtCase,
-      caseBundleMaster,
-      tenantId,
-      requestInfo,
-      TEMP_FILES_DIR,
-      indexCopy
-    ),
-    processVakalatSection(
-      courtCase,
-      caseBundleMaster,
-      tenantId,
-      requestInfo,
-      TEMP_FILES_DIR,
-      indexCopy,
-      messagesMap
-    ),
-    processAdditionalFilings(
-      courtCase,
-      caseBundleMaster,
-      tenantId,
-      requestInfo,
-      TEMP_FILES_DIR,
-      indexCopy,
-      messagesMap
-    ),
-  ];
+  logger.info(`[CaseBundle] Processing group 3: mandatorysubmissions, complainantevidence, accusedevidence, courtevidence, applications`);
+  await Promise.all([
+    runSection("mandatorysubmissions", () => processMandatorySubmissions(courtCase, caseBundleMaster, tenantId, requestInfo, TEMP_FILES_DIR, indexCopy, messagesMap), ctx),
+    runSection("complainantevidence", () => processComplainantEvidence(courtCase, caseBundleMaster, tenantId, requestInfo, TEMP_FILES_DIR, indexCopy, messagesMap), ctx),
+    runSection("accusedevidence", () => processAccusedEvidence(courtCase, caseBundleMaster, tenantId, requestInfo, TEMP_FILES_DIR, indexCopy, messagesMap), ctx),
+    runSection("courtevidence", () => processCourtEvidence(courtCase, caseBundleMaster, tenantId, requestInfo, TEMP_FILES_DIR, indexCopy), ctx),
+    runSection("applications", () => processDisposedApplications(courtCase, caseBundleMaster, tenantId, requestInfo, TEMP_FILES_DIR, indexCopy, messagesMap), ctx),
+  ]);
 
-  await Promise.all(filingPromises);
+  logger.info(`[CaseBundle] Processing group 4: baildocument, processes`);
+  await Promise.all([
+    runSection("baildocument", () => processBailDocuments(courtCase, caseBundleMaster, tenantId, requestInfo, TEMP_FILES_DIR, indexCopy, messagesMap), ctx),
+    runSection("processes", () => processTaskProcesses(courtCase, caseBundleMaster, tenantId, requestInfo, TEMP_FILES_DIR, indexCopy), ctx),
+  ]);
 
-  const processingPromises = [
-    processMandatorySubmissions(
-      courtCase,
-      caseBundleMaster,
-      tenantId,
-      requestInfo,
-      TEMP_FILES_DIR,
-      indexCopy,
-      messagesMap
-    ),
-    processComplainantEvidence(
-      courtCase,
-      caseBundleMaster,
-      tenantId,
-      requestInfo,
-      TEMP_FILES_DIR,
-      indexCopy,
-      messagesMap
-    ),
-    processAccusedEvidence(
-      courtCase,
-      caseBundleMaster,
-      tenantId,
-      requestInfo,
-      TEMP_FILES_DIR,
-      indexCopy,
-      messagesMap
-    ),
-    processCourtEvidence(
-      courtCase,
-      caseBundleMaster,
-      tenantId,
-      requestInfo,
-      TEMP_FILES_DIR,
-      indexCopy
-    ),
-    processDisposedApplications(
-      courtCase,
-      caseBundleMaster,
-      tenantId,
-      requestInfo,
-      TEMP_FILES_DIR,
-      indexCopy,
-      messagesMap
-    ),
-  ];
+  logger.info(`[CaseBundle] Processing group 5: paymentreceipts, digitalizedDocuments, orders`);
+  await Promise.all([
+    runSection("paymentreceipts", () => processPaymentReceipts(courtCase, caseBundleMaster, tenantId, requestInfo, TEMP_FILES_DIR, indexCopy), ctx),
+    runSection("digitalizedDocuments", () => processExamination(courtCase, caseBundleMaster, tenantId, requestInfo, TEMP_FILES_DIR, indexCopy), ctx),
+    runSection("orders", () => processOrders(courtCase, caseBundleMaster, tenantId, requestInfo, TEMP_FILES_DIR, indexCopy), ctx),
+  ]);
 
-  await Promise.all(processingPromises);
-
-  const finalPromises = [
-    processBailDocuments(
-      courtCase,
-      caseBundleMaster,
-      tenantId,
-      requestInfo,
-      TEMP_FILES_DIR,
-      indexCopy,
-      messagesMap
-    ),
-    processTaskProcesses(
-      courtCase,
-      caseBundleMaster,
-      tenantId,
-      requestInfo,
-      TEMP_FILES_DIR,
-      indexCopy
-    ),
-  ];
-
-  await Promise.all(finalPromises);
-
-  const orderPromises = [
-    processPaymentReceipts(
-      courtCase,
-      caseBundleMaster,
-      tenantId,
-      requestInfo,
-      TEMP_FILES_DIR,
-      indexCopy
-    ),
-    processExamination(
-      courtCase,
-      caseBundleMaster,
-      tenantId,
-      requestInfo,
-      TEMP_FILES_DIR,
-      indexCopy
-    ),
-    processOrders(
-      courtCase,
-      caseBundleMaster,
-      tenantId,
-      requestInfo,
-      TEMP_FILES_DIR,
-      indexCopy
-    ),
-  ];
-
-  await Promise.all(orderPromises);
-
-  const othersPromises = [
-    processOthersSection(
-      courtCase,
-      caseBundleMaster,
-      tenantId,
-      requestInfo,
-      TEMP_FILES_DIR,
-      indexCopy
-    ),
-  ];
-
-  await Promise.all(othersPromises);
+  logger.info(`[CaseBundle] Processing group 6: others`);
+  await Promise.all([
+    runSection("others", () => processOthersSection(courtCase, caseBundleMaster, tenantId, requestInfo, TEMP_FILES_DIR, indexCopy), ctx),
+  ]);
 
   indexCopy.isRegistered = true;
   indexCopy.contentLastModified = Date.now();
 
+  logger.info(`[CaseBundle] processPendingAdmissionCase completed | caseId: ${caseId}`);
   return indexCopy;
 }
 

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processPendingApplicationsSection.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processPendingApplicationsSection.js
@@ -1,15 +1,10 @@
 const { search_application_v2 } = require("../../api");
-const {
-  filterCaseBundleBySection,
-} = require("../utils/filterCaseBundleBySection");
+const { filterCaseBundleBySection } = require("../utils/filterCaseBundleBySection");
 const { applyDocketToDocument } = require("../utils/applyDocketToDocument");
-const {
-  combineMultipleFilestores,
-} = require("../utils/combineMultipleFilestores");
-const {
-  duplicateExistingFileStore,
-} = require("../utils/duplicateExistingFileStore");
+const { combineMultipleFilestores } = require("../utils/combineMultipleFilestores");
+const { duplicateExistingFileStore } = require("../utils/duplicateExistingFileStore");
 const { getDynamicSectionNumber } = require("../utils/getDynamicSectionNumber");
+const { logger } = require("../../logger");
 
 const extractNumber = (cmpNumber) => {
   const parts = cmpNumber.split("/");
@@ -25,6 +20,7 @@ async function processPendingApplicationsSection(
   indexCopy,
   messagesMap
 ) {
+  logger.info(`[processPendingApplicationsSection] Started | filingNumber: ${courtCase?.filingNumber}`);
   const pendingReviewApplicationSection = filterCaseBundleBySection(
     caseBundleMaster,
     "pendingapplications"

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processTaskProcesses.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processTaskProcesses.js
@@ -1,11 +1,8 @@
-const {
-  filterCaseBundleBySection,
-} = require("../utils/filterCaseBundleBySection");
+const { filterCaseBundleBySection } = require("../utils/filterCaseBundleBySection");
 const { search_table_task } = require("../../api");
 const { getCaseNumber } = require("../../utils/commonUtils");
-const {
-  duplicateExistingFileStore,
-} = require("../utils/duplicateExistingFileStore");
+const { duplicateExistingFileStore } = require("../utils/duplicateExistingFileStore");
+const { logger } = require("../../logger");
 
 async function processTaskProcesses(
   courtCase,
@@ -15,6 +12,7 @@ async function processTaskProcesses(
   TEMP_FILES_DIR,
   indexCopy
 ) {
+  logger.info(`[processTaskProcesses] Started | filingNumber: ${courtCase?.filingNumber}`);
   const processesSection = filterCaseBundleBySection(
     caseBundleMaster,
     "processes"

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processTitlePageSection.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processTitlePageSection.js
@@ -3,9 +3,7 @@ const { create_pdf_v2 } = require("../../api");
 const { persistPDF } = require("../utils/persistPDF");
 const { logger } = require("../../logger");
 const { getCaseNumber } = require("../../utils/commonUtils");
-const {
-  filterCaseBundleBySection,
-} = require("../utils/filterCaseBundleBySection");
+const { filterCaseBundleBySection } = require("../utils/filterCaseBundleBySection");
 
 async function processTitlePageSection(
   courtCase,
@@ -15,6 +13,7 @@ async function processTitlePageSection(
   TEMP_FILES_DIR,
   indexCopy
 ) {
+  logger.info(`[processTitlePageSection] Started | filingNumber: ${courtCase?.filingNumber}`);
   const titlepageSection = filterCaseBundleBySection(
     caseBundleMaster,
     "titlepage"

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processVakalatSection.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processVakalatSection.js
@@ -1,11 +1,8 @@
 const { applyDocketToDocument } = require("../utils/applyDocketToDocument");
-const {
-  duplicateExistingFileStore,
-} = require("../utils/duplicateExistingFileStore");
-const {
-  filterCaseBundleBySection,
-} = require("../utils/filterCaseBundleBySection");
+const { duplicateExistingFileStore } = require("../utils/duplicateExistingFileStore");
+const { filterCaseBundleBySection } = require("../utils/filterCaseBundleBySection");
 const { getDynamicSectionNumber } = require("../utils/getDynamicSectionNumber");
+const { logger } = require("../../logger");
 
 async function processVakalatSection(
   courtCase,
@@ -16,7 +13,7 @@ async function processVakalatSection(
   indexCopy,
   messagesMap
 ) {
-  // update vakalatnamas
+  logger.info(`[processVakalatSection] Started | filingNumber: ${courtCase?.filingNumber}`);
   const vakalatnamaSection = filterCaseBundleBySection(
     caseBundleMaster,
     "vakalat"

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/utils/applyDocketToDocument.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/utils/applyDocketToDocument.js
@@ -3,6 +3,7 @@ const { mergePDFDocuments } = require("./mergePDFDocuments");
 const { persistPDF } = require("./persistPDF");
 const { convertFileStoreToDocument } = require("./convertFileStoreToDocument");
 const { search_mdms, create_pdf_v2 } = require("../../api");
+const { logger } = require("../../logger");
 
 /**
  *
@@ -31,95 +32,105 @@ async function applyDocketToDocument(
     return null;
   }
 
-  const filingPDFDocument = await convertFileStoreToDocument(
-    tenantId,
-    documentFileStoreId,
-    requestInfo
-  );
+  logger.info(`[applyDocketToDocument] Started | fileStoreId: ${documentFileStoreId}, docketApplicationType: ${docketApplicationType}`);
+  try {
+    const filingPDFDocument = await convertFileStoreToDocument(
+      tenantId,
+      documentFileStoreId,
+      requestInfo
+    );
 
-  // handling with multiple name and names are seperated by comma
-  const complainants = courtCase.litigants.filter((litigant) =>
-    litigant.partyType.includes("complainant")
-  );
+    // handling with multiple name and names are seperated by comma
+    const complainants = courtCase.litigants.filter((litigant) =>
+      litigant.partyType.includes("complainant")
+    );
 
-  const filteredRespondents =
-    courtCase.litigants?.filter((litigant) =>
-      litigant.partyType.includes("respondent")
-    ) || [];
+    const filteredRespondents =
+      courtCase.litigants?.filter((litigant) =>
+        litigant.partyType.includes("respondent")
+      ) || [];
 
-  const respondents =
-    filteredRespondents.length > 0
-      ? filteredRespondents
-      : courtCase?.additionalDetails?.respondentDetails?.formdata?.map(
-          (item) => item?.data
-        ) || [];
+    const respondents =
+      filteredRespondents.length > 0
+        ? filteredRespondents
+        : courtCase?.additionalDetails?.respondentDetails?.formdata?.map(
+            (item) => item?.data
+          ) || [];
 
-  const docketComplainantName = complainants
-    .map((lit) => lit.additionalDetails.fullName)
-    .filter(Boolean)
-    .join(", ");
+    const docketComplainantName = complainants
+      .map((lit) => lit.additionalDetails.fullName)
+      .filter(Boolean)
+      .join(", ");
 
-  const docketAccusedName =
-    respondents
-      ?.map((lit) => lit?.additionalDetails?.fullName)
-      ?.filter(Boolean)
-      ?.join(", ") ||
-    respondents
-      ?.map(
-        ({ respondentFirstName, respondentMiddleName, respondentLastName }) =>
-          [respondentFirstName, respondentMiddleName, respondentLastName]
-            ?.filter(Boolean)
-            ?.join(" ")
-      )
-      ?.filter(Boolean)
-      ?.join(", ");
+    const docketAccusedName =
+      respondents
+        ?.map((lit) => lit?.additionalDetails?.fullName)
+        ?.filter(Boolean)
+        ?.join(", ") ||
+      respondents
+        ?.map(
+          ({ respondentFirstName, respondentMiddleName, respondentLastName }) =>
+            [respondentFirstName, respondentMiddleName, respondentLastName]
+              ?.filter(Boolean)
+              ?.join(" ")
+        )
+        ?.filter(Boolean)
+        ?.join(", ");
 
-  const response = await search_mdms(
-    courtCase.courtId,
-    "common-masters.Court_Rooms",
-    tenantId,
-    requestInfo
-  ).then((mdmsRes) => {
-    return mdmsRes.data.mdms.filter((x) => x.isActive).map((x) => x.data);
-  });
+    logger.info(`[applyDocketToDocument] Fetching court room MDMS | courtId: ${courtCase.courtId}`);
+    const response = await search_mdms(
+      courtCase.courtId,
+      "common-masters.Court_Rooms",
+      tenantId,
+      requestInfo
+    ).then((mdmsRes) => {
+      return mdmsRes.data.mdms.filter((x) => x.isActive).map((x) => x.data);
+    });
 
-  const data = {
-    Data: [
-      {
-        docketDateOfSubmission: docketDateOfSubmission,
-        docketCourtName: "Before The " + response[0].name,
-        docketComplainantName,
-        docketAccusedName,
-        docketApplicationType,
-        docketNameOfAdvocate,
-        docketCounselFor,
-        docketNameOfFiling,
-        documentPath,
-      },
-    ],
-  };
-  const filingDocketPdfResponse = await create_pdf_v2(
-    tenantId,
-    "docket-page",
-    data,
-    { RequestInfo: requestInfo }
-  );
-  const filingDocketPDFDocument = await PDFDocument.load(
-    filingDocketPdfResponse.data,
-    { ignoreEncryption: true }
-  );
+    const data = {
+      Data: [
+        {
+          docketDateOfSubmission: docketDateOfSubmission,
+          docketCourtName: "Before The " + response[0].name,
+          docketComplainantName,
+          docketAccusedName,
+          docketApplicationType,
+          docketNameOfAdvocate,
+          docketCounselFor,
+          docketNameOfFiling,
+          documentPath,
+        },
+      ],
+    };
 
-  const mergedDocumentWithDocket = await mergePDFDocuments(
-    filingDocketPDFDocument,
-    filingPDFDocument
-  );
-  const mergedDocWithDocketFileStoreId = await persistPDF(
-    mergedDocumentWithDocket,
-    tenantId,
-    requestInfo,
-    TEMP_FILES_DIR
-  );
-  return mergedDocWithDocketFileStoreId;
+    logger.info(`[applyDocketToDocument] Generating docket page PDF | fileStoreId: ${documentFileStoreId}`);
+    const filingDocketPdfResponse = await create_pdf_v2(
+      tenantId,
+      "docket-page",
+      data,
+      { RequestInfo: requestInfo }
+    );
+    const filingDocketPDFDocument = await PDFDocument.load(
+      filingDocketPdfResponse.data,
+      { ignoreEncryption: true }
+    );
+
+    const mergedDocumentWithDocket = await mergePDFDocuments(
+      filingDocketPDFDocument,
+      filingPDFDocument
+    );
+    const mergedDocWithDocketFileStoreId = await persistPDF(
+      mergedDocumentWithDocket,
+      tenantId,
+      requestInfo,
+      TEMP_FILES_DIR
+    );
+    logger.info(`[applyDocketToDocument] Completed | sourceFileStoreId: ${documentFileStoreId}, resultFileStoreId: ${mergedDocWithDocketFileStoreId}`);
+    return mergedDocWithDocketFileStoreId;
+  } catch (err) {
+    logger.error(`[applyDocketToDocument] Failed | fileStoreId: ${documentFileStoreId}, docketApplicationType: ${docketApplicationType} | error: ${err.message}`);
+    throw err;
+  }
 }
 
 module.exports = {

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/utils/combineMultipleFilestores.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/utils/combineMultipleFilestores.js
@@ -1,6 +1,7 @@
 const { convertFileStoreToDocument } = require("./convertFileStoreToDocument");
 const { mergePDFDocuments } = require("./mergePDFDocuments");
 const { persistPDF } = require("./persistPDF");
+const { logger } = require("../../logger");
 
 async function combineMultipleFilestores(
   fileStoreIds,
@@ -12,20 +13,28 @@ async function combineMultipleFilestores(
     throw new Error("fileStoreIds must be a non-empty array");
   }
 
-  const pdfDocuments = await Promise.all(
-    fileStoreIds.map((id) =>
-      convertFileStoreToDocument(tenantId, id, requestInfo)
-    )
-  );
+  logger.info(`[combineMultipleFilestores] Combining ${fileStoreIds.length} fileStore(s) | ids: [${fileStoreIds.join(", ")}]`);
+  try {
+    const pdfDocuments = await Promise.all(
+      fileStoreIds.map((id) =>
+        convertFileStoreToDocument(tenantId, id, requestInfo)
+      )
+    );
 
-  const mergedDocumentWithDocket = await mergePDFDocuments(...pdfDocuments);
+    const mergedDocumentWithDocket = await mergePDFDocuments(...pdfDocuments);
 
-  return await persistPDF(
-    mergedDocumentWithDocket,
-    tenantId,
-    requestInfo,
-    TEMP_FILES_DIR
-  );
+    const resultId = await persistPDF(
+      mergedDocumentWithDocket,
+      tenantId,
+      requestInfo,
+      TEMP_FILES_DIR
+    );
+    logger.info(`[combineMultipleFilestores] Combined successfully | resultFileStoreId: ${resultId}`);
+    return resultId;
+  } catch (err) {
+    logger.error(`[combineMultipleFilestores] Failed | fileStoreIds: [${fileStoreIds.join(", ")}] | error: ${err.message}`);
+    throw err;
+  }
 }
 
 module.exports = { combineMultipleFilestores };

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/utils/convertFileStoreToDocument.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/utils/convertFileStoreToDocument.js
@@ -2,45 +2,60 @@ const { PDFDocument } = require("pdf-lib");
 const { fixJpg } = require("./fixJpg");
 const { A4_WIDTH, A4_HEIGHT } = require("./size");
 const { search_pdf_v2 } = require("../../api");
+const { logger } = require("../../logger");
 
 async function convertFileStoreToDocument(
   tenantId,
   documentFileStoreId,
   requestInfo
 ) {
-  const { data: stream, headers } = await search_pdf_v2(
-    tenantId,
-    documentFileStoreId,
-    requestInfo
-  );
-  const mimeType = headers["content-type"];
-  let filingPDFDocument;
-  if (mimeType === "application/pdf") {
-    filingPDFDocument = await PDFDocument.load(stream, {
-      ignoreEncryption: true,
-    });
-  } else if (["image/jpeg", "image/png", "image/jpg"].includes(mimeType)) {
-    filingPDFDocument = await PDFDocument.create();
-    let img;
-    if (mimeType === "image/png") {
-      img = await filingPDFDocument.embedPng(stream);
-    } else {
-      const repairedImage = await fixJpg(stream);
-      img = await filingPDFDocument.embedJpg(repairedImage);
-    }
-
-    const { width, height } = img.scale(1);
-    const scale = Math.min(A4_WIDTH / width, A4_HEIGHT / height);
-    const xOffset = (A4_WIDTH - width * scale) / 2;
-    const yOffset = (A4_HEIGHT - height * scale) / 2;
-    const page = filingPDFDocument.addPage([A4_WIDTH, A4_HEIGHT]);
-    page.drawImage(img, {
-      x: xOffset,
-      y: yOffset,
-      width: width * scale,
-      height: height * scale,
-    });
+  logger.info(`[convertFileStoreToDocument] Fetching | fileStoreId: ${documentFileStoreId}`);
+  let stream, mimeType;
+  try {
+    const response = await search_pdf_v2(tenantId, documentFileStoreId, requestInfo);
+    stream = response.data;
+    mimeType = response.headers["content-type"];
+  } catch (err) {
+    logger.error(`[convertFileStoreToDocument] FileStore fetch failed | fileStoreId: ${documentFileStoreId} | error: ${err.message}`);
+    throw err;
   }
+
+  logger.info(`[convertFileStoreToDocument] Converting | fileStoreId: ${documentFileStoreId}, mimeType: ${mimeType}`);
+  let filingPDFDocument;
+  try {
+    if (mimeType === "application/pdf") {
+      filingPDFDocument = await PDFDocument.load(stream, {
+        ignoreEncryption: true,
+      });
+    } else if (["image/jpeg", "image/png", "image/jpg"].includes(mimeType)) {
+      filingPDFDocument = await PDFDocument.create();
+      let img;
+      if (mimeType === "image/png") {
+        img = await filingPDFDocument.embedPng(stream);
+      } else {
+        const repairedImage = await fixJpg(stream);
+        img = await filingPDFDocument.embedJpg(repairedImage);
+      }
+
+      const { width, height } = img.scale(1);
+      const scale = Math.min(A4_WIDTH / width, A4_HEIGHT / height);
+      const xOffset = (A4_WIDTH - width * scale) / 2;
+      const yOffset = (A4_HEIGHT - height * scale) / 2;
+      const page = filingPDFDocument.addPage([A4_WIDTH, A4_HEIGHT]);
+      page.drawImage(img, {
+        x: xOffset,
+        y: yOffset,
+        width: width * scale,
+        height: height * scale,
+      });
+    } else {
+      throw new Error(`Unsupported mimeType: ${mimeType}`);
+    }
+  } catch (err) {
+    logger.error(`[convertFileStoreToDocument] Conversion failed | fileStoreId: ${documentFileStoreId}, mimeType: ${mimeType} | error: ${err.message}`);
+    throw err;
+  }
+
   return filingPDFDocument;
 }
 

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/utils/duplicateExistingFileStore.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/utils/duplicateExistingFileStore.js
@@ -1,5 +1,6 @@
 const { convertFileStoreToDocument } = require("./convertFileStoreToDocument");
 const { persistPDF } = require("./persistPDF");
+const { logger } = require("../../logger");
 
 async function duplicateExistingFileStore(
   tenantId,
@@ -7,13 +8,20 @@ async function duplicateExistingFileStore(
   requestInfo,
   TEMP_FILES_DIR
 ) {
-  const document = await convertFileStoreToDocument(
-    tenantId,
-    documentFileStoreId,
-    requestInfo
-  );
-
-  return await persistPDF(document, tenantId, requestInfo, TEMP_FILES_DIR);
+  logger.info(`[duplicateExistingFileStore] Duplicating | fileStoreId: ${documentFileStoreId}`);
+  try {
+    const document = await convertFileStoreToDocument(
+      tenantId,
+      documentFileStoreId,
+      requestInfo
+    );
+    const newId = await persistPDF(document, tenantId, requestInfo, TEMP_FILES_DIR);
+    logger.info(`[duplicateExistingFileStore] Duplicated | sourceFileStoreId: ${documentFileStoreId}, newFileStoreId: ${newId}`);
+    return newId;
+  } catch (err) {
+    logger.error(`[duplicateExistingFileStore] Failed | fileStoreId: ${documentFileStoreId} | error: ${err.message}`);
+    throw err;
+  }
 }
 
 module.exports = {

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/utils/persistPDF.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/utils/persistPDF.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 const { create_file_v2 } = require("../../api");
+const { logger } = require("../../logger");
 
 /**
  *
@@ -10,23 +11,36 @@ const { create_file_v2 } = require("../../api");
  * @returns {Promise<string>}
  */
 async function persistPDF(pdfDoc, tenantId, requestInfo, TEMP_FILES_DIR) {
-  const pdfBytes = await pdfDoc.save();
-
   const mergedFilePath = path.join(
     TEMP_FILES_DIR,
     `merged-bundle-${Date.now()}.pdf`
   );
-  fs.writeFileSync(mergedFilePath, pdfBytes);
+  try {
+    const pdfBytes = await pdfDoc.save();
+    fs.writeFileSync(mergedFilePath, pdfBytes);
+    logger.info(`[persistPDF] Uploading to FileStore | tenantId: ${tenantId}, tempFile: ${path.basename(mergedFilePath)}`);
 
-  const fileStoreResponse = await create_file_v2({
-    filePath: mergedFilePath,
-    tenantId,
-    requestInfo,
-    module: "case-bundle-case-index",
-  });
-  fs.unlinkSync(mergedFilePath);
+    const fileStoreResponse = await create_file_v2({
+      filePath: mergedFilePath,
+      tenantId,
+      requestInfo,
+      module: "case-bundle-case-index",
+    });
 
-  return fileStoreResponse?.data?.files?.[0].fileStoreId;
+    const fileStoreId = fileStoreResponse?.data?.files?.[0].fileStoreId;
+    if (!fileStoreId) {
+      throw new Error("FileStore upload returned no fileStoreId");
+    }
+    logger.info(`[persistPDF] Upload succeeded | fileStoreId: ${fileStoreId}`);
+    return fileStoreId;
+  } catch (err) {
+    logger.error(`[persistPDF] Failed | tenantId: ${tenantId}, tempFile: ${path.basename(mergedFilePath)} | error: ${err.message}`);
+    throw err;
+  } finally {
+    if (fs.existsSync(mergedFilePath)) {
+      fs.unlinkSync(mergedFilePath);
+    }
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
## Requirements

- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the github issues('s)
- [x] I performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`

Addresses https://github.com/pucardotorg/dristi/issues/5725

## Summary

Previously, when the case bundle generation failed in the pod, logs only showed a generic error with no indication of which section or document caused the failure. This PR adds structured, contextual logging throughout the entire case bundle flow in `dristi-pdf` so that failures can be diagnosed directly from pod logs.

**Key changes:**

- `processPendingAdmissionCase`: Introduced a `runSection()` wrapper around every `Promise.all` group — on failure it logs the exact section name, `caseId`, and `filingNumber` instead of a silent rejection
- `generateIndex`: Added try/catch with error log on `processCaseBundle` failure
- `buildCasePdf`: Logs section and item progress with `fileStoreId`, page counts, and error context with `caseNumber`/`tenantId`
- `convertFileStoreToDocument`: Logs FileStore fetch failures and unsupported mimeType with `fileStoreId`
- `persistPDF`: Logs upload failures; moved temp file cleanup to `finally` block
- `combineMultipleFilestores`: Logs all `fileStoreIds` involved on failure
- `duplicateExistingFileStore`: Logs source `fileStoreId` on failure
- `applyDocketToDocument`: Logs each step (fetch → MDMS court room → docket PDF generate → merge → persist) with `fileStoreId`
- All 13 section processors: Added `logger` import and a start log with `filingNumber`
- `processComplaintSection`: Added a specific `[error]` log when the signed complaint document is missing — the most common failure point
- `processFilingsSection`: Removed the noisy `logger.info(caseBundleMaster)` that was dumping the entire MDMS config on every run

**Verified on QA:** Triggered 3 case bundle downloads. Two completed successfully and were traceable end-to-end in logs. The third failure was immediately pinpointed in logs:
```
[error]: [processComplaintSection] No complaint document found | filingNumber: KL-001533-2026, expected documentType: case.complaint.signed
[error]: [CaseBundle] Failed section: complaint | error: no case complaint
```

## Data Changes

None — no MDMS, workflow, or deployment configuration changes.

## Preview

N/A — backend logging change only.

## Other

- No breaking changes
- No new dependencies
- Pure observability improvement; existing behavior is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Strengthened file storage validation to prevent invalid responses from causing silent failures.
  * Improved error handling and recovery across PDF generation workflows.

* **Chores**
  * Enhanced diagnostic tracking throughout case bundle processing.
  * Standardized error context and reporting across PDF utilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pucardotorg/dristi-solutions/pull/6622)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->