### PR TITLE
fix: remove unnecessary styles from popup module action bar

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/css/src/orders/orders.scss
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/css/src/orders/orders.scss
@@ -332,11 +332,6 @@
       padding: 40px !important;
       .popup-module-action-bar {
         margin: 0px !important;
-        .popup-module-action-bar-buttons {
-          display: flex !important;
-          flex-direction: row !important;
-          gap: 16px !important;
-          width: 100% !important;
         .selector-button-border {
           border: 1px solid #007e7e !important;
           display: flex;
@@ -378,7 +373,6 @@
             text-align: center;
           }
         }
-      }
       }
     }
   }


### PR DESCRIPTION
## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the order success modal action area styling by removing the dedicated button-group layout rules.
  * Button spacing and full-width container behavior in that modal’s action bar may now appear different.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->