### PR TITLE
fix: restrict reason dropdown visibility to SUMMONS and WARRANT task …

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/components/UpdateDeliveryStatusComponent.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/components/UpdateDeliveryStatusComponent.js
@@ -45,7 +45,7 @@ const UpdateDeliveryStatusComponent = ({
   const isIcops = rowData?.taskDetails?.deliveryChannels?.channelCode === "POLICE";
   const isSummons = (orderType || rowData?.taskType) === "SUMMONS";
   const reasonOptions = isSummons ? SUMMONS_REASON_OPTIONS : WARRANT_REASON_OPTIONS;
-  const showReasonDropdown = selectedDelievery?.key === "NOT_DELIVERED" && !isIcops;
+  const showReasonDropdown = ["SUMMONS", "WARRANT"].includes(rowData?.taskType) && selectedDelievery?.key === "NOT_DELIVERED" && !isIcops;
   const showReasonText = showReasonDropdown && selectedReason?.key === "OTHER";
 
   const deliveryOptions = [


### PR DESCRIPTION
…types
https://github.com/pucardotorg/dristi/issues/5784
## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The “Reason for Non-Delivery” dropdown now appears only for eligible delivery tasks, reducing confusion in other order types.
  * It is shown when delivery is marked as not delivered and the channel is not ICOPS, but only for summons and warrant tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->