### PR TITLE
fix(treasury): align AuthSekQueryBuilderTest expectations with retry_…

### DIFF
--- a/backend/integration-services/treasury-backend/src/test/java/org/egov/eTreasury/repository/AuthSekQueryBuilderTest.java
+++ b/backend/integration-services/treasury-backend/src/test/java/org/egov/eTreasury/repository/AuthSekQueryBuilderTest.java
@@ -33,7 +33,7 @@ class AuthSekQueryBuilderTest {
         // Then
         assertThat(preparedStmtList).containsExactly("testAuthToken");
         assertThat(query).isEqualTo(
-                "SELECT auth_token, decrypted_sek, bill_id, business_service, service_number, total_due, mobile_number, paid_by, session_time, department_id, request_blob, payment_status, completion_source, verification_timestamp, processed_status  FROM auth_sek_session_data  WHERE  auth_token = ? ORDER BY session_time "
+                "SELECT auth_token, decrypted_sek, bill_id, business_service, service_number, total_due, mobile_number, paid_by, session_time, department_id, request_blob, payment_status, completion_source, verification_timestamp, processed_status, retry_count  FROM auth_sek_session_data  WHERE  auth_token = ? ORDER BY session_time "
         );
     }
 
@@ -47,7 +47,7 @@ class AuthSekQueryBuilderTest {
         String query = queryBuilder.getAuthSekQuery(authToken, preparedStmtList);
 
         // Then
-        assertThat(query).isEqualTo("SELECT auth_token, decrypted_sek, bill_id, business_service, service_number, total_due, mobile_number, paid_by, session_time, department_id, request_blob, payment_status, completion_source, verification_timestamp, processed_status  FROM auth_sek_session_data ORDER BY session_time ");
+        assertThat(query).isEqualTo("SELECT auth_token, decrypted_sek, bill_id, business_service, service_number, total_due, mobile_number, paid_by, session_time, department_id, request_blob, payment_status, completion_source, verification_timestamp, processed_status, retry_count  FROM auth_sek_session_data ORDER BY session_time ");
         Assertions.assertNotNull(preparedStmtList);
     }
 
@@ -63,7 +63,7 @@ class AuthSekQueryBuilderTest {
 
         // Then
         assertThat(query).isEqualTo(
-                "SELECT auth_token, decrypted_sek, bill_id, business_service, service_number, total_due, mobile_number, paid_by, session_time, department_id, request_blob, payment_status, completion_source, verification_timestamp, processed_status  FROM auth_sek_session_data  AND  auth_token = ? ORDER BY session_time "
+                "SELECT auth_token, decrypted_sek, bill_id, business_service, service_number, total_due, mobile_number, paid_by, session_time, department_id, request_blob, payment_status, completion_source, verification_timestamp, processed_status, retry_count  FROM auth_sek_session_data  AND  auth_token = ? ORDER BY session_time "
         );
         Assertions.assertNotNull(preparedStmtList);
     }


### PR DESCRIPTION
…count column

The BASE_QUERY in AuthSekQueryBuilder was updated to select the retry_count column, but the test's hardcoded expected query strings were not updated, causing mvn clean install to fail at the test phase.

## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->
