### PR TITLE
feat: allow all state bar council prefixes in advocate registration (#5873)

### DIFF
--- a/backend/dristi-services/advocate/src/main/resources/application.properties
+++ b/backend/dristi-services/advocate/src/main/resources/application.properties
@@ -129,4 +129,4 @@ logging.loki.app=order-management
 logging.loki.environment=local
 logging.level.root=INFO
 
-dristi.bar.registration.number.format=^K/(?!0+/)(\\d{1,6})/\\d{4}$
+dristi.bar.registration.number.format=^[A-Z]/(?!0+/)(\\d{1,6})/\\d{4}$

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/registration/config.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/registration/config.js
@@ -752,7 +752,7 @@ export const advocateClerkConfig = [
               name: "barRegistrationNumber",
               validation: {
                 isRequired: true,
-                pattern: "^K/\\d{1,6}/\\d{4}$",
+                pattern: "^[A-Z]/\\d{1,6}/\\d{4}$",
                 errMsg: "BAR_REGISTRATION_NUMBER_INVALID_PATTERN",
                 maxlength: 20,
                 minlength: 1,


### PR DESCRIPTION
## Problem
Advocates whose bar enrollment number does not start with `K` (Karnataka) — e.g. `D/...` (Delhi), `P/...`, `H/...` — were unable to register on the OnCourts portal. The bar registration number validation was hard-coded to only accept a `K/` prefix.

Adresses #5873

## Changes
Relaxed the state-council prefix in the bar registration number format from the hard-coded `K` to any single uppercase letter `[A-Z]`, keeping the rest of the format (`/serial/year`) unchanged.

- **Frontend** — `dristi/.../registration/config.js`: `^K/\d{1,6}/\d{4}$` → `^[A-Z]/\d{1,6}/\d{4}$`
- **Backend** — `advocate/.../application.properties`: `^K/(?!0+/)(\d{1,6})/\d{4}$` → `^[A-Z]/(?!0+/)(\d{1,6})/\d{4}$`

The tokenizer / uniqueness logic in the advocate service was already state-agnostic, so no further backend changes were required.

## Follow-ups (outside this repo)
- **Localization**: the on-screen hint (`BAR_REGISTRATION_NUMBER_INVALID_PATTERN`, currently "Format: K/(1–6 digits)/yyyy") lives in the DIGIT localization service and should be updated to not reference `K` specifically.
- **Deployment override**: confirm the environment config does not override `dristi.bar.registration.number.format` with the old `^K/...` value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Broadened bar registration number validation to accept any single uppercase letter as the starting prefix instead of only one specific letter.
  * Kept the existing number and year format rules unchanged, so valid registrations still follow the same overall structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->