### PR TITLE
fix(payment): auto-close eTreasury popup on success & restyle processing page (#5783) [cherry-pick to develop]

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/hooks/usePaymentProcess.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/hooks/usePaymentProcess.js
@@ -205,28 +205,51 @@ const usePaymentProcess = ({ tenantId, consumerCode, service, path, caseDetails,
           setPaymentLoader(true);
           popup.document.body.removeChild(form);
         }
-        let retryCount = 0;
-        const maxRetries = 3;
-        const checkPopupClosed = setInterval(async () => {
-          if (popup.closed) {
-            setPaymentLoader(false);
-            if (retryCount < maxRetries) {
-              retryCount++;
-              const billAfterPayment = await DRISTIService.callSearchBill(
-                {},
-                { tenantId, consumerCode: consumerCode || billConsumerCode, service: service || billBusinessService }
-              );
-              if (billAfterPayment?.Bill?.[0]?.status === "PAID") {
-                clearInterval(checkPopupClosed);
-                resolve(true);
-              } else if (retryCount === maxRetries) {
-                clearInterval(checkPopupClosed);
-                resolve(false);
-              }
-            } else {
-              clearInterval(checkPopupClosed);
-              resolve(false);
+        // Poll the bill status every second instead of waiting for the success popup's
+        // auto-close. The moment the bill is PAID we close the popup and resolve(true),
+        // so the user no longer waits out the success page timer.
+        let isResolved = false;
+        let pollCount = 0;
+        let graceCount = 0;
+        const maxPolls = 300; // safety cap (~5 min) so the interval can never run forever
+        const graceAfterClose = 5; // keep polling ~5s after the user closes the popup, to let the async reconciliation catch up
+
+        const finish = (intervalId, result) => {
+          if (isResolved) return;
+          isResolved = true;
+          clearInterval(intervalId);
+          setPaymentLoader(false);
+          popup?.close();
+          resolve(result);
+        };
+
+        const checkBillStatus = setInterval(async () => {
+          pollCount++;
+          try {
+            const billAfterPayment = await DRISTIService.callSearchBill(
+              {},
+              { tenantId, consumerCode: consumerCode || billConsumerCode, service: service || billBusinessService }
+            );
+            if (billAfterPayment?.Bill?.[0]?.status === "PAID") {
+              finish(checkBillStatus, true);
+              return;
             }
+          } catch (error) {
+            console.error("Error checking bill status:", error);
+          }
+
+          // Once the user closes the popup, give the async reconciliation a short grace
+          // window to mark the bill PAID before treating the attempt as failed.
+          if (popup?.closed) {
+            graceCount++;
+            if (graceCount >= graceAfterClose) {
+              finish(checkBillStatus, false);
+              return;
+            }
+          }
+
+          if (pollCount >= maxPolls) {
+            finish(checkBillStatus, false);
           }
         }, 1000);
         if (!["applicationSubmission", "EfillingCase"?.includes(scenario)]) {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/hooks/usePaymentProcess.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/hooks/usePaymentProcess.js
@@ -211,7 +211,7 @@ const usePaymentProcess = ({ tenantId, consumerCode, service, path, caseDetails,
         let isResolved = false;
         let pollCount = 0;
         let graceCount = 0;
-        const maxPolls = 300; // safety cap (~5 min) so the interval can never run forever
+        const maxPolls = 600; // safety cap (~10 min) so the interval can never run forever
         const graceAfterClose = 5; // keep polling ~5s after the user closes the popup, to let the async reconciliation catch up
 
         const finish = (intervalId, result) => {

--- a/frontend/treasury-webpage/public/payment-success.html
+++ b/frontend/treasury-webpage/public/payment-success.html
@@ -32,6 +32,7 @@
       Payment Completed!
     </h1>
     <p>Your transaction has been processed successfully.</p>
+    <p>Please do not close the popup. It will get closed automatically.</p>
     <script src="main.js"></script>
     <script>
       // Set timeout to close the window after 15 seconds

--- a/frontend/treasury-webpage/public/payment-success.html
+++ b/frontend/treasury-webpage/public/payment-success.html
@@ -9,30 +9,87 @@
         font-family: sans-serif;
         margin: 2rem;
         text-align: center;
+        color: #0b0c0c;
       }
       h1 {
-        font-size: 2rem;
-        color: green;
+        font-size: 2.5rem;
+        color: #2e8b2e;
+        margin-bottom: 0.5rem;
       }
       p {
         font-size: 1.2rem;
       }
+      .subtext {
+        margin-top: 0;
+      }
+      .info-card {
+        display: flex;
+        align-items: flex-start;
+        gap: 16px;
+        text-align: left;
+        max-width: 540px;
+        margin: 1.5rem auto;
+        padding: 20px 24px;
+        background-color: #eef4fc;
+        border: 1px solid #d3e3f8;
+        border-radius: 8px;
+      }
+      .info-card .info-icon {
+        flex-shrink: 0;
+        margin-top: 4px;
+      }
+      .info-card .info-title {
+        margin: 0 0 6px 0;
+        font-size: 1.4rem;
+        font-weight: 700;
+        color: #1a5dd6;
+      }
+      .info-card .info-line {
+        margin: 0;
+        font-size: 1.15rem;
+        color: #0b0c0c;
+      }
+      .info-card .info-warning {
+        margin: 4px 0 0 0;
+        font-size: 1.15rem;
+        font-weight: 700;
+        color: #0b0c0c;
+      }
+      .spinner {
+        margin: 2rem auto 0 auto;
+        width: 56px;
+        height: 56px;
+        border: 6px solid #e2e8f5;
+        border-top-color: #1a5dd6;
+        border-radius: 50%;
+        animation: spin 1s linear infinite;
+      }
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
     </style>
   </head>
   <body>
-    <h1>
-      <img
-        src="https://pucarfilestore.blob.core.windows.net/pucar-filestore/kl/check-mark-icon.png"
-        alt="Success icon"
-        width="100"
-        height="100"
-        style="vertical-align: middle; margin-right: 10px"
-        ;
-      />
-      Payment Completed!
-    </h1>
-    <p>Your transaction has been processed successfully.</p>
-    <p>Please do not close the popup. It will get closed automatically.</p>
+    <h1>Payment Successful!</h1>
+    <p class="subtext">Your transaction has been processed successfully.</p>
+
+    <div class="info-card" role="status">
+      <svg class="info-icon" width="40" height="40" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <circle cx="12" cy="12" r="12" fill="#2563eb" />
+        <rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff" />
+        <circle cx="12" cy="7" r="1.3" fill="#ffffff" />
+      </svg>
+      <div>
+        <p class="info-title">Please wait while we redirect you.</p>
+        <p class="info-line">This window will close automatically.</p>
+        <p class="info-warning">Do not close or refresh this window.</p>
+      </div>
+    </div>
+
+    <div class="spinner" aria-hidden="true"></div>
+
     <script src="main.js"></script>
     <script>
       // Set timeout to close the window after 15 seconds

--- a/frontend/treasury-webpage/public/payment-success.html
+++ b/frontend/treasury-webpage/public/payment-success.html
@@ -5,62 +5,46 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Payment Confirmation</title>
     <style>
+      * {
+        box-sizing: border-box;
+      }
       body {
         font-family: sans-serif;
-        margin: 2rem;
-        text-align: center;
-        color: #0b0c0c;
-      }
-      h1 {
-        font-size: 2.5rem;
-        color: #2e8b2e;
-        margin-bottom: 0.5rem;
-      }
-      p {
-        font-size: 1.2rem;
-      }
-      .subtext {
-        margin-top: 0;
-      }
-      .info-card {
-        display: flex;
-        align-items: flex-start;
-        gap: 16px;
-        text-align: left;
-        max-width: 540px;
-        margin: 1.5rem auto;
-        padding: 20px 24px;
-        background-color: #eef4fc;
-        border: 1px solid #d3e3f8;
-        border-radius: 8px;
-      }
-      .info-card .info-icon {
-        flex-shrink: 0;
-        margin-top: 4px;
-      }
-      .info-card .info-title {
-        margin: 0 0 6px 0;
-        font-size: 1.4rem;
-        font-weight: 700;
-        color: #1a5dd6;
-      }
-      .info-card .info-line {
         margin: 0;
-        font-size: 1.15rem;
-        color: #0b0c0c;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background-color: #f3f4f6;
+        color: #1f2937;
       }
-      .info-card .info-warning {
-        margin: 4px 0 0 0;
-        font-size: 1.15rem;
-        font-weight: 700;
-        color: #0b0c0c;
+      .card {
+        position: relative;
+        width: 100%;
+        max-width: 440px;
+        margin: 1.5rem;
+        padding: 48px 40px 40px 40px;
+        background-color: #ffffff;
+        border-radius: 16px;
+        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
+        text-align: center;
+        overflow: hidden;
+      }
+      .card::before {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 6px;
+        background-color: #3b82f6;
       }
       .spinner {
-        margin: 2rem auto 0 auto;
-        width: 56px;
-        height: 56px;
-        border: 6px solid #e2e8f5;
-        border-top-color: #1a5dd6;
+        margin: 0 auto 28px auto;
+        width: 64px;
+        height: 64px;
+        border: 6px solid #e5e9f2;
+        border-top-color: #3b82f6;
         border-radius: 50%;
         animation: spin 1s linear infinite;
       }
@@ -69,26 +53,36 @@
           transform: rotate(360deg);
         }
       }
+      .card h1 {
+        margin: 0 0 12px 0;
+        font-size: 1.6rem;
+        font-weight: 700;
+        color: #1f2937;
+      }
+      .card .subtext {
+        margin: 0 auto 28px auto;
+        max-width: 320px;
+        font-size: 1.05rem;
+        line-height: 1.5;
+        color: #6b7280;
+      }
+      .pill {
+        display: inline-block;
+        padding: 9px 20px;
+        background-color: #eceef1;
+        border-radius: 9999px;
+        font-size: 0.95rem;
+        color: #4b5563;
+      }
     </style>
   </head>
   <body>
-    <h1>Payment Successful!</h1>
-    <p class="subtext">Your transaction has been processed successfully.</p>
-
-    <div class="info-card" role="status">
-      <svg class="info-icon" width="40" height="40" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-        <circle cx="12" cy="12" r="12" fill="#2563eb" />
-        <rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff" />
-        <circle cx="12" cy="7" r="1.3" fill="#ffffff" />
-      </svg>
-      <div>
-        <p class="info-title">Please wait while we redirect you.</p>
-        <p class="info-line">This window will close automatically.</p>
-        <p class="info-warning">Do not close or refresh this window.</p>
-      </div>
+    <div class="card" role="status">
+      <div class="spinner" aria-hidden="true"></div>
+      <h1>Processing Your Payment</h1>
+      <p class="subtext">Please wait a moment while we securely update your transaction.</p>
+      <span class="pill">Do not close or refresh this window</span>
     </div>
-
-    <div class="spinner" aria-hidden="true"></div>
 
     <script src="main.js"></script>
     <script>


### PR DESCRIPTION
## Requirements

- [x] This PR has a proper title that briefly describes the work done
- [x] I have referenced the github issue(s)
- [x] I performed a self-review of my own code
- [x] I have added proper logs and comments for the developed code
- [ ] This PR does not include MDMS, workflow, or deployment configuration changes

## Summary

Cherry-pick to `develop` of the eTreasury payment popup fix (also raised to `main` in #6728).

Previously the eFiling / notice-summons payment flow only checked the bill status **after** the eTreasury success popup auto-closed (a hard 15s timer), then polled just 3×1s. If the user closed the window early, the asynchronous bill→`PAID` reconciliation hadn't completed and the payment was wrongly treated as failed; on success the user still had to wait out the full 15s.

Changes (`usePaymentProcess.js`, real/non-mock branch):
1. **Auto-close on success** — poll the bill status every second and, the moment it is `PAID`, close the popup and resolve success (no more 15s dead wait).
2. **Continuous polling cap** of ~10 min (`maxPolls = 600`) covering the full time the user spends selecting a payment mode and completing the payment.
3. **5s grace window** after the user closes the popup, to let the async reconciliation catch up before marking the attempt failed.
4. Single-resolve guard + guaranteed `clearInterval` so the promise resolves once and no interval leaks.

eTreasury success page (`payment-success.html`) restyled per client design: centered card with a blue accent, spinner, "Processing Your Payment" heading, a securely-updating subtext, and a "Do not close or refresh this window" notice.

Fixes https://github.com/pucardotorg/dristi/issues/5783

## Data Changes

None. No MDMS, workflow, or deployment-config data changes.

## Preview

UI change to the eTreasury success/processing popup (`frontend/treasury-webpage/public/payment-success.html`): blue-accented card with spinner, "Processing Your Payment" heading, and a "Do not close or refresh this window" pill. Popup now closes automatically as soon as the bill is marked `PAID`.

## Other

- **Deployment:** requires deploying both **digit-ui** (the `usePaymentProcess.js` hook) and **epayments** / treasury-webpage (the `payment-success.html` page) — these run as separate pods.
- No backend, dependency, or config changes.
- Cherry-pick of commits from `5783-payment-popup-auto-close` (PR #6728 to `main`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Payment processing experience improved with a dedicated processing status screen that displays a visual loading indicator while the system verifies your payment status
  * Enhanced verification system with extended reconciliation window to provide accurate payment confirmation
  * Added clear user guidance instructing users to maintain their open browser window throughout the entire verification process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->