### PR TITLE
fix(EFilingCases): show friendly error for duplicate individual creation (idempotency)

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingCases.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingCases.js
@@ -2694,6 +2694,10 @@ function EFilingCases({ path }) {
         let message = t("E_FILING_SUBMISSION_FAILED");
         if (error instanceof DocumentUploadError) {
           message = `${t(error?.code || "DOCUMENT_FORMAT_DOES_NOT_MATCH")} : ${t(documentLabels[error?.documentType])}`;
+        } else if (error?.response?.data?.Errors?.some?.((err) => err?.code === "INDIVIDUAL_ALREADY_EXISTS_FOR_USER")) {
+          // Idempotency guard: backend rejects creating a second individual for the same user
+          // (e.g. same mobile number verified and continued from two tabs simultaneously).
+          message = t("USER_ALREADY_EXISTS_WITH_THIS_MOBILE_NUMBER");
         } else if (extractCodeFromErrorMsg(error) === 413) {
           message = t("FAILED_TO_UPLOAD_FILE");
         }


### PR DESCRIPTION
## Requirements
Addresses https://github.com/pucardotorg/dristi/issues/5806

## Summary
Handles the UI side of the user-creation idempotency fix. The backend (PR #6717) now rejects creating a second individual for the same user via the `SystemUserValidator`, returning error code `INDIVIDUAL_ALREADY_EXISTS_FOR_USER`.

This can happen in the eFiling complainant flow when the same mobile number is verified and "Continue" is clicked from two tabs simultaneously — both tabs pass verification (individual not yet created), then both attempt to create the individual.

Previously this surfaced as the generic `E_FILING_SUBMISSION_FAILED` toast. Now we detect the specific error code and show a user-friendly localized message.

## Changes
- `EFilingCases.js`: in the Continue-flow `catch`, detect `INDIVIDUAL_ALREADY_EXISTS_FOR_USER` in the API error and show `t("USER_ALREADY_EXISTS_WITH_THIS_MOBILE_NUMBER")`.

## Note
- The localization key `USER_ALREADY_EXISTS_WITH_THIS_MOBILE_NUMBER` needs to be added to the DRISTI localization service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error messaging for case filing submissions to provide clearer feedback when duplicate submissions are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->