### PR TITLE
fix: reset selected reason and reason text on error and modal close

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/ReviewSummonsNoticeAndWarrant.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/ReviewSummonsNoticeAndWarrant.js
@@ -611,6 +611,9 @@ const ReviewSummonsNoticeAndWarrant = () => {
         console.error("Error updating task data:", error);
         const errorId = error?.response?.headers?.["x-correlation-id"] || error?.response?.headers?.["X-Correlation-Id"];
         setShowToast({ label: t("HOME_SCREEN_UPDATE_FAILED"), error: true, errorId });
+      } finally {
+        setSelectedReason({});
+        setReasonText("");
       }
     }
   }, [dayInMillisecond, orderData, orderType, refetch, reload, selectedDelievery, selectedReason, reasonText, tasksData, tenantId, todayDate]);
@@ -1784,6 +1787,8 @@ const ReviewSummonsNoticeAndWarrant = () => {
 
   const handleCloseActionModal = useCallback(() => {
     setShowActionModal(false);
+    setSelectedReason({});
+    setReasonText("");
     if (taskNumber) history.replace(`/${window?.contextPath}/employee/orders/Summons&Notice`);
   }, [history, taskNumber]);
 


### PR DESCRIPTION
## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cleared the selected reason and comment fields after attempting a status update, so the form resets whether the update succeeds or fails.
  * Reset the same fields when closing the action modal, ensuring users return to a clean state when dismissing the dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->