### PR TITLE
fix(dristi-pdf): profile-edit signature attributes advocate to their actual client

### DIFF
--- a/backend/ui-integration-services/dristi-pdf/src/applicationHandlers/applicationProfileEdit.js
+++ b/backend/ui-integration-services/dristi-pdf/src/applicationHandlers/applicationProfileEdit.js
@@ -276,6 +276,23 @@ async function applicationProfileEdit(
       courtCase || {},
     );
 
+    // Resolve the litigant(s) the filing advocate actually represents, so the
+    // signature reads "Advocate for <real client>" rather than the party being
+    // edited (these differ when, e.g., a complainant's advocate edits the accused).
+    const filingAdvocate =
+      courtCase?.representatives?.find(
+        (rep) => rep?.additionalDetails?.uuid === application?.asUser,
+      ) || {};
+    const advocateRepresentingName =
+      filingAdvocate?.representing?.find(
+        (litigant) => litigant?.individualId === uniqueId,
+      )?.additionalDetails?.fullName ||
+      filingAdvocate?.representing
+        ?.map((litigant) => litigant?.additionalDetails?.fullName)
+        ?.filter(Boolean)
+        ?.join(", ") ||
+      partyName;
+
     const data = {
       Data: [
         {
@@ -290,6 +307,7 @@ async function applicationProfileEdit(
           date: formattedToday,
           partyName: partyName,
           advocateName,
+          advocateRepresentingName,
           reasonForEditing: reasonForChange,
           advocateSignature: "Advocate Signature",
           day: day + ordinalSuffix,


### PR DESCRIPTION
Addresses https://github.com/pucardotorg/dristi/issues/5275

The profile-edit application PDF signature line attributed the signing advocate to the party being edited instead of the litigant they actually represent (e.g. a complainant's advocate editing the accused showed "Advocate for <accused>"). Resolves the filing advocate's represented litigant via `asUser` uuid (order-handler pattern) and renders it as `advocateRepresentingName`. Paired with the kerala-configs template/data-config PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved PDF output to show a more specific “advocate representing” name when available.
  * Display now uses the matched litigant’s full name, or a comma-separated list of represented names, with a fallback to the existing party name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->