### PR TITLE
fix: resolve inbox table issues - tab switch stale data, form reset, and incorrect jsonPaths

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/core/src/components/InboxSearchComposer/hoc/InboxSearchComposer.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/core/src/components/InboxSearchComposer/hoc/InboxSearchComposer.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useReducer, useState,useMemo } from "react";
+import React, { useEffect, useReducer, useState, useMemo, useRef } from "react";
 import { Toast } from "@egovernments/digit-ui-components";
 import ResultsTable from "./ResultsTable"
 import reducer, { initialInboxState } from "./InboxSearchComposerReducer";
@@ -26,10 +26,14 @@ const InboxSearchComposer = ({configs,headerLabel,additionalConfig,onFormValueCh
     const [type, setType] = useState("");
     const [popup, setPopup] = useState(false);
    
-    const [apiDetails, setApiDetails] = useState(configs?.apiDetails);
+    const [apiDetails, setApiDetails] = useState(() => _.cloneDeep(configs?.apiDetails));
+    const prevConfigLabelRef = useRef(configs?.label);
 
     useEffect(()=>{
-        setApiDetails(configs?.apiDetails)
+        if (prevConfigLabelRef.current === configs?.label) return;
+        prevConfigLabelRef.current = configs?.label;
+        setApiDetails(_.cloneDeep(configs?.apiDetails));
+        dispatch({ type: "obj", updatedState: initialInboxState(configs) });
     },[configs])
 
     const mobileSearchSession = Digit.Hooks.useSessionStorage("MOBILE_SEARCH_MODAL_FORM", 
@@ -176,9 +180,10 @@ const InboxSearchComposer = ({configs,headerLabel,additionalConfig,onFormValueCh
                 {
                     configs?.type === 'search' && configs?.sections?.search?.show &&
                         <div className={`section search ${showTab ? "tab": ""}`}>
-                            <SearchComponent 
-                                uiConfig={ configs?.sections?.search?.uiConfig} 
-                                header={configs?.sections?.search?.label} 
+                            <SearchComponent
+                                key={configs?.label}
+                                uiConfig={ configs?.sections?.search?.uiConfig}
+                                header={configs?.sections?.search?.label}
                                 screenType={configs.type}
                                 fullConfig={configs}
                                 data={data}
@@ -191,12 +196,13 @@ const InboxSearchComposer = ({configs,headerLabel,additionalConfig,onFormValueCh
 
                 }
                 {   
-                    configs?.type === 'search' && configs?.sections?.filter?.show && 
+                    configs?.type === 'search' && configs?.sections?.filter?.show &&
 
                         <div className="section filter">
-                            <SearchComponent 
-                                uiConfig={ configs?.sections?.filter?.uiConfig} 
-                                header={configs?.sections?.filter?.label} 
+                            <SearchComponent
+                                key={configs?.label}
+                                uiConfig={ configs?.sections?.filter?.uiConfig}
+                                header={configs?.sections?.filter?.label}
                                 screenType={configs.type}
                                 fullConfig={configs}
                                 data={data}
@@ -208,9 +214,10 @@ const InboxSearchComposer = ({configs,headerLabel,additionalConfig,onFormValueCh
                     configs?.type === 'inbox' && configs?.sections?.search?.show &&
                     <MediaQuery minWidth={426}>
                         <div className="section search">
-                            <SearchComponent 
-                                uiConfig={ configs?.sections?.search?.uiConfig} 
-                                header={configs?.sections?.search?.label} 
+                            <SearchComponent
+                                key={configs?.label}
+                                uiConfig={ configs?.sections?.search?.uiConfig}
+                                header={configs?.sections?.search?.label}
                                 screenType={configs.type}
                                 fullConfig={configs}
                                 data={data}
@@ -220,12 +227,13 @@ const InboxSearchComposer = ({configs,headerLabel,additionalConfig,onFormValueCh
                      </MediaQuery>
                 }
                 {   
-                    configs?.type === 'inbox' && configs?.sections?.filter?.show && 
+                    configs?.type === 'inbox' && configs?.sections?.filter?.show &&
                     <MediaQuery minWidth={426}>
                         <div className="section filter">
-                            <SearchComponent 
-                                uiConfig={ configs?.sections?.filter?.uiConfig} 
-                                header={configs?.sections?.filter?.label} 
+                            <SearchComponent
+                                key={configs?.label}
+                                uiConfig={ configs?.sections?.filter?.uiConfig}
+                                header={configs?.sections?.filter?.label}
                                 screenType={configs.type}
                                 fullConfig={configs}
                                 data={data}

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/core/src/components/InboxSearchComposer/hoc/ResultsTable.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/core/src/components/InboxSearchComposer/hoc/ResultsTable.js
@@ -138,6 +138,10 @@ const ResultsTable = ({ tableContainerClass, config,data,isLoading,isFetching,fu
     setDefaultValues()
   }, [session])
 
+  useEffect(() => {
+    reset(state.tableForm);
+  }, [state.tableForm])
+
     const isMobile = window.Digit.Utils.browser.isMobile();
     const [searchQuery, onSearch] = useState("");
     const debouncedValue = config?.debouncedValue || 1000;

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/configs/LitigantHomeConfig.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/configs/LitigantHomeConfig.js
@@ -336,7 +336,7 @@ export const TabLitigantSearchConfig = {
               },
               {
                 label: "CS_STAGE",
-                jsonPath: "status",
+                jsonPath: "stage",
                 additionalCustomization: true,
               },
               {
@@ -346,7 +346,7 @@ export const TabLitigantSearchConfig = {
               },
               {
                 label: "CS_LAST_EDITED",
-                jsonPath: "auditDetails.lastModifiedTime",
+                jsonPath: "lastModifiedTime",
                 additionalCustomization: true,
               },
             ],


### PR DESCRIPTION
## Summary

- **InboxSearchComposer**: Added `useRef` guard so `apiDetails` and inbox state only reset when the config `label` actually changes (tab switch), preventing stale data and double-click issues. Added `key={configs?.label}` to `SearchComponent` instances to force re-mount on tab change.
- **ResultsTable**: Added `useEffect` to reset the table form when `state.tableForm` changes, ensuring form state stays in sync after tab switches.
- **LitigantHomeConfig**: Fixed incorrect `jsonPath` values — `CS_STAGE` column changed from `status` → `stage`, and `CS_LAST_EDITED` column changed from `auditDetails.lastModifiedTime` → `lastModifiedTime`.

## Test plan

- [ ] Switch between tabs on the employee home inbox — verify no stale results or double-fetch
- [ ] Confirm the CS_STAGE column shows the correct stage value (not status) in the Litigant view
- [ ] Confirm the CS_LAST_EDITED column renders correctly
- [ ] Verify search/filter forms reset cleanly when switching tabs

https://github.com/pucardotorg/dristi/issues/5742

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed search state management to properly reflect configuration changes
  * Corrected form field resets in results table
  * Fixed data mappings in pending submission search results columns to display accurate stage and modification time information

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pucardotorg/dristi-solutions/pull/6656)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->