### PR TITLE
fix: show matched case number in Join a Case search results

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/cases/src/pages/employee/joinCaseComponent/SearchCaseAndShowDetails.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/cases/src/pages/employee/joinCaseComponent/SearchCaseAndShowDetails.js
@@ -62,6 +62,15 @@ const SearchCaseAndShowDetails = ({
     return [];
   }, [caseDetails]);
 
+  const getDisplayNumber = (option, searchTerm) => {
+    if (!searchTerm) return option?.filingNumber;
+    const term = searchTerm.toLowerCase();
+    if (option?.cmpNumber?.toLowerCase().includes(term)) return option?.cmpNumber;
+    if (option?.cnrNumber?.toLowerCase().includes(term)) return option?.cnrNumber;
+    if (option?.courtCaseNumber?.toLowerCase().includes(term)) return option?.courtCaseNumber;
+    return option?.filingNumber;
+  };
+
   return (
     <div className="case-number-input">
       {!caseDetails?.cnrNumber && (
@@ -102,7 +111,7 @@ const SearchCaseAndShowDetails = ({
                     onSelect(option);
                   }}
                 >
-                  <span> {option?.filingNumber}</span>
+                  <span> {getDisplayNumber(option, caseNumber)}</span>
                 </div>
               );
             })}


### PR DESCRIPTION
Addresses https://github.com/pucardotorg/dristi/issues/5733

## Summary

- In the Join a Case search result dropdown, the displayed number now reflects the number type that matched the user's search input
- Previously, the dropdown always showed the filing number regardless of what was searched
- Now, if the user searched by CMP number, the CMP number is shown; if by CNR, the CNR is shown; etc.

## Changes

- `frontend/.../joinCaseComponent/SearchCaseAndShowDetails.js` — added `getDisplayNumber` helper that picks the matched field (CMP → CNR → court case number → filing number fallback) and uses it in the dropdown

## Test Plan

- [ ] Search by filing number → dropdown shows filing number
- [ ] Search by CNR number → dropdown shows CNR number
- [ ] Search by CMP number → dropdown shows CMP number
- [ ] Search by court case number → dropdown shows court case number

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the case search experience by displaying more relevant case number information in search results based on your search input, ensuring you see the most pertinent matches when browsing cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pucardotorg/dristi-solutions/pull/6632)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->