### PR TITLE
fix: align LitigantHomeConfig LPR payload with employee-side config

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/configs/LitigantHomeConfig.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/configs/LitigantHomeConfig.js
@@ -132,7 +132,9 @@ export const TabLitigantSearchConfig = {
         requestParam: {},
         requestBody: {
           tenantId: "pg",
-          criteria: {},
+          criteria: {
+            lifecycleStatus: "ACTIVE",
+          },
         },
         masterName: "commonUiConfig",
         moduleName: "homeLitigantUiConfig",
@@ -367,7 +369,7 @@ export const TabLitigantSearchConfig = {
         requestParam: {},
         requestBody: {
           tenantId: "pg",
-          criteria: { outcome: [] },
+          criteria: { outcome: [], lifecycleStatus: "ACTIVE" },
         },
         masterName: "commonUiConfig",
         moduleName: "homeLitigantUiConfig",
@@ -520,7 +522,7 @@ export const TabLitigantSearchConfig = {
         requestBody: {
           tenantId: "pg",
           criteria: {
-            isLPRCase: true,
+            lifecycleStatus: "LPR",
           },
         },
         masterName: "commonUiConfig",


### PR DESCRIPTION
## Summary

https://github.com/pucardotorg/dristi/issues/5742

- Updated `CS_LPR` tab in `LitigantHomeConfig` to send `lifecycleStatus: "LPR"` instead of the stale `isLPRCase: true`, matching the employee-side configs (JudgeHomeConfig, BenchHomeConfig, CourtRoomHomeConfig, HomeConfig)
- Added `lifecycleStatus: "ACTIVE"` to the `CS_ONGOING` tab (was sending an empty `criteria: {}`)
- Added `lifecycleStatus: "ACTIVE"` to the `CS_CLOSED` tab (was missing it alongside the existing `outcome` filter)

## Root cause

The employee-side configs were updated to use `lifecycleStatus` but the citizen-side `LitigantHomeConfig` was missed in the same change.

## Test plan

- [ ] On citizen home (`citizen/home/home-pending-task`), click the **Long Pending Register** tab — verify the API request body contains `lifecycleStatus: "LPR"` (not `isLPRCase: true`)
- [ ] On citizen home, click the **Ongoing** tab — verify the request body contains `lifecycleStatus: "ACTIVE"`
- [ ] On citizen home, click the **Closed** tab — verify the request body contains `lifecycleStatus: "ACTIVE"` alongside the outcome filter
- [ ] Verify employee-side tabs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated case search filtering logic across home dashboard tabs to properly categorize cases by their lifecycle status, ensuring accurate results in the ongoing, closed, and legal proceedings cases sections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pucardotorg/dristi-solutions/pull/6653)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->