### PR TITLE
fix: remove hardcoded filing number format hint from Join a Case search

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/cases/src/pages/employee/joinCaseComponent/SearchCaseAndShowDetails.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/cases/src/pages/employee/joinCaseComponent/SearchCaseAndShowDetails.js
@@ -106,9 +106,7 @@ const SearchCaseAndShowDetails = ({
                 </div>
               );
             })}
-          <p style={{ fontSize: "12px" }}>
-            {t("FILLING_NUMBER_FORMATE_TEXT")} {"KL-<6 digit sequence number>-<YYYY>"}
-          </p>
+
         </LabelFieldPair>
       )}
       {errors?.caseNumber && (


### PR DESCRIPTION
Addresses https://github.com/pucardotorg/dristi/issues/5733

## Summary

- Removed the hardcoded format hint `KL-<6 digit sequence number>-<YYYY>` shown below the case number input in Join a Case
- This hint was specific to filing numbers and misleading now that the search accepts any case identifier (filing number, CNR, CMP, court case number)

## Changes

- `frontend/.../joinCaseComponent/SearchCaseAndShowDetails.js` — removed the `<p>` tag containing the filing number format hint

## Test Plan

- [ ] Open Join a Case search — format hint text should no longer appear below the input field

🤖 Generated with [Claude Code](https://claude.com/claude-code)