### PR TITLE
fix(home): trigger refetch on pagination for A-Diary and Register Users

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/configs/UICustomizations.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/configs/UICustomizations.js
@@ -997,14 +997,25 @@ export const UICustomizations = {
       const courtId = localStorage.getItem("courtId");
       if (date) sessionStorage.setItem("diaryDateFilter", date);
 
+      const limit = requestCriteria?.state?.tableForm?.limit || 10;
+      const offSet = requestCriteria?.state?.tableForm?.offset || 0;
+
       return {
         ...requestCriteria,
+        // useCustomAPIHook keys the query on [url, changeQueryName] (body is NOT in the key),
+        // so pagination/date changes must be reflected here to re-trigger the API call.
+        changeQueryName: `adiary_${date}_${limit}_${offSet}`,
         body: {
           ...requestCriteria?.body,
           criteria: {
             ...requestCriteria?.body?.criteria,
             date,
             courtId,
+          },
+          pagination: {
+            ...requestCriteria?.body?.pagination,
+            limit,
+            offSet,
           },
         },
         config: {
@@ -1086,6 +1097,8 @@ export const UICustomizations = {
               moduleName: moduleName,
               tenantId: window?.Digit.ULBService.getStateId(),
             },
+            limit: requestCriteria?.state?.tableForm?.limit,
+            offset: requestCriteria?.state?.tableForm?.offset,
             tenantId: window?.Digit.ULBService.getStateId(),
           },
         },


### PR DESCRIPTION
## Problem
On the **Sign A-Diary** and **Register Users** home tabs, changing the table pagination (next/prev page or page size) did **not** trigger a new API call, and the new `offSet` was never sent.

## Root cause
`InboxSearchComposer` fetches through `useCustomAPIHook`, whose React Query key is `[url, changeQueryName]` — **the request body is not part of the key**. With `changeQueryName` left at its default constant, a page change rebuilt the request body (with the new `offSet`) but React Query saw an unchanged key and returned cached data, so no request was made.

## Fix
- **`bulkADiarySignConfig` (Sign A-Diary):** add a `changeQueryName` keyed on `date`/`limit`/`offSet` so the query key changes on pagination/date change, and send `pagination.offSet` (capital S, matching the ab-diary backend `Pagination` model).
- **`registerUserHomeConfig` (Register Users):** send `limit`/`offset` in the inbox request body.

## Testing
- Verified locally: changing page / page-size on Sign A-Diary now fires a fresh `POST /ab-diary/case/diary/entries/v1/search` with `pagination.offSet` advancing `0 → 10 → 20…`.

## Note
Cherry-pick of the change in https://github.com/pucardotorg/dristi-solutions/pull/6738 (raised to `main`) onto `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pagination behavior to ensure data properly re-fetches when pagination parameters or dates change.
  * Improved search criteria handling to correctly include pagination parameters in results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->