### PR TITLE
fix: allow 1-4 letter state prefix in bar registration number (#5873)

### DIFF
--- a/backend/dristi-services/advocate/src/main/resources/application.properties
+++ b/backend/dristi-services/advocate/src/main/resources/application.properties
@@ -129,4 +129,4 @@ logging.loki.app=order-management
 logging.loki.environment=local
 logging.level.root=INFO
 
-dristi.bar.registration.number.format=^[A-Z]/(?!0+/)(\\d{1,6})/\\d{4}$
+dristi.bar.registration.number.format=^[A-Z]{1,4}/(?!0+/)(\\d{1,6})/\\d{4}$

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/registration/config.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/registration/config.js
@@ -752,7 +752,7 @@ export const advocateClerkConfig = [
               name: "barRegistrationNumber",
               validation: {
                 isRequired: true,
-                pattern: "^[A-Z]/\\d{1,6}/\\d{4}$",
+                pattern: "^[A-Z]{1,4}/\\d{1,6}/\\d{4}$",
                 errMsg: "BAR_REGISTRATION_NUMBER_INVALID_PATTERN",
                 maxlength: 20,
                 minlength: 1,


### PR DESCRIPTION
## Context
Follow-up to #6817. That change relaxed the bar registration number prefix from a hard-coded `K` to a single uppercase letter `[A-Z]`. Per the issue discussion, the state-council prefix can actually be **1 to 4 letters** (e.g. `MAH`, `AP`), so a single letter is too strict.

Adresses #5873

## Change
Update the state-prefix in the bar registration number format from `[A-Z]` to `[A-Z]{1,4}` in both frontend and backend validation.

- **Frontend** — `dristi/.../registration/config.js`: `^[A-Z]/\d{1,6}/\d{4}$` → `^[A-Z]{1,4}/\d{1,6}/\d{4}$`
- **Backend** — `advocate/.../application.properties`: `^[A-Z]/(?!0+/)(\d{1,6})/\d{4}$` → `^[A-Z]{1,4}/(?!0+/)(\d{1,6})/\d{4}$`

## Follow-ups (outside this repo)
- **Localization**: update the on-screen hint (`BAR_REGISTRATION_NUMBER_INVALID_PATTERN`) to reflect the new format.
- **Deployment override**: confirm the environment config does not override `dristi.bar.registration.number.format` with an older value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)