### PR TITLE
fix(egov-user): restore same-token-until-expiry and invalidate tokens…

### DIFF
--- a/backend/digit-services/egov-user/src/main/java/org/egov/user/domain/service/UserService.java
+++ b/backend/digit-services/egov-user/src/main/java/org/egov/user/domain/service/UserService.java
@@ -444,6 +444,7 @@ public class UserService {
         validatePassword(updatePasswordRequest.getNewPassword());
         user.updatePassword(encryptPwd(updatePasswordRequest.getNewPassword()));
         userRepository.update(user, user, user.getId() , user.getUuid());
+        removeTokensByUser(user);
     }
 
     /**
@@ -474,6 +475,7 @@ public class UserService {
         /* encrypted value is stored in DB*/
         user = encryptionDecryptionUtil.encryptObject(user, "User", User.class);
         userRepository.update(user, user,user.getId() , user.getUuid());
+        removeTokensByUser(user);
     }
 
 

--- a/backend/digit-services/egov-user/src/main/java/org/egov/user/security/oauth2/CustomTokenEndpoint.java
+++ b/backend/digit-services/egov-user/src/main/java/org/egov/user/security/oauth2/CustomTokenEndpoint.java
@@ -223,10 +223,43 @@ public class CustomTokenEndpoint {
         return domainRoles.stream().map(Role::new).collect(Collectors.toSet());
     }
 
-    private Map<String, Object> issueTokenResponse(Authentication authentication, String scope, 
+    private Map<String, Object> issueTokenResponse(Authentication authentication, String scope,
                                                      String existingRefreshToken) {
+        SecureUser secureUser = (SecureUser) authentication.getPrincipal();
+
+        // Reuse the active token for this user+tenantId if one still exists in Redis,
+        // restoring the pre-Java17-migration behaviour (same token until expiry).
+        String activeToken = (existingRefreshToken == null)
+                ? tokenStore.getActiveAccessToken(secureUser.getUsername(), secureUser.getTenantId())
+                : null;
+
+        if (activeToken != null) {
+            // existingRefreshToken is always null here (refresh_token flow skips this path);
+            // generate a new refresh token to pair with the reused access token.
+            String refreshTokenToReturn = UUID.randomUUID().toString();
+            long accessExpirySeconds = (long) accessTokenValidityMinutes * 60;
+
+            Map<String, Object> responseInfo = new LinkedHashMap<>();
+            responseInfo.put("api_id", "");
+            responseInfo.put("ver", "");
+            responseInfo.put("ts", "");
+            responseInfo.put("res_msg_id", "");
+            responseInfo.put("msg_id", "");
+            responseInfo.put("status", "Access Token generated successfully");
+
+            Map<String, Object> response = new LinkedHashMap<>();
+            response.put("access_token", activeToken);
+            response.put("token_type", "bearer");
+            response.put("refresh_token", refreshTokenToReturn);
+            response.put("expires_in", accessExpirySeconds);
+            response.put("scope", scope);
+            response.put("ResponseInfo", responseInfo);
+            response.put("UserRequest", secureUser.getUser());
+            return response;
+        }
+
         String accessToken = UUID.randomUUID().toString();
-        
+
         // Reuse existing refresh token if configured (matches old setReuseRefreshToken(true))
         String refreshTokenToReturn;
         if (reuseRefreshToken && existingRefreshToken != null) {
@@ -252,8 +285,6 @@ public class CustomTokenEndpoint {
         
         // Store mapping between access token and refresh token (for invalidation on next refresh)
         tokenStore.storeAccessTokenToRefreshTokenMapping(accessToken, refreshTokenToReturn);
-
-        SecureUser secureUser = (SecureUser) authentication.getPrincipal();
 
         Map<String, Object> responseInfo = new LinkedHashMap<>();
         responseInfo.put("api_id", "");

--- a/backend/digit-services/egov-user/src/main/java/org/egov/user/security/oauth2/CustomTokenEndpoint.java
+++ b/backend/digit-services/egov-user/src/main/java/org/egov/user/security/oauth2/CustomTokenEndpoint.java
@@ -238,6 +238,12 @@ public class CustomTokenEndpoint {
             // generate a new refresh token to pair with the reused access token.
             String refreshTokenToReturn = UUID.randomUUID().toString();
             long accessExpirySeconds = (long) accessTokenValidityMinutes * 60;
+            long refreshExpirySeconds = (long) refreshTokenValidityMinutes * 60;
+
+            // Persist the new refresh token and its mapping to the reused access token so a
+            // subsequent refresh_token grant can resolve it (mirrors the normal-issue path below).
+            tokenStore.storeRefreshToken(refreshTokenToReturn, authentication, refreshExpirySeconds);
+            tokenStore.storeAccessTokenToRefreshTokenMapping(activeToken, refreshTokenToReturn);
 
             Map<String, Object> responseInfo = new LinkedHashMap<>();
             responseInfo.put("api_id", "");

--- a/backend/digit-services/egov-user/src/main/java/org/egov/user/security/oauth2/EgovTokenStore.java
+++ b/backend/digit-services/egov-user/src/main/java/org/egov/user/security/oauth2/EgovTokenStore.java
@@ -34,4 +34,10 @@ public interface EgovTokenStore {
 
     /** Remove all access tokens issued to a given username (used on account lock). */
     void removeAllTokensByUsername(String username);
+
+    /**
+     * Return the active access token for a user+tenantId combination if one
+     * exists and has not yet expired in the store.  Returns null if none found.
+     */
+    String getActiveAccessToken(String username, String tenantId);
 }

--- a/backend/digit-services/egov-user/src/main/java/org/egov/user/security/oauth2/RedisEgovTokenStore.java
+++ b/backend/digit-services/egov-user/src/main/java/org/egov/user/security/oauth2/RedisEgovTokenStore.java
@@ -18,6 +18,7 @@ public class RedisEgovTokenStore implements EgovTokenStore {
     private static final String REFRESH_PREFIX = "refresh_token:";
     private static final String USER_TOKENS_PREFIX = "user_tokens:";
     private static final String REFRESH_TO_ACCESS_PREFIX = "refresh_to_access:";
+    private static final String USER_ACTIVE_TOKEN_PREFIX = "user_active_token:";
 
     private final StringRedisTemplate redisTemplate;
     private final ObjectMapper objectMapper;
@@ -32,11 +33,14 @@ public class RedisEgovTokenStore implements EgovTokenStore {
         try {
             String json = serializeAuthentication(authentication);
             redisTemplate.opsForValue().set(ACCESS_PREFIX + token, json, expirySeconds, TimeUnit.SECONDS);
-            // Maintain reverse index: username → set of tokens (for bulk invalidation on account lock)
             SecureUser secureUser = (SecureUser) authentication.getPrincipal();
+            // Maintain reverse index: username → set of tokens (for bulk invalidation on account lock)
             String userKey = USER_TOKENS_PREFIX + secureUser.getUsername();
             redisTemplate.opsForSet().add(userKey, token);
             redisTemplate.expire(userKey, expirySeconds, TimeUnit.SECONDS);
+            // Track the single active token per user+tenantId for reuse on re-login
+            String activeKey = USER_ACTIVE_TOKEN_PREFIX + secureUser.getUsername() + ":" + secureUser.getTenantId();
+            redisTemplate.opsForValue().set(activeKey, token, expirySeconds, TimeUnit.SECONDS);
         } catch (Exception e) {
             log.error("Failed to store access token in Redis", e);
             throw new RuntimeException("Failed to store access token", e);
@@ -112,6 +116,21 @@ public class RedisEgovTokenStore implements EgovTokenStore {
 
     @Override
     public boolean removeAccessToken(String accessToken) {
+        // Also remove the active-token pointer if it still points at this token
+        try {
+            String json = redisTemplate.opsForValue().get(ACCESS_PREFIX + accessToken);
+            if (json != null) {
+                org.egov.user.web.contract.auth.User user =
+                        objectMapper.readValue(json, org.egov.user.web.contract.auth.User.class);
+                String activeKey = USER_ACTIVE_TOKEN_PREFIX + user.getUserName() + ":" + user.getTenantId();
+                String current = redisTemplate.opsForValue().get(activeKey);
+                if (accessToken.equals(current)) {
+                    redisTemplate.delete(activeKey);
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Could not clean up active token pointer during removeAccessToken", e);
+        }
         Boolean deleted = redisTemplate.delete(ACCESS_PREFIX + accessToken);
         return Boolean.TRUE.equals(deleted);
     }
@@ -127,9 +146,32 @@ public class RedisEgovTokenStore implements EgovTokenStore {
                 }
             }
             redisTemplate.delete(userKey);
+            // Remove all active-token pointers for this user (pattern scan across tenants)
+            java.util.Set<String> activeKeys = redisTemplate.keys(USER_ACTIVE_TOKEN_PREFIX + username + ":*");
+            if (activeKeys != null && !activeKeys.isEmpty()) {
+                redisTemplate.delete(activeKeys);
+            }
         } catch (Exception e) {
             log.error("Failed to remove tokens for user: {}", username, e);
         }
+    }
+
+    @Override
+    public String getActiveAccessToken(String username, String tenantId) {
+        try {
+            String activeKey = USER_ACTIVE_TOKEN_PREFIX + username + ":" + tenantId;
+            String candidate = redisTemplate.opsForValue().get(activeKey);
+            if (candidate != null && Boolean.TRUE.equals(redisTemplate.hasKey(ACCESS_PREFIX + candidate))) {
+                return candidate;
+            }
+            // Stale pointer — clean it up
+            if (candidate != null) {
+                redisTemplate.delete(activeKey);
+            }
+        } catch (Exception e) {
+            log.warn("Could not look up active token for user: {}", username, e);
+        }
+        return null;
     }
 
     @Override

--- a/backend/digit-services/egov-user/src/main/java/org/egov/user/security/oauth2/RedisEgovTokenStore.java
+++ b/backend/digit-services/egov-user/src/main/java/org/egov/user/security/oauth2/RedisEgovTokenStore.java
@@ -3,6 +3,8 @@ package org.egov.user.security.oauth2;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.egov.user.domain.model.SecureUser;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -146,9 +148,15 @@ public class RedisEgovTokenStore implements EgovTokenStore {
                 }
             }
             redisTemplate.delete(userKey);
-            // Remove all active-token pointers for this user (pattern scan across tenants)
-            java.util.Set<String> activeKeys = redisTemplate.keys(USER_ACTIVE_TOKEN_PREFIX + username + ":*");
-            if (activeKeys != null && !activeKeys.isEmpty()) {
+            // Remove all active-token pointers for this user (non-blocking SCAN across tenants;
+            // KEYS would block the whole Redis instance in production)
+            String activeTokenPattern = USER_ACTIVE_TOKEN_PREFIX + username + ":*";
+            ScanOptions scanOptions = ScanOptions.scanOptions().match(activeTokenPattern).count(100).build();
+            java.util.Set<String> activeKeys = new java.util.HashSet<>();
+            try (Cursor<String> cursor = redisTemplate.scan(scanOptions)) {
+                cursor.forEachRemaining(activeKeys::add);
+            }
+            if (!activeKeys.isEmpty()) {
                 redisTemplate.delete(activeKeys);
             }
         } catch (Exception e) {

--- a/backend/digit-services/egov-user/src/test/java/org/egov/user/domain/service/UserServiceTest.java
+++ b/backend/digit-services/egov-user/src/test/java/org/egov/user/domain/service/UserServiceTest.java
@@ -72,6 +72,7 @@ public class UserServiceTest {
 
     @Mock
     private EncryptionDecryptionUtil encryptionDecryptionUtil;
+    @Mock
     private EgovTokenStore tokenStore;
 
     private UserService userService;


### PR DESCRIPTION
Why: The Java 17 migration (Feature 5296, Apr 2026) replaced the deprecated Spring Security OAuth2 stack with a custom CustomTokenEndpoint + RedisEgovTokenStore. The old DefaultTokenServices + CustomAuthenticationKeyGenerator computed a deterministic hash of username+tenantId+scope to look up an existing Redis token before ever issuing a new one, giving users the same token until expiry. The migration dropped this lookup and called UUID.randomUUID() unconditionally, issuing a new token on every login and accumulating unlimited live tokens per user in Redis.

Additionally, updatePasswordForLoggedInUser and updatePasswordForNonLoggedInUser never called removeTokensByUser, meaning active tokens survived a password change.

Changes:
- EgovTokenStore: add getActiveAccessToken(username, tenantId) contract
- RedisEgovTokenStore: write user_active_token:<user>:<tenant> pointer on storeAccessToken; validate and return it in getActiveAccessToken; clean it up in removeAccessToken and removeAllTokensByUsername (pattern-delete across tenants)
- CustomTokenEndpoint.issueTokenResponse: check getActiveAccessToken before generating a UUID — reuse the existing token when still live in Redis
- UserService: call removeTokensByUser after both password-update flows so tokens are invalidated immediately when a user changes their password
- UserServiceTest: add missing @Mock on EgovTokenStore field (was plain null, causing NPE once removeTokensByUser was called from the password-update paths)

## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Access tokens are now cleared after password updates (both logged-in and forgot-password flows) to prevent continued use of previously issued tokens.

* **New Features**
  * Access-token issuance can now reuse an already-active access token when applicable, reducing unnecessary token churn.

* **Performance Optimization**
  * Token reuse is supported by tracking an active, tenant-scoped access token per user, improving efficiency during token issuance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->