### PR TITLE
Default 'Request Bail Bond' checkbox to checked on accept bail order (#5847)

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pageComponents/AddOrderTypeModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pageComponents/AddOrderTypeModal.js
@@ -48,6 +48,10 @@ const AddOrderTypeModal = ({
   const [isSubmitDisabled, setIsSubmitDisabled] = useState(false);
   const containerRef = useRef(null);
   const [showBailBondModal, setShowBailBondModal] = useState(false);
+  // Tracks whether the judge has explicitly toggled the "Request Bail Bond" checkbox this session.
+  // Lets us distinguish "not yet decided" (apply the default-checked behavior) from "explicitly
+  // unchecked" (respect it, do not auto-recheck).
+  const [bailBondUserTouched, setBailBondUserTouched] = useState(false);
 
   const multiSelectDropdownKeys = useMemo(() => {
     const foundKeys = [];
@@ -365,6 +369,18 @@ const AddOrderTypeModal = ({
     return currentOrder;
   }, [currentOrder, index]);
 
+  // Effective checked-state for the "Request Bail Bond" checkbox (issue #5847: default to checked).
+  // - A saved order item carries a concrete boolean -> respect it (and stays locked once saved checked).
+  // - Once the judge has toggled it this session -> respect that choice.
+  // - Otherwise default to checked as soon as the checkbox is enabled (SURETY + valid amount + sureties),
+  //   so it is unchecked while required fields are empty and auto-checks the moment they become valid.
+  const effectiveRequestBailBond = useMemo(() => {
+    const persisted = newCurrentOrder?.additionalDetails?.formdata?.requestBailBond;
+    if (persisted !== undefined) return Boolean(persisted);
+    if (bailBondUserTouched) return Boolean(bailBondRequired);
+    return isBailBondCheckboxEnabled;
+  }, [newCurrentOrder, bailBondUserTouched, bailBondRequired, isBailBondCheckboxEnabled]);
+
   const initialBailType = useMemo(() => {
     const bt = newCurrentOrder?.additionalDetails?.formdata?.bailType;
     if (bt == null) return { type: "SURETY", code: "SURETY", name: "SURETY" };
@@ -505,8 +521,9 @@ const AddOrderTypeModal = ({
                         id="bail-bond-required"
                         type="checkbox"
                         className="custom-checkbox"
-                        checked={newCurrentOrder?.additionalDetails?.formdata?.requestBailBond || bailBondRequired}
+                        checked={effectiveRequestBailBond}
                         onChange={(e) => {
+                          setBailBondUserTouched(true);
                           const checked = e?.target?.checked;
                           if (checked === true) {
                             setShowBailBondModal(true);
@@ -561,7 +578,7 @@ const AddOrderTypeModal = ({
                       const updatedFormData = {
                         ...formdata,
                         ...(orderType?.code === "ACCEPT_BAIL" && {
-                          requestBailBond: Boolean(newCurrentOrder?.additionalDetails?.formdata?.requestBailBond || bailBondRequired),
+                          requestBailBond: Boolean(effectiveRequestBailBond),
                         }),
                       };
                       handleSubmit(updatedFormData, index);


### PR DESCRIPTION
## Requirements

Fixes pucardotorg/dristi#5847

- [x] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the github issue('s)
- [x] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes <!-- No unit tests exist for this component; ESLint passes with 0 errors. -->
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes: <!-- N/A — none of these are included. -->

## Summary

When a Magistrate accepts a bail application via an `ACCEPT_BAIL` order (for `bailType = SURETY`), the form shows a **"Request Bail Bond"** checkbox. This checkbox is the **sole gate** that starts the bail-bond flow: when checked, two pending tasks are created — one for the advocate/litigant to **raise** the bail bond and one for the judge to **sign** it. When left unchecked, **neither task is created and the bail-bond flow never starts**.

Previously the checkbox defaulted to **unchecked**, so staff had to remember to tick it every time. This PR makes it **default to checked** (while keeping it editable), to reduce the risk of it being forgotten.

**Change (frontend only):** `frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pageComponents/AddOrderTypeModal.js`

- The checkbox now defaults to **checked** as soon as it is enabled (SURETY + valid cheque amount + number of sureties).
- It remains **editable** — the judge can still uncheck it; a new `bailBondUserTouched` flag prevents it from auto-re-checking after a manual uncheck.
- A previously **saved** value is respected on re-edit, and a saved-checked item stays locked (its tasks already exist).
- The "Create Bail Bond Task" confirmation pop-up now appears **only on a manual re-check**, so the default-checked state never interrupts the judge.

The task-creation gate, both pending-task creators, and the bail-bond lifecycle are unchanged — only the default value of `requestBailBond` flips.

## Data Changes

None. No MDMS, workflow, or deployment configuration changes.

## Preview

UI change in the `ACCEPT_BAIL` (surety) order form. With a valid cheque amount and number of sureties entered, the "Request Bail Bond" checkbox is now checked by default and can still be unchecked. (Flow verified locally by the reviewer.)

## Other

- No breaking changes.
- No dependencies added/removed.
- Frontend-only; no backend/config impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “Request Bail Bond” checkbox behavior when creating or editing an order.
  * The checkbox now keeps the correct state based on saved values, user interaction, and validation rules.
  * Submissions now send the expected bail bond request value, reducing cases where the selection could be saved incorrectly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->