### PR TITLE
added null check for names

### DIFF
--- a/backend/dristi-services/case/src/main/java/org/pucar/dristi/enrichment/AdvocateDetailBlockBuilder.java
+++ b/backend/dristi-services/case/src/main/java/org/pucar/dristi/enrichment/AdvocateDetailBlockBuilder.java
@@ -70,12 +70,12 @@ public class AdvocateDetailBlockBuilder {
                         try {
                             if (litigant.getAdditionalDetails() != null) {
                                 JsonNode litNode = objectMapper.convertValue(litigant.getAdditionalDetails(), JsonNode.class);
-                                if (litNode.has("firstName")) complainant.setFirstName(litNode.get("firstName").asText());
-                                if (litNode.has("middleName")) complainant.setMiddleName(litNode.get("middleName").asText());
-                                if (litNode.has("lastName")) complainant.setLastName(litNode.get("lastName").asText());
-                                if (litNode.has("mobileNumber")) complainant.setMobileNumber(litNode.get("mobileNumber").asText());
+                                if (litNode.hasNonNull("firstName")) complainant.setFirstName(litNode.get("firstName").asText());
+                                if (litNode.hasNonNull("middleName")) complainant.setMiddleName(litNode.get("middleName").asText());
+                                if (litNode.hasNonNull("lastName")) complainant.setLastName(litNode.get("lastName").asText());
+                                if (litNode.hasNonNull("mobileNumber")) complainant.setMobileNumber(litNode.get("mobileNumber").asText());
                                 // if additionalDetails contains a display/full name, prefer that
-                                if (litNode.has("fullName")) complainant.setFullName(litNode.get("fullName").asText());
+                                if (litNode.hasNonNull("fullName")) complainant.setFullName(litNode.get("fullName").asText());
                             }
                         } catch (Exception e) {
                             log.trace("Could not parse additionalDetails for litigant: {}", e.getMessage());
@@ -149,11 +149,11 @@ public class AdvocateDetailBlockBuilder {
                                         if (repNode.has("advocateUuid") && !repNode.get("advocateUuid").isNull() && adv.getAdvocateUuid() == null) {
                                             try { adv.setAdvocateUuid(UUID.fromString(repNode.get("advocateUuid").asText())); } catch (Exception ignored) {}
                                         }
-                                        if (repNode.has("firstName") && (adv.getFirstName() == null || adv.getFirstName().isBlank())) adv.setFirstName(repNode.get("firstName").asText());
-                                        if (repNode.has("middleName") && (adv.getMiddleName() == null || adv.getMiddleName().isBlank())) adv.setMiddleName(repNode.get("middleName").asText());
-                                        if (repNode.has("lastName") && (adv.getLastName() == null || adv.getLastName().isBlank())) adv.setLastName(repNode.get("lastName").asText());
-                                        if (repNode.has("mobileNumber") && (adv.getMobileNumber() == null || adv.getMobileNumber().isBlank())) adv.setMobileNumber(repNode.get("mobileNumber").asText());
-                                        if (repNode.has("advocateName") && (adv.getFirstName() == null || adv.getFirstName().isBlank())) adv.setFirstName(repNode.get("advocateName").asText());
+                                        if (repNode.hasNonNull("firstName") && (adv.getFirstName() == null || adv.getFirstName().isBlank())) adv.setFirstName(repNode.get("firstName").asText());
+                                        if (repNode.hasNonNull("middleName") && (adv.getMiddleName() == null || adv.getMiddleName().isBlank())) adv.setMiddleName(repNode.get("middleName").asText());
+                                        if (repNode.hasNonNull("lastName") && (adv.getLastName() == null || adv.getLastName().isBlank())) adv.setLastName(repNode.get("lastName").asText());
+                                        if (repNode.hasNonNull("mobileNumber") && (adv.getMobileNumber() == null || adv.getMobileNumber().isBlank())) adv.setMobileNumber(repNode.get("mobileNumber").asText());
+                                        if (repNode.hasNonNull("advocateName") && (adv.getFirstName() == null || adv.getFirstName().isBlank())) adv.setFirstName(repNode.get("advocateName").asText());
                                     }
                                 } catch (Exception ignored) { }
 
@@ -173,10 +173,10 @@ public class AdvocateDetailBlockBuilder {
                                                                 JsonNode nameDetails = n.path("advocateNameDetails");
                                                                 JsonNode bar = n.path("advocateBarRegNumberWithName");
                                                                 if (bar.has("advocateId") && adv.getIndividualId() != null && adv.getIndividualId().equalsIgnoreCase(bar.path("individualId").asText())) {
-                                                                    if (nameDetails.has("firstName")) adv.setFirstName(nameDetails.get("firstName").asText());
-                                                                    if (nameDetails.has("middleName")) adv.setMiddleName(nameDetails.get("middleName").asText());
-                                                                    if (nameDetails.has("lastName")) adv.setLastName(nameDetails.get("lastName").asText());
-                                                                    if (nameDetails.has("advocateMobileNumber")) adv.setMobileNumber(nameDetails.get("advocateMobileNumber").asText());
+                                                                    if (nameDetails.hasNonNull("firstName")) adv.setFirstName(nameDetails.get("firstName").asText());
+                                                                    if (nameDetails.hasNonNull("middleName")) adv.setMiddleName(nameDetails.get("middleName").asText());
+                                                                    if (nameDetails.hasNonNull("lastName")) adv.setLastName(nameDetails.get("lastName").asText());
+                                                                    if (nameDetails.hasNonNull("advocateMobileNumber")) adv.setMobileNumber(nameDetails.get("advocateMobileNumber").asText());
                                                                 }
                                                             }
                                                         }

--- a/backend/dristi-services/case/src/main/java/org/pucar/dristi/repository/rowmapper/RepresentativeRowMapper.java
+++ b/backend/dristi-services/case/src/main/java/org/pucar/dristi/repository/rowmapper/RepresentativeRowMapper.java
@@ -83,7 +83,7 @@ public class RepresentativeRowMapper implements ResultSetExtractor<Map<UUID, Lis
                     try {
                         if (advocate.getAdditionalDetails() != null) {
                             com.fasterxml.jackson.databind.JsonNode advNode = (com.fasterxml.jackson.databind.JsonNode) advocate.getAdditionalDetails();
-                            if (advNode.has("advocateUuid") && !advNode.get("advocateUuid").isNull()) {
+                            if (advNode.hasNonNull("advocateUuid")) {
                                 try { advocate.setAdvocateUuid(UUID.fromString(advNode.get("advocateUuid").asText())); } catch (Exception ignored) {}
                             }
                             if (advNode.hasNonNull("firstName")) advocate.setFirstName(advNode.get("firstName").asText());

--- a/backend/dristi-services/case/src/main/java/org/pucar/dristi/repository/rowmapper/RepresentativeRowMapper.java
+++ b/backend/dristi-services/case/src/main/java/org/pucar/dristi/repository/rowmapper/RepresentativeRowMapper.java
@@ -86,10 +86,10 @@ public class RepresentativeRowMapper implements ResultSetExtractor<Map<UUID, Lis
                             if (advNode.has("advocateUuid") && !advNode.get("advocateUuid").isNull()) {
                                 try { advocate.setAdvocateUuid(UUID.fromString(advNode.get("advocateUuid").asText())); } catch (Exception ignored) {}
                             }
-                            if (advNode.has("firstName")) advocate.setFirstName(advNode.get("firstName").asText());
-                            if (advNode.has("middleName")) advocate.setMiddleName(advNode.get("middleName").asText());
-                            if (advNode.has("lastName")) advocate.setLastName(advNode.get("lastName").asText());
-                            if (advNode.has("mobileNumber")) advocate.setMobileNumber(advNode.get("mobileNumber").asText());
+                            if (advNode.hasNonNull("firstName")) advocate.setFirstName(advNode.get("firstName").asText());
+                            if (advNode.hasNonNull("middleName")) advocate.setMiddleName(advNode.get("middleName").asText());
+                            if (advNode.hasNonNull("lastName")) advocate.setLastName(advNode.get("lastName").asText());
+                            if (advNode.hasNonNull("mobileNumber")) advocate.setMobileNumber(advNode.get("mobileNumber").asText());
                         }
                     } catch (Exception ignored) {}
 
@@ -100,10 +100,10 @@ public class RepresentativeRowMapper implements ResultSetExtractor<Map<UUID, Lis
                             if (advocate.getAdvocateUuid() == null && repNode.has("uuid") && !repNode.get("uuid").isNull()) {
                                 try { advocate.setAdvocateUuid(UUID.fromString(repNode.get("uuid").asText())); } catch (Exception ignored) {}
                             }
-                            if ((advocate.getFirstName() == null || advocate.getFirstName().isBlank()) && repNode.has("firstName")) advocate.setFirstName(repNode.get("firstName").asText());
-                            if ((advocate.getMiddleName() == null || advocate.getMiddleName().isBlank()) && repNode.has("middleName")) advocate.setMiddleName(repNode.get("middleName").asText());
-                            if ((advocate.getLastName() == null || advocate.getLastName().isBlank()) && repNode.has("lastName")) advocate.setLastName(repNode.get("lastName").asText());
-                            if ((advocate.getMobileNumber() == null || advocate.getMobileNumber().isBlank()) && repNode.has("mobileNumber")) advocate.setMobileNumber(repNode.get("mobileNumber").asText());
+                            if ((advocate.getFirstName() == null || advocate.getFirstName().isBlank()) && repNode.hasNonNull("firstName")) advocate.setFirstName(repNode.get("firstName").asText());
+                            if ((advocate.getMiddleName() == null || advocate.getMiddleName().isBlank()) && repNode.hasNonNull("middleName")) advocate.setMiddleName(repNode.get("middleName").asText());
+                            if ((advocate.getLastName() == null || advocate.getLastName().isBlank()) && repNode.hasNonNull("lastName")) advocate.setLastName(repNode.get("lastName").asText());
+                            if ((advocate.getMobileNumber() == null || advocate.getMobileNumber().isBlank()) && repNode.hasNonNull("mobileNumber")) advocate.setMobileNumber(repNode.get("mobileNumber").asText());
                         }
                     } catch (Exception ignored) {}
 


### PR DESCRIPTION
## Requirements

https://github.com/pucardotorg/dristi/issues/5752

- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of advocate and complainant profile details so fields are only populated when valid, non-null values are available.
  * Prevents overwriting existing data with nulls from incoming case/representative details, ensuring advocate and complainant names and mobile numbers remain accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->