### PR TITLE
fix: add react-responsive, react-table and react-tooltip to web/package.json for build

### DIFF
--- a/frontend/micro-ui/web/package.json
+++ b/frontend/micro-ui/web/package.json
@@ -37,7 +37,10 @@
     "react-hook-form": "6.15.8",
     "react-i18next": "11.16.2",
     "react-query": "3.6.1",
+    "react-responsive": "9.0.2",
     "react-router-dom": "5.3.0",
+    "react-table": "7.7.0",
+    "react-tooltip": "4.1.2",
     "style-loader": "2.0.0",
     "terser-brunch": "^4.1.0",
     "webpack-cli": "4.10.0"


### PR DESCRIPTION
## Requirements

- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - inbox-search-composer-build-fixes
- [x] I have referenced the github issues('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`

## Summary

Related to https://github.com/pucardotorg/dristi-backend-pbhrch/issues/50

The Docker/CI build uses `micro-ui/web/` as the root and runs `yarn install` from there, so all packages referenced by module dist files must also be listed in `web/package.json`.

The following packages were added to individual module `package.json` files inside `micro-ui-internals` but were missing from the root `web/package.json`, causing webpack to fail during the build:

- `react-responsive@9.0.2` — used by `InboxSearchComposer` (core module)
- `react-table@7.7.0` — used by home and cases modules
- `react-tooltip@4.1.2` — used by core, dristi, home, and orders modules

## Data Changes

None.

## Preview

Build errors fixed:
- `Module not found: Can't resolve 'react-responsive' in core/dist`
- `Module not found: Can't resolve 'react-tooltip' in core/dist, dristi/dist, home/dist, orders/dist`

## Other

- No breaking changes
- Must be merged to `develop` before (or alongside) the InboxSearchComposer PR so the build succeeds