### PR TITLE
fix: LPR stage label in CaseDetailsStrip and built-in pagination for Parties tab

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/configs/UICustomizations.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/configs/UICustomizations.js
@@ -1330,7 +1330,6 @@ export const UICustomizations = {
   },
   PartiesConfig: {
     preProcess: (requestCriteria, additionalDetails) => {
-      const { limit, offset } = requestCriteria.state?.tableForm || {};
       return {
         ...requestCriteria,
         config: {
@@ -1491,14 +1490,13 @@ export const UICustomizations = {
               ...advocateOfficeClerks,
               ...advocateOfficeAssistantAdvocates,
             ];
-            const paginatedParties = allParties.slice(offset, offset + limit);
             return {
               ...data,
               criteria: {
                 ...data.criteria[0],
                 responseList: {
                   ...data.criteria[0].responseList[0],
-                  parties: paginatedParties,
+                  parties: allParties,
                 },
               },
               totalCount: allParties?.length,

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCasesConfig.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/AdmittedCasesConfig.js
@@ -753,6 +753,7 @@ export const TabSearchconfigNew = {
 
             enableColumnSort: true,
             resultsJsonPath: "criteria.responseList.parties",
+            manualPagination: false,
           },
           show: true,
         },

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/components/CaseDetailsStrip.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/components/CaseDetailsStrip.js
@@ -52,7 +52,7 @@ const CaseDetailsStrip = ({ t, caseDetails, advocateName, delayCondonationData, 
             <div className="sub-details-text">{t(caseDetails?.filingNumber)}</div> <hr className="vertical-line" />
           </React.Fragment>
         )}
-        <div className="sub-details-text">Stage: {t(caseDetails?.stage)}</div>
+        <div className="sub-details-text">Stage: {isLPRCase(caseDetails) ? t("CS_LPR") : t(caseDetails?.stage)}</div>
         {(Array.isArray(caseDetails?.secondaryStage) ? caseDetails?.secondaryStage?.length > 0 : caseDetails?.secondaryStage) && (
           <React.Fragment>
             <hr className="vertical-line" />


### PR DESCRIPTION
## Requirements

- [x] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the github issue('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code

## Summary

- **CaseDetailsStrip:** Show `CS_LPR` translation key as the Stage label when `isLPRCase(caseDetails)` is true; otherwise keep the existing `t(caseDetails.stage)` behavior. This avoids displaying the raw workflow stage on LPR (Long Pending Register) cases.
- **Parties tab pagination:** Removed the manual `slice(offset, offset+limit)` in `PartiesConfig.preProcess` (UICustomizations.js) and set `manualPagination: false` on the Parties tab in `AdmittedCasesConfig.js`, letting react-table handle pagination internally with the full parties list.

## Data Changes

N/A — no MDMS, workflow, or deployment config changes.

## Preview

UI change is limited to the Stage chip on the case details strip:
- Before (LPR case): \`Stage: <raw workflow stage>\`
- After (LPR case): \`Stage: <CS_LPR localized value>\`
- Non-LPR cases: unchanged.

> Note: \`CS_LPR\` must be added to the DIGIT localization service so it renders the user-friendly label instead of the raw key.

## Other

- No breaking changes.
- No dependency changes.
- Parties tab now relies on react-table's built-in pagination — verify large parties lists paginate correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Parties list now displays the complete set of results without pagination constraints, improving data accessibility and visibility for users reviewing case participants.
  * Updated case stage label display to properly reflect different case types in the case details view.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pucardotorg/dristi-solutions/pull/6661?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->