### PR TITLE
fix: add doc viewer card styling to ImageModal component

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/css/src/dristi/eFiling.scss
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/css/src/dristi/eFiling.scss
@@ -2399,3 +2399,10 @@
   margin-left: 12px;
   cursor: pointer;
 }
+
+
+.doc-viewer-card{
+  height: calc(100vh - 154px);
+  margin-bottom: 16px;
+  max-width: 100% !important;
+}

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/ImageModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/ImageModal.js
@@ -157,6 +157,7 @@ export const ImageModal = ({
         showDownloadOption={false}
         style={{ transform: `rotate(${rotation}deg)`, transition: "transform 0.2s ease" }}
         pdfZoom={zoom}
+        docViewerCardClassName="doc-viewer-card"
       />
     </Modal>
   );


### PR DESCRIPTION
## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated document viewer card styling to enhance layout spacing and responsive sizing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pucardotorg/dristi-solutions/pull/6669?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->