### PR TITLE
Fix: MARK_COMPLETE fast path drops rescheduled hearing date

### DIFF
--- a/backend/dristi-services/hearing/src/main/java/org/pucar/dristi/service/HearingService.java
+++ b/backend/dristi-services/hearing/src/main/java/org/pucar/dristi/service/HearingService.java
@@ -314,6 +314,16 @@ public class HearingService {
                 newHearingType = hearingRequest.getHearing().getHearingType();
                 hearing.setHearingType(newHearingType);
             }
+            // Preserve a rescheduled date supplied on the request (e.g. MARK_COMPLETE moving a future
+            // hearing to today). The normal updateHearing path copies these from the request; the fast
+            // path must do the same, else the existing (stale) startTime/endTime are persisted unchanged.
+            // Guard against null so minimal status-only requests (START/CLOSE/PASS_OVER auto-advance) don't wipe them.
+            if (hearingRequest.getHearing().getStartTime() != null) {
+                hearing.setStartTime(hearingRequest.getHearing().getStartTime());
+            }
+            if (hearingRequest.getHearing().getEndTime() != null) {
+                hearing.setEndTime(hearingRequest.getHearing().getEndTime());
+            }
             hearingRequest.setHearing(hearing);
 
             enrichmentUtil.enrichHearingApplicationUponUpdate(hearingRequest);


### PR DESCRIPTION
## Problem

Rescheduling a future hearing to **today** (action `MARK_COMPLETE`) correctly flips the status to `COMPLETED` but leaves the hearing's `startTime`/`endTime` at the **old future date**. Confirmed in QA on hearing `KL-001182-2026-HR3`: rescheduled June‑12 → June‑8, status went `COMPLETED` but `startTime` stayed `2026-06-12 11:00`. Works correctly on `main`.

## Root cause

This branch adds a Redis fast path to `HearingService.updateHearing`:

```java
if (action != null && isFastPathAction(action) && Boolean.TRUE.equals(config.getRedisEnabled()))
    return updateHearingFastPath(hearingRequest, action);   // isFastPathAction includes MARK_COMPLETE
```

`updateHearingFastPath` → `performPersistStatusChange` re-fetches the **existing** hearing and pushes it after setting only `workflow`, `status` and `hearingType`. It never copies the request's `startTime`/`endTime`, so the stale date is persisted unchanged.

The normal `updateHearing` path copies them from the request (`HearingService.java:159-160`) — which is why `main` (no fast path) works.

### Runtime proof (QA logs, hearing `KL-001182-2026-HR3`)
- order-management computed today = `1780857000000` (June‑8 00:00) and POSTed `/hearing/v1/update` action `MARK_COMPLETE`.
- hearing svc ran the fast path (`persistStatusChange IN_PROGRESS → COMPLETED`, `SPRING_REDIS_ENABLED=true`) and persisted `startTime=1781242200000` (June‑12 11:00, the old slot). June‑8 never reached the DB.

## Fix

Copy `startTime`/`endTime` from the request in `performPersistStatusChange`, null-guarded so minimal status-only auto-advance requests (`START`/`CLOSE`/`PASS_OVER` via `buildMinimalHearingRequest`) don't wipe them. This makes the fast path mirror the normal path.

## Notes
- Branched from the **deployed** commit `cf8a5ae6`, not the current branch tip (`c9c4c51f1`), because the tip does not compile on its own — it references `cacheService.tryLock(...)`/`releaseLock(...)` which don't exist in `CacheService` (pre-existing broken WIP, unrelated to this fix). That needs to be resolved separately before the tip can ship.
- `mvn compile` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)