### PR TITLE
fix(BulkESignView): show backend hearing-already-scheduled error in toast

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/BulkESignView.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/BulkESignView.js
@@ -349,7 +349,9 @@ function BulkESignView() {
       });
     } catch (e) {
       const errorId = e?.response?.headers?.["x-correlation-id"] || e?.response?.headers?.["X-Correlation-Id"];
-      setShowToast({ label: t("FAILED_TO_PERFORM_BULK_SIGN"), error: true, errorId });
+      const backendError = e?.response?.data?.Errors?.[0];
+      const label = backendError?.code === "HEARING_ALREADY_SCHEDULED_ERROR" ? backendError?.message : t("FAILED_TO_PERFORM_BULK_SIGN");
+      setShowToast({ label, error: true, errorId });
       console.error("Failed to perform bulk sign", e?.message);
     } finally {
       setIsLoading(false);


### PR DESCRIPTION
https://github.com/pucardotorg/dristi/issues/5778

## Requirements

- [x] This PR has a proper title that briefly describes the work done
- [x] I have referenced the github issue(s)
- [x] I performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes — N/A

## Summary

Backend PR #6700 adds a pre-validation in `BSSService.createOrderToSignRequest` (the `order-management/_getOrdersToSign` endpoint) that blocks bulk-signing an order which would create a new hearing for a case that already has a hearing in `SCHEDULED` status. In that case the API returns:

```json
{
  "Errors": [{
    "code": "HEARING_ALREADY_SCHEDULED_ERROR",
    "message": "A hearing is already scheduled for the following case(s): KL-002637-2026. Cannot publish an order that schedules a new hearing for these case(s)."
  }]
}
```

Previously the bulk-sign flow swallowed this and showed the generic `FAILED_TO_PERFORM_BULK_SIGN` toast. This PR updates the catch block in `BulkESignView.handleBulkSign` so that when the error code is `HEARING_ALREADY_SCHEDULED_ERROR`, the toast shows the descriptive message returned by the backend (which lists the conflicting case number(s)); all other failures continue to show the generic message.

Only the orders bulk-sign flow (`BulkESignView`) calls `getOrdersToSign`, so this is the only caller affected. The summons/notice/warrant bulk-sign in `ReviewSummonsNoticeAndWarrant` uses `getProcessToSign` and does not hit this validation.

## Data Changes

None.

## Preview

Toast now reads e.g. *"A hearing is already scheduled for the following case(s): KL-002637-2026. Cannot publish an order that schedules a new hearing for these case(s)."* instead of "Failed to perform bulk sign." (Screenshot to be attached after deploy/verify.)

## Other

- Error path `error?.response?.data?.Errors?.[0]?.code` matches the existing convention used by other home-module sign modals (`BailBondSignModal`, `DigitalDocumentSignModal`, etc.).
- The backend message is rendered verbatim (not via `t(...)`) because it is a dynamic server-composed string containing the conflicting case number(s), not a localization key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for bulk signing operations to display specific backend error details instead of generic failure messages, providing clearer feedback when operations encounter issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->