### PR TITLE
feat: add notDeliveredReason and notDeliveredReasonText to DeliveryChannel DTOs

### DIFF
--- a/backend/dristi-services/analytics/src/main/java/org/pucar/dristi/web/models/taskManagement/DeliveryChannel.java
+++ b/backend/dristi-services/analytics/src/main/java/org/pucar/dristi/web/models/taskManagement/DeliveryChannel.java
@@ -61,4 +61,10 @@ public class DeliveryChannel {
 
     @JsonProperty("channelDetails")
     private Map<String, String> channelDetails;
+
+    @JsonProperty("notDeliveredReason")
+    private String notDeliveredReason;
+
+    @JsonProperty("notDeliveredReasonText")
+    private String notDeliveredReasonText;
 }

--- a/backend/dristi-services/casemanagement/src/main/java/org/pucar/dristi/web/models/task/DeliveryChannel.java
+++ b/backend/dristi-services/casemanagement/src/main/java/org/pucar/dristi/web/models/task/DeliveryChannel.java
@@ -65,4 +65,10 @@ public class DeliveryChannel {
     @JsonProperty("isPendingCollection")
     private Boolean isPendingCollection = false;
 
+    @JsonProperty("notDeliveredReason")
+    private String notDeliveredReason;
+
+    @JsonProperty("notDeliveredReasonText")
+    private String notDeliveredReasonText;
+
 }

--- a/backend/dristi-services/casemanagement/src/main/java/org/pucar/dristi/web/models/taskManagement/DeliveryChannel.java
+++ b/backend/dristi-services/casemanagement/src/main/java/org/pucar/dristi/web/models/taskManagement/DeliveryChannel.java
@@ -65,4 +65,10 @@ public class DeliveryChannel {
     @JsonProperty("isPendingCollection")
     private Boolean isPendingCollection = false;
 
+    @JsonProperty("notDeliveredReason")
+    private String notDeliveredReason;
+
+    @JsonProperty("notDeliveredReasonText")
+    private String notDeliveredReasonText;
+
 }

--- a/backend/dristi-services/epost-tracker/src/main/java/org/pucar/dristi/model/DeliveryChannel.java
+++ b/backend/dristi-services/epost-tracker/src/main/java/org/pucar/dristi/model/DeliveryChannel.java
@@ -39,4 +39,10 @@ public class DeliveryChannel {
     @JsonProperty("isPendingCollection")
     private Boolean isPendingCollection;
 
+    @JsonProperty("notDeliveredReason")
+    private String notDeliveredReason;
+
+    @JsonProperty("notDeliveredReasonText")
+    private String notDeliveredReasonText;
+
 }

--- a/backend/dristi-services/hearing/src/main/java/org/pucar/dristi/web/models/taskManagement/DeliveryChannel.java
+++ b/backend/dristi-services/hearing/src/main/java/org/pucar/dristi/web/models/taskManagement/DeliveryChannel.java
@@ -60,4 +60,10 @@ public class DeliveryChannel {
     @JsonProperty("deliveryChannelName")
     private String deliveryChannelName;
 
+    @JsonProperty("notDeliveredReason")
+    private String notDeliveredReason;
+
+    @JsonProperty("notDeliveredReasonText")
+    private String notDeliveredReasonText;
+
 }

--- a/backend/dristi-services/openapi/src/main/java/org/pucar/dristi/web/models/DeliveryChannel.java
+++ b/backend/dristi-services/openapi/src/main/java/org/pucar/dristi/web/models/DeliveryChannel.java
@@ -53,4 +53,10 @@ public class DeliveryChannel {
     @JsonProperty("isPendingCollection")
     private Boolean isPendingCollection;
 
+    @JsonProperty("notDeliveredReason")
+    private String notDeliveredReason;
+
+    @JsonProperty("notDeliveredReasonText")
+    private String notDeliveredReasonText;
+
 }

--- a/backend/dristi-services/order-management/src/main/java/pucar/web/models/task/DeliveryChannel.java
+++ b/backend/dristi-services/order-management/src/main/java/pucar/web/models/task/DeliveryChannel.java
@@ -65,4 +65,10 @@ public class DeliveryChannel {
     @JsonProperty("isPendingCollection")
     private Boolean isPendingCollection = false;
 
+    @JsonProperty("notDeliveredReason")
+    private String notDeliveredReason;
+
+    @JsonProperty("notDeliveredReasonText")
+    private String notDeliveredReasonText;
+
 }

--- a/backend/dristi-services/task-management/src/main/java/digit/web/models/DeliveryChannel.java
+++ b/backend/dristi-services/task-management/src/main/java/digit/web/models/DeliveryChannel.java
@@ -63,4 +63,10 @@ public class DeliveryChannel {
     @JsonProperty("isPendingCollection")
     private Boolean isPendingCollection = false;
 
+    @JsonProperty("notDeliveredReason")
+    private String notDeliveredReason;
+
+    @JsonProperty("notDeliveredReasonText")
+    private String notDeliveredReasonText;
+
 }

--- a/backend/integration-services/icops_integration-kerala/src/main/java/com/egov/icops_integrationkerala/model/DeliveryChannel.java
+++ b/backend/integration-services/icops_integration-kerala/src/main/java/com/egov/icops_integrationkerala/model/DeliveryChannel.java
@@ -37,4 +37,10 @@ public class DeliveryChannel {
     @JsonProperty("isPendingCollection")
     private Boolean isPendingCollection;
 
+    @JsonProperty("notDeliveredReason")
+    private String notDeliveredReason;
+
+    @JsonProperty("notDeliveredReasonText")
+    private String notDeliveredReasonText;
+
 }

--- a/backend/integration-services/summons-svc/src/main/java/digit/web/models/DeliveryChannel.java
+++ b/backend/integration-services/summons-svc/src/main/java/digit/web/models/DeliveryChannel.java
@@ -52,4 +52,10 @@ public class DeliveryChannel {
     @JsonProperty("isPendingCollection")
     private Boolean isPendingCollection = false;
 
+    @JsonProperty("notDeliveredReason")
+    private String notDeliveredReason;
+
+    @JsonProperty("notDeliveredReasonText")
+    private String notDeliveredReasonText;
+
 }


### PR DESCRIPTION


Add the two new delivery-channel fields to all typed DeliveryChannel models across services that deserialize taskDetails, so the values are not dropped during (de)serialization.

https://github.com/pucardotorg/dristi/issues/5784

## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->
