### PR TITLE
feat: use searchNumber in Join a Case to support all case identifiers

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/cases/src/pages/employee/JoinCaseHome.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/cases/src/pages/employee/JoinCaseHome.js
@@ -125,7 +125,7 @@ const JoinCaseHome = ({ refreshInbox, setShowJoinCase, showJoinCase, type, data 
           const response = await DRISTIService.summaryCaseSearchService(
             {
               criteria: {
-                filingNumber: caseNumber,
+                searchNumber: caseNumber,
                 ...(courtId && { courtId }),
                 pagination: {
                   limit: 5,


### PR DESCRIPTION
Addresses https://github.com/pucardotorg/dristi/issues/5687

## Summary

- Replace `filingNumber` with `searchNumber` in the `summaryCaseSearchService` call inside `JoinCaseHome.js`
- The backend API `/case/v2/search/summary` now accepts `searchNumber` and searches across all case identifiers: filing number, CNR number, court case number, and CMP number
- This allows users to join a case using any number they have, regardless of which stage the case is at

## Changes

- `frontend/micro-ui/web/micro-ui-internals/packages/modules/cases/src/pages/employee/JoinCaseHome.js` — renamed `filingNumber` → `searchNumber` in the search criteria passed to the summary search API

## Test Plan

- [ ] Enter a filing number in Join a Case — case should be found
- [ ] Enter a CNR number in Join a Case — case should be found
- [ ] Enter a CMP number in Join a Case — case should be found
- [ ] Enter a court case number in Join a Case — case should be found
- [ ] Enter an invalid number — should show NO_CASE_FOUND error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved case search accuracy by correcting the case identification field used in case number searches.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pucardotorg/dristi-solutions/pull/6628)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->