### PR TITLE
fix(UploadModal): allow custom filename for downloaded files at leftover places

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/common/src/components/UploadModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/common/src/components/UploadModal.js
@@ -6,7 +6,7 @@ import { buildUploadModalConfig, SIGNATURE_UPLOAD_CONFIG } from "../utils/fileCo
 import axiosInstance from "@egovernments/digit-ui-module-core/src/Utils/axiosInstance";
 import { Loader } from "@egovernments/digit-ui-react-components";
 
-const AuthenticatedLink = ({ t, uri, displayFilename = false, pdf = false }) => {
+const AuthenticatedLink = ({ t, uri, displayFilename = false, pdf = false, name = "downloadedFile" }) => {
   const handleClick = (e) => {
     e.preventDefault();
 
@@ -26,7 +26,7 @@ const AuthenticatedLink = ({ t, uri, displayFilename = false, pdf = false }) => 
           const blobUrl = URL.createObjectURL(blob);
           const link = document.createElement("a");
           link.href = blobUrl;
-          link.download = `downloadedFile.${extension}`;
+          link.download = `${name}.${extension}`;
           document.body.appendChild(link);
           link.click();
           document.body.removeChild(link);
@@ -103,6 +103,7 @@ function UploadModal({
   uploadGuidelines = null,
   fileStoreId,
   isParentLoading = false,
+  downloadedFileName,
 }) {
   const [errors, setErrors] = useState({});
   const combineAndSelectRef = useRef(null);
@@ -262,7 +263,7 @@ function UploadModal({
               {t("CLICK_HERE")}
             </span>
           ) : (
-            <AuthenticatedLink uri={uri} t={t} displayFilename={"CLICK_HERE"} pdf={true} />
+            <AuthenticatedLink uri={uri} t={t} displayFilename={"CLICK_HERE"} pdf={true} name={downloadedFileName} />
           )}
         </div>
       )}

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/MediationFormSignaturePage.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/MediationFormSignaturePage.js
@@ -617,7 +617,7 @@ const MediationFormSignaturePage = () => {
                       color: "#007E7E",
                     }}
                     onButtonClick={() => {
-                      const name = `${digitalizationServiceDetails?.mediationDetails?.mediationId}_mediation`;
+                      const name = `${documentNumber}_mediation`;
                       downloadPdf(tenantId, signatureDocumentId || mediationFileStoreId, name);
                     }}
                   />
@@ -739,7 +739,7 @@ const MediationFormSignaturePage = () => {
           isParentLoading={uploadLoader}
           fileUploadError={fileUploadError}
           setFileUploadError={setFileUploadError}
-          downloadedFileName={`${digitalizationServiceDetails?.mediationDetails?.mediationId}_mediation`}
+          downloadedFileName={`${documentNumber}_mediation`}
         />
       )}
       {showSkipConfirmModal && (

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/WitnessDrawerV2.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/WitnessDrawerV2.js
@@ -1163,7 +1163,8 @@ const WitnessDrawerV2 = ({
     }
   };
 
-  if (isFilingTypeLoading || isEvidenceLoading || caseApiLoading) {
+  const isDataLoading = isFilingTypeLoading || isEvidenceLoading || caseApiLoading;
+  if (isDataLoading) {
     return <Loader />;
   }
 
@@ -1354,7 +1355,7 @@ const WitnessDrawerV2 = ({
               <div className="drawer-footer" style={{ display: "flex", justifyContent: "end", flexDirection: "row", gap: "16px" }}>
                 <Button
                   label={t("SAVE_DRAFT")}
-                  isDisabled={!IsSelectedWitness}
+                  isDisabled={!IsSelectedWitness || isDataLoading}
                   onButtonClick={() => handleSaveDraft()}
                   style={{
                     width: "130px",
@@ -1366,7 +1367,7 @@ const WitnessDrawerV2 = ({
                 />
                 <Button
                   label={t("SUBMIT_BUTTON")}
-                  isDisabled={!IsSelectedWitness || witnessDepositionText?.length === 0}
+                  isDisabled={!IsSelectedWitness || witnessDepositionText?.length === 0 || isDataLoading}
                   className={"order-drawer-save-btn"}
                   onButtonClick={() => handleSaveDraft(true)}
                   style={{


### PR DESCRIPTION
fix(UploadModal): allow custom filename for downloaded files; update MediationFormSignaturePage to use document number for naming; improve loading state handling in WitnessDrawerV2

## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->
