### PR TITLE
fix: pass authToken in fetchBill call on offline payment screen (#5719)

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/Payment/ViewPaymentDetails.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/Payment/ViewPaymentDetails.js
@@ -87,15 +87,11 @@ const ViewPaymentDetails = ({ location, match }) => {
   const summonsPincode = useMemo(() => tasksData?.taskDetails?.respondentDetails?.address?.pincode, [tasksData]);
   const channelId = useMemo(() => extractFeeMedium(tasksData?.taskDetails?.deliveryChannels?.channelName || ""), [tasksData]);
 
-  const { data: paymentDetails, isLoading: isFetchBillLoading } = Digit.Hooks.useFetchBillsForBuissnessService(
-    {
-      tenantId: tenantId,
-      consumerCode: consumerCode,
-      businessService: businessService,
-    },
-    {
-      enabled: Boolean(tenantId && consumerCode),
-    }
+  const { data: paymentDetails, isLoading: isFetchBillLoading } = Digit.Hooks.dristi.useFetchBill(
+    {},
+    { tenantId, consumerCode, businessService },
+    `view-payment-${consumerCode}-${businessService}`,
+    Boolean(tenantId && consumerCode)
   );
   const { data: BillResponse, isLoading: isBillLoading } = Digit.Hooks.dristi.useBillSearch(
     {},


### PR DESCRIPTION
## Requirements

- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the github issues('s)
- [x] I performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`

Addresses https://github.com/pucardotorg/dristi/issues/5719

## Summary

On the gCMO offline payment screen (`pending-payment-details`), the payment breakdown was not visible because the billing service was returning `"Bill": []`.

The fix replaces `Digit.Hooks.useFetchBillsForBuissnessService` (from the external `@egovernments/digit-ui-libraries` package) with the existing `Digit.Hooks.dristi.useFetchBill` hook, which correctly passes `authToken` in the request.

## Root Cause Analysis

**File:** `frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/Payment/ViewPaymentDetails.js`

The component used `Digit.Hooks.useFetchBillsForBuissnessService` (from the external `@egovernments/digit-ui-libraries` package) to fetch the bill on page load. This hook builds the `RequestInfo` body **without** the `authToken` field:

```json
{ "RequestInfo": { "apiId": "Dristi", "msgId": "...", "plainAccessRequest": {} } }
```

The DIGIT billing service (`/billing-service/bill/v2/_fetchbill`) requires a valid `authToken` to authenticate the caller. Without it, the service rejects the request and returns an empty `Bill` array — so the UI had nothing to render in the payment breakdown section.

**Fix:** Replaced the external hook with `Digit.Hooks.dristi.useFetchBill`, which internally calls `DRISTIService.callFetchBill` with `userService: true`. The DIGIT `Request` helper uses this flag to automatically inject the user's `authToken` from the session into `RequestInfo`, resulting in a successful authenticated bill fetch.

Note: `DRISTIService.callFetchBill` was already being used correctly (with `userService: true`) in the form submit handler (`onSubmitCase`) — the initial page load fetch was the only call using the unauthenticated hook.

## Data Changes

N/A — no MDMS, workflow, or deployment configuration changes.

## Preview

Payment breakdown is now visible on the gCMO offline payment screen after this fix (verified on QA).

## Other

No breaking changes. No new dependencies. The `useFetchBill` hook already existed in the dristi module and was already exported — only the call site in `ViewPaymentDetails.js` was changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the internal mechanism for retrieving payment details to improve data fetching efficiency and reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pucardotorg/dristi-solutions/pull/6624)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->