### PR TITLE
fix(EFilingCases): show friendly error for duplicate individual creation (idempotency)

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingCases.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EFilingCases.js
@@ -2710,6 +2710,10 @@ function EFilingCases({ path }) {
         let message = t("SOMETHING_WENT_WRONG");
         if (error instanceof DocumentUploadError) {
           message = `${t(error?.code || "DOCUMENT_FORMAT_DOES_NOT_MATCH")} : ${t(documentLabels[error?.documentType])}`;
+        } else if (error?.response?.data?.Errors?.some?.((err) => err?.code === "INDIVIDUAL_ALREADY_EXISTS_FOR_USER")) {
+          // Idempotency guard: backend rejects creating a second individual for the same user
+          // (e.g. same mobile number verified and continued from two tabs simultaneously).
+          message = t("USER_ALREADY_EXISTS_WITH_THIS_MOBILE_NUMBER");
         } else if (extractCodeFromErrorMsg(error) === 413) {
           message = t("FAILED_TO_UPLOAD_FILE");
         }


### PR DESCRIPTION
## Requirements
Cherry-pick for https://github.com/pucardotorg/dristi/issues/5806

## Summary
Handles the UI side of the user-creation idempotency fix. The backend (PR #6717) rejects creating a second individual for the same user via the `SystemUserValidator`, returning error code `INDIVIDUAL_ALREADY_EXISTS_FOR_USER`.

This can happen in the eFiling complainant flow when the same mobile number is verified and "Continue" is clicked from two tabs simultaneously — both tabs pass verification (individual not yet created), then both attempt to create the individual.

Previously this surfaced as the generic `E_FILING_SUBMISSION_FAILED` toast. Now we detect the specific error code and show a user-friendly localized message.

## Changes
- `EFilingCases.js`: in the Continue-flow `catch`, detect `INDIVIDUAL_ALREADY_EXISTS_FOR_USER` in the API error and show `t("USER_ALREADY_EXISTS_WITH_THIS_MOBILE_NUMBER")`.

## Note
- The localization key `USER_ALREADY_EXISTS_WITH_THIS_MOBILE_NUMBER` needs to be added to the DRISTI localization service.

Cherry-pick of the change in develop PR #6718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)