### PR TITLE
fix(CitizenHome): remove stale-closure refetchAdvocateClerk causing empty-criteria clerk search

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/Home/index.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/Home/index.js
@@ -69,10 +69,8 @@ function CitizenHome({ tenantId, setHideBack = () => {} }) {
   );
   useEffect(() => {
     refetch().then(() => {
-      refetchAdvocateClerk().then(() => {
-        setIsFetchingAdvocate(false);
-      });
       setIsFetching(false);
+      setIsFetchingAdvocate(false);
     });
   }, []);
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a proper title that briefly describes the work done
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`

## Summary

When an advocate logs in and the citizen home page mounts, an unintended API call was being fired to `/advocate/clerk/v1/_search` with empty criteria `[{}]`.

**Root cause — stale closure bug:**

```javascript
// Before fix
useEffect(() => {
  refetch().then(() => {
    refetchAdvocateClerk().then(() => {   // <-- bug
      setIsFetchingAdvocate(false);
    });
    setIsFetching(false);
  });
}, []);
```

- `refetch()` fetches individual data and resolves, but React **has not re-rendered yet**
- `refetchAdvocateClerk()` is called inside `.then()` while `individualId` and `userType` are still `undefined` in the stale closure
- React Query's `refetch()` **bypasses the `enabled` guard**, so the query fires unconditionally
- `individualId: undefined` serialises to `criteria: [{}]`; `userType` being `undefined` makes the URL default to `/advocate/clerk/v1/_search` instead of `/advocate/v1/_search`

**Fix:**

Remove the manual `refetchAdvocateClerk()` call. React Query's `enabled` condition on `useGetAdvocateClerk` (`isUserLoggedIn && individualId && userType && userType !== "LITIGANT"`) automatically triggers the search after the component re-renders with the correct `individualId` and `userType` values.

```javascript
// After fix
useEffect(() => {
  refetch().then(() => {
    setIsFetching(false);
    setIsFetchingAdvocate(false);
  });
}, []);
```

**File changed:** `frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/Home/index.js`

## Data Changes

None.

## Preview

No UI change — this fix eliminates a redundant/incorrect background API call. The page behaviour for advocates, clerks, and litigants remains the same.

## Other

- No breaking changes
- No new dependencies
- No MDMS / workflow / deployment changes required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined data loading behavior on the citizen home page by optimizing how loading states are managed during data synchronization, resulting in improved responsiveness and user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->