### PR TITLE
fix(dristi-pdf): add complaint document fallback chain in processComplaintSection (#5725)

### DIFF
--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processComplaintSection.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processComplaintSection.js
@@ -3,6 +3,7 @@ const {
 } = require("../utils/filterCaseBundleBySection");
 const { applyDocketToDocument } = require("../utils/applyDocketToDocument");
 const { getDynamicSectionNumber } = require("../utils/getDynamicSectionNumber");
+const { logger } = require("../../logger");
 
 async function processComplaintSection(
   courtCase,
@@ -12,6 +13,9 @@ async function processComplaintSection(
   TEMP_FILES_DIR,
   indexCopy
 ) {
+  logger.info(
+    `[processComplaintSection] Started | filingNumber: ${courtCase?.filingNumber}`
+  );
   const complaintSection = filterCaseBundleBySection(
     caseBundleMaster,
     "complaint"
@@ -29,10 +33,39 @@ async function processComplaintSection(
   if (complaintSection?.length !== 0) {
     const section = complaintSection[0];
 
-    const complaintFileStoreId = courtCase.documents?.find(
+    // Fallback chain mirroring Java ComplaintSection.java:
+    // 1. case.complaint.signed (ideal — fully signed document)
+    // 2. additionalDetails.signedCaseDocument (backup written by ComplainantSignature.js)
+    // 3. case.complaint.unsigned (last resort — signing incomplete but doc exists)
+    let complaintFileStoreId = courtCase.documents?.find(
       (doc) => doc.documentType === "case.complaint.signed"
     )?.fileStore;
+
     if (!complaintFileStoreId) {
+      complaintFileStoreId =
+        courtCase.additionalDetails?.signedCaseDocument || null;
+      if (complaintFileStoreId) {
+        logger.warn(
+          `[processComplaintSection] case.complaint.signed not found, falling back to additionalDetails.signedCaseDocument | filingNumber: ${courtCase?.filingNumber}, fileStoreId: ${complaintFileStoreId}`
+        );
+      }
+    }
+
+    if (!complaintFileStoreId) {
+      complaintFileStoreId = courtCase.documents?.find(
+        (doc) => doc.documentType === "case.complaint.unsigned"
+      )?.fileStore;
+      if (complaintFileStoreId) {
+        logger.warn(
+          `[processComplaintSection] Falling back to case.complaint.unsigned | filingNumber: ${courtCase?.filingNumber}, fileStoreId: ${complaintFileStoreId}`
+        );
+      }
+    }
+
+    if (!complaintFileStoreId) {
+      logger.error(
+        `[processComplaintSection] No complaint document found in any fallback (signed, additionalDetails.signedCaseDocument, unsigned) | filingNumber: ${courtCase?.filingNumber}`
+      );
       throw new Error("no case complaint");
     }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the github issues('s)
- [x] I performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`

Addresses https://github.com/pucardotorg/dristi/issues/5725

## Summary

`processComplaintSection` was throwing a hard error when `case.complaint.signed` was not found in the case documents, crashing the entire case bundle even when the document existed under a different type (e.g. due to an incomplete signing flow, e-sign failure, or data migration).

Added a 3-level fallback chain mirroring what the Java backend `ComplaintSection.java` already does:

1. `case.complaint.signed` — ideal path (fully signed document)
2. `additionalDetails.signedCaseDocument` — backup explicitly written by `ComplainantSignature.js` at sign-time
3. `case.complaint.unsigned` — last resort when signing was never completed

If all three lookups fail, a `logger.error` is emitted and the error is thrown (not silently swallowed). Each fallback step logs a `warn` with `filingNumber` so the data gap is visible in pod logs.

## Data Changes

None.

## Preview

N/A — backend only.

## Other

- No breaking changes
- No new dependencies
- Single file change: `processComplaintSection.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved complaint document handling reliability with enhanced fallback mechanisms for document resolution.
  * Strengthened error logging and diagnostics for document processing operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pucardotorg/dristi-solutions/pull/6623)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->