### PR TITLE
fix: allow forward slash in Join a Case search input

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/cases/src/pages/employee/joinCaseComponent/SearchCaseAndShowDetails.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/cases/src/pages/employee/joinCaseComponent/SearchCaseAndShowDetails.js
@@ -77,7 +77,7 @@ const SearchCaseAndShowDetails = ({
                 setCaseList([]);
                 let str = e.target.value;
                 if (str) {
-                  str = str.replace(/[^a-zA-Z0-9.-]/g, "");
+                  str = str.replace(/[^a-zA-Z0-9.\/-]/g, "");
                   if (str.length > 50) {
                     str = str.substring(0, 50);
                   }


### PR DESCRIPTION
Addresses https://github.com/pucardotorg/dristi/issues/5687

## Summary

- Update the character filter regex in `SearchCaseAndShowDetails.js` to allow `/` in the case number input field
- Previously, only alphanumeric characters, `.`, and `-` were permitted — this silently stripped `/` which may appear in CMP numbers and court case numbers (e.g. `CMP/1234/2024`, `CC/123/2024`)

## Changes

- `frontend/.../joinCaseComponent/SearchCaseAndShowDetails.js` — updated regex from `/[^a-zA-Z0-9.-]/g` to `/[^a-zA-Z0-9.\/-]/g`

## Test Plan

- [ ] Enter a case number containing `/` (e.g. `CMP/1234/2024`) — characters should not be stripped
- [ ] Enter a filing number (`KL-000001-2024`) — still works as before
- [ ] Enter invalid special characters (e.g. `@`, `#`, space) — should still be stripped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced case number input validation to accept forward slashes, enabling support for case numbers that include this character.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pucardotorg/dristi-solutions/pull/6630)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->