### PR TITLE
fix(PaymentForSummonModal): add party unique ID and name and task type warrant for online payment task

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/PaymentForSummonModalSMSAndEmail.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/PaymentForSummonModalSMSAndEmail.js
@@ -35,6 +35,7 @@ const orderTypeEnum = {
   WARRANT: "Warrant",
   PROCLAMATION: "Proclamation",
   ATTACHMENT: "Attachment",
+  SCHEDULE_OF_HEARING_DATE: "Warrant",
 };
 
 const PaymentForSummonComponent = ({
@@ -201,6 +202,8 @@ const PaymentForSummonModalSMSAndEmail = ({ path }) => {
   );
 
   const filteredTasks = useMemo(() => tasksData?.list, [tasksData]);
+  const partyUniqueId = useMemo(() => filteredTasks?.[0]?.taskDetails?.respondentDetails?.uniqueId, [filteredTasks]);
+  const partyName = useMemo(() => filteredTasks?.[0]?.taskDetails?.respondentDetails?.name, [filteredTasks]);
 
   const { data: orderData, isLoading: isOrdersLoading } = Digit.Hooks.orders.useSearchOrdersService(
     { tenantId, criteria: { id: filteredTasks?.[0]?.orderId, ...(caseCourtId && { courtId: caseCourtId }) } },
@@ -244,6 +247,7 @@ const PaymentForSummonModalSMSAndEmail = ({ path }) => {
       PROCLAMATION: paymentType.TASK_PROCLAMATION,
       ATTACHMENT: paymentType.TASK_ATTACHMENT,
       NOTICE: paymentType.TASK_NOTICE,
+      SCHEDULE_OF_HEARING_DATE: paymentType.TASK_WARRANT,
     };
     return businessServiceMap?.[orderType];
   };
@@ -635,6 +639,7 @@ const PaymentForSummonModalSMSAndEmail = ({ path }) => {
       formdata?.warrantFor ||
       formdata?.proclamationFor ||
       formdata?.attachmentFor ||
+      partyName ||
       "";
 
     const task = filteredTasks?.[0];


### PR DESCRIPTION
https://github.com/pucardotorg/dristi/issues/5643
## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment handling for hearing-date schedule orders by matching them to the existing warrant payment flow.
  * Made the “Issued to” name display more reliable by falling back to a computed party name when the primary name format is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->