### PR TITLE
fix: derive open-hearing case number from live court case

### DIFF
--- a/backend/dristi-services/case/src/main/java/org/pucar/dristi/repository/CaseRepository.java
+++ b/backend/dristi-services/case/src/main/java/org/pucar/dristi/repository/CaseRepository.java
@@ -241,6 +241,38 @@ public class CaseRepository {
         }
     }
 
+    /**
+     * Resolves a filingNumber to its caseId. Lightweight single-column, indexed lookup
+     * used to build the Redis key (tenantId:caseId) for the Redis-first metadata read.
+     * Returns null when the filingNumber does not exist.
+     */
+    public String getCaseIdByFilingNumber(String filingNumber) {
+        if (filingNumber == null || filingNumber.trim().isEmpty()) {
+            return null;
+        }
+        String query = "SELECT cases.id FROM dristi_cases cases WHERE cases.filingnumber = ? LIMIT 1";
+        List<String> ids = jdbcTemplate.query(query, new Object[]{filingNumber}, new int[]{java.sql.Types.VARCHAR},
+                (rs, rowNum) -> rs.getString("id"));
+        return ids.isEmpty() ? null : ids.get(0);
+    }
+
+    /**
+     * Scalar-only case metadata lookup by filingNumber(s). Single-table read against
+     * dristi_cases with no child-table joins, no Redis, and no decryption. Used as the
+     * database fallback when the case is not present in the Redis cache.
+     */
+    public List<CaseMeta> getCaseMeta(List<String> filingNumbers) {
+        if (filingNumbers == null || filingNumbers.isEmpty()) {
+            return new ArrayList<>();
+        }
+        List<Object> preparedStmtList = new ArrayList<>();
+        List<Integer> preparedStmtArgList = new ArrayList<>();
+        String query = queryBuilder.getCaseMetaQuery(filingNumbers, preparedStmtList, preparedStmtArgList);
+        log.info("Final case meta query :: {}", query);
+        return jdbcTemplate.query(query, preparedStmtList.toArray(),
+                preparedStmtArgList.stream().mapToInt(Integer::intValue).toArray(), new CaseMetaRowMapper());
+    }
+
     public List<CaseCriteria> getCases(List<CaseCriteria> searchCriteria, RequestInfo requestInfo) {
 
         try {

--- a/backend/dristi-services/case/src/main/java/org/pucar/dristi/repository/querybuilder/CaseQueryBuilder.java
+++ b/backend/dristi-services/case/src/main/java/org/pucar/dristi/repository/querybuilder/CaseQueryBuilder.java
@@ -100,7 +100,31 @@ public class CaseQueryBuilder {
 
     private static final String BASE_CASE_EXIST_QUERY = " SELECT COUNT(*) FROM dristi_cases cases ";
 
+    // Scalar-only projection (single table, no joins). All selected columns are plaintext,
+    // so results need no enc-service decryption.
+    private static final String BASE_CASE_META_QUERY = " SELECT cases.id as id, cases.tenantid as tenantid, cases.filingnumber as filingnumber, " +
+            " cases.courtid as courtid, cases.courtcasenumber as courtcasenumber, cases.cmpnumber as cmpnumber, cases.lprnumber as lprnumber, " +
+            " cases.cnrnumber as cnrnumber, cases.lifecyclestatus as lifecyclestatus, cases.casetitle as casetitle, cases.status as status, " +
+            " cases.stage as stage, cases.filingdate as filingdate, cases.registrationdate as registrationdate ";
+
     public static final String AND = " AND ";
+
+    public String getCaseMetaQuery(List<String> filingNumbers, List<Object> preparedStmtList, List<Integer> preparedStmtArgList) {
+        try {
+            StringBuilder query = new StringBuilder(BASE_CASE_META_QUERY);
+            query.append(FROM_CASES_TABLE);
+            String placeholders = filingNumbers.stream().map(f -> "?").collect(Collectors.joining(", "));
+            query.append(" WHERE cases.filingnumber IN (").append(placeholders).append(")");
+            for (String filingNumber : filingNumbers) {
+                preparedStmtList.add(filingNumber);
+                preparedStmtArgList.add(Types.VARCHAR);
+            }
+            return query.toString();
+        } catch (Exception e) {
+            log.error("Error while building case meta query :: {}", e.toString());
+            throw new CustomException(CASE_SEARCH_QUERY_EXCEPTION, "Exception occurred while building the case meta query: " + e.getMessage());
+        }
+    }
 
     public String getCaseSummarySearchQuery(CaseSummarySearchCriteria criteria, List<Object> preparedStmtList, List<Integer> preparedStmtArgList) {
         try {

--- a/backend/dristi-services/case/src/main/java/org/pucar/dristi/repository/rowmapper/CaseMetaRowMapper.java
+++ b/backend/dristi-services/case/src/main/java/org/pucar/dristi/repository/rowmapper/CaseMetaRowMapper.java
@@ -1,0 +1,52 @@
+package org.pucar.dristi.repository.rowmapper;
+
+import lombok.extern.slf4j.Slf4j;
+import org.pucar.dristi.web.models.CaseMeta;
+import org.pucar.dristi.web.models.enums.LifecycleStatus;
+import org.springframework.jdbc.core.RowMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Maps a single dristi_cases row to the scalar {@link CaseMeta} projection.
+ *
+ * Stateless with no dependencies, so it is instantiated directly by the repository
+ * rather than registered as a Spring bean.
+ */
+@Slf4j
+public class CaseMetaRowMapper implements RowMapper<CaseMeta> {
+
+    @Override
+    public CaseMeta mapRow(ResultSet rs, int rowNum) throws SQLException {
+        String lifecycleStatus = rs.getString("lifecyclestatus");
+        return CaseMeta.builder()
+                .caseId(rs.getString("id"))
+                .tenantId(rs.getString("tenantid"))
+                .filingNumber(rs.getString("filingnumber"))
+                .courtId(rs.getString("courtid"))
+                .courtCaseNumber(rs.getString("courtcasenumber"))
+                .cmpNumber(rs.getString("cmpnumber"))
+                .lprNumber(rs.getString("lprnumber"))
+                .cnrNumber(rs.getString("cnrnumber"))
+                .lifecycleStatus(parseLifecycleStatus(lifecycleStatus))
+                .caseTitle(rs.getString("casetitle"))
+                .status(rs.getString("status"))
+                .stage(rs.getString("stage"))
+                .filingDate(rs.getObject("filingdate", Long.class))
+                .registrationDate(rs.getObject("registrationdate", Long.class))
+                .build();
+    }
+
+    private LifecycleStatus parseLifecycleStatus(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            return LifecycleStatus.valueOf(value);
+        } catch (IllegalArgumentException e) {
+            log.warn("Unknown lifecycleStatus value in dristi_cases: {}", value);
+            return null;
+        }
+    }
+}

--- a/backend/dristi-services/case/src/main/java/org/pucar/dristi/service/CaseService.java
+++ b/backend/dristi-services/case/src/main/java/org/pucar/dristi/service/CaseService.java
@@ -441,6 +441,78 @@ public class CaseService {
         }
     }
 
+    /**
+     * Redis-first, scalar-metadata lookup by filingNumber.
+     *
+     * For each filingNumber: resolve its caseId (lightweight indexed read), then look the case
+     * up in Redis by caseId. On a cache hit the metadata is built from the cached CourtCase and
+     * no case body is read from the database. On a miss it falls back to a single-table
+     * dristi_cases projection. All returned fields are plaintext, so no enc-service decryption
+     * is performed.
+     *
+     * Note: Redis is caseId-keyed, so the filingNumber -> caseId resolution is one unavoidable
+     * lightweight DB read. Only the (expensive, in the full-case sense) case body read is skipped
+     * on a cache hit. The cache is not repopulated from here, since this endpoint never
+     * materialises a full CourtCase to store.
+     *
+     * Intended for trusted internal/system callers that need case identifiers/scalars only; it
+     * does not apply the court/advocate/litigant ACL scoping that searchCases does, so it must
+     * not be exposed to citizen/advocate tokens without adding equivalent scoping.
+     */
+    public List<CaseMeta> searchCaseMeta(CaseMetaRequest request) {
+        try {
+            RequestInfo requestInfo = request.getRequestInfo();
+            List<CaseMeta> result = new ArrayList<>();
+            for (String filingNumber : request.getFilingNumbers()) {
+                CaseMeta meta = null;
+
+                String caseId = caseRepository.getCaseIdByFilingNumber(filingNumber);
+                if (caseId != null) {
+                    CourtCase cachedCase = searchRedisCache(requestInfo, caseId);
+                    if (cachedCase != null) {
+                        log.info("CaseMeta served from Redis for caseId: {}", caseId);
+                        meta = toCaseMeta(cachedCase);
+                    }
+                }
+
+                if (meta == null) {
+                    log.info("CaseMeta not found in Redis; reading dristi_cases for filingNumber: {}", filingNumber);
+                    List<CaseMeta> dbResult = caseRepository.getCaseMeta(Collections.singletonList(filingNumber));
+                    if (!dbResult.isEmpty()) {
+                        meta = dbResult.get(0);
+                    }
+                }
+
+                if (meta != null) {
+                    result.add(meta);
+                }
+            }
+            return result;
+        } catch (Exception e) {
+            log.error("Error while fetching case meta :: {}", e.toString());
+            throw new CustomException(SEARCH_CASE_ERR, e.getMessage());
+        }
+    }
+
+    private CaseMeta toCaseMeta(CourtCase courtCase) {
+        return CaseMeta.builder()
+                .caseId(courtCase.getId() != null ? courtCase.getId().toString() : null)
+                .tenantId(courtCase.getTenantId())
+                .filingNumber(courtCase.getFilingNumber())
+                .courtId(courtCase.getCourtId())
+                .courtCaseNumber(courtCase.getCourtCaseNumber())
+                .cmpNumber(courtCase.getCmpNumber())
+                .lprNumber(courtCase.getLprNumber())
+                .cnrNumber(courtCase.getCnrNumber())
+                .lifecycleStatus(courtCase.getLifecycleStatus())
+                .caseTitle(courtCase.getCaseTitle())
+                .status(courtCase.getStatus())
+                .stage(courtCase.getStage())
+                .filingDate(courtCase.getFilingDate())
+                .registrationDate(courtCase.getRegistrationDate())
+                .build();
+    }
+
     private void enrichAdvocateJoinedStatus(CourtCase courtCase, String advocateId) {
         if (advocateId != null && courtCase.getPendingAdvocateRequests() != null) {
             Optional<PendingAdvocateRequest> foundPendingAdvocateRequest = courtCase.getPendingAdvocateRequests().stream().filter(pendingAdvocateRequest -> pendingAdvocateRequest.getAdvocateId().equalsIgnoreCase(advocateId)).findFirst();

--- a/backend/dristi-services/case/src/main/java/org/pucar/dristi/web/controllers/CaseApiController.java
+++ b/backend/dristi-services/case/src/main/java/org/pucar/dristi/web/controllers/CaseApiController.java
@@ -88,6 +88,16 @@ public class CaseApiController {
         return new ResponseEntity<>(caseResponse, HttpStatus.OK);
     }
 
+    @PostMapping(value = "/v1/casemeta/_search")
+    public ResponseEntity<CaseMetaResponse> caseMetaSearch(
+            @Parameter(in = ParameterIn.DEFAULT, description = "filingNumbers + RequestInfo meta data.", required = true, schema = @Schema()) @Valid @RequestBody CaseMetaRequest body) {
+
+        List<CaseMeta> cases = caseService.searchCaseMeta(body);
+        ResponseInfo responseInfo = responseInfoFactory.createResponseInfoFromRequestInfo(body.getRequestInfo(), true);
+        CaseMetaResponse response = CaseMetaResponse.builder().cases(cases).responseInfo(responseInfo).build();
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
     @PostMapping(value = "/v2/search/details")
     public ResponseEntity<CaseSearchResponse> caseV2SearchDetails(
             @Parameter(in = ParameterIn.DEFAULT, description = "Search criteria + RequestInfo meta data.", required = true, schema = @Schema()) @Valid @RequestBody CaseSearchRequestV2 body) {

--- a/backend/dristi-services/case/src/main/java/org/pucar/dristi/web/models/CaseMeta.java
+++ b/backend/dristi-services/case/src/main/java/org/pucar/dristi/web/models/CaseMeta.java
@@ -1,0 +1,71 @@
+package org.pucar.dristi.web.models;
+
+import org.pucar.dristi.web.models.enums.LifecycleStatus;
+import org.springframework.validation.annotation.Validated;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * CaseMeta
+ *
+ * Lightweight, scalar-only projection of a court case, sourced directly from the
+ * dristi_cases table (single table, no joins) and served without Redis caching or
+ * enc-service decryption. All fields here are plaintext identifiers/metadata.
+ * Intended for internal callers that need case identifiers/scalars by filingNumber
+ * without paying the cost of the full case _search.
+ */
+@Validated
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CaseMeta {
+
+	@JsonProperty("caseId")
+	private String caseId = null;
+
+	@JsonProperty("tenantId")
+	private String tenantId = null;
+
+	@JsonProperty("filingNumber")
+	private String filingNumber = null;
+
+	@JsonProperty("courtId")
+	private String courtId = null;
+
+	@JsonProperty("courtCaseNumber")
+	private String courtCaseNumber = null;
+
+	@JsonProperty("cmpNumber")
+	private String cmpNumber = null;
+
+	@JsonProperty("lprNumber")
+	private String lprNumber = null;
+
+	@JsonProperty("cnrNumber")
+	private String cnrNumber = null;
+
+	@JsonProperty("lifecycleStatus")
+	private LifecycleStatus lifecycleStatus = null;
+
+	@JsonProperty("caseTitle")
+	private String caseTitle = null;
+
+	@JsonProperty("status")
+	private String status = null;
+
+	@JsonProperty("stage")
+	private String stage = null;
+
+	@JsonProperty("filingDate")
+	private Long filingDate = null;
+
+	@JsonProperty("registrationDate")
+	private Long registrationDate = null;
+
+}

--- a/backend/dristi-services/case/src/main/java/org/pucar/dristi/web/models/CaseMetaRequest.java
+++ b/backend/dristi-services/case/src/main/java/org/pucar/dristi/web/models/CaseMetaRequest.java
@@ -1,0 +1,42 @@
+package org.pucar.dristi.web.models;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.egov.common.contract.request.RequestInfo;
+import org.springframework.validation.annotation.Validated;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * CaseMetaRequest
+ *
+ * Batch-friendly request for the lightweight case-metadata projection. Resolves one
+ * or more filingNumbers to their scalar case metadata.
+ */
+@Validated
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CaseMetaRequest {
+
+	@JsonProperty("RequestInfo")
+	@Valid
+	private RequestInfo requestInfo = null;
+
+	@JsonProperty("tenantId")
+	private String tenantId = null;
+
+	@JsonProperty("filingNumbers")
+	@NotEmpty
+	private List<String> filingNumbers = new ArrayList<>();
+
+}

--- a/backend/dristi-services/case/src/main/java/org/pucar/dristi/web/models/CaseMetaResponse.java
+++ b/backend/dristi-services/case/src/main/java/org/pucar/dristi/web/models/CaseMetaResponse.java
@@ -1,0 +1,35 @@
+package org.pucar.dristi.web.models;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.egov.common.contract.response.ResponseInfo;
+import org.springframework.validation.annotation.Validated;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * CaseMetaResponse
+ */
+@Validated
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CaseMetaResponse {
+
+	@JsonProperty("ResponseInfo")
+	@Valid
+	private ResponseInfo responseInfo = null;
+
+	@JsonProperty("cases")
+	@Valid
+	private List<CaseMeta> cases = new ArrayList<>();
+
+}

--- a/backend/dristi-services/transformer/src/main/java/org/egov/transformer/config/TransformerProperties.java
+++ b/backend/dristi-services/transformer/src/main/java/org/egov/transformer/config/TransformerProperties.java
@@ -20,6 +20,9 @@ public class TransformerProperties {
     @Value("${egov.case.path}")
     private String caseSearchUrlEndPoint;
 
+    @Value("${egov.case.meta.path}")
+    private String caseMetaPath;
+
     @Value("${transformer.producer.save.case.topic}")
     private String saveCaseTopic;
 

--- a/backend/dristi-services/transformer/src/main/java/org/egov/transformer/models/CaseMeta.java
+++ b/backend/dristi-services/transformer/src/main/java/org/egov/transformer/models/CaseMeta.java
@@ -1,0 +1,68 @@
+package org.egov.transformer.models;
+
+import org.springframework.validation.annotation.Validated;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * CaseMeta
+ *
+ * Lightweight scalar projection of a court case returned by the case service
+ * case/v1/casemeta/_search endpoint. Sourced directly from the dristi_cases table
+ * (always fresh, no Redis, no decryption).
+ */
+@Validated
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CaseMeta {
+
+    @JsonProperty("caseId")
+    private String caseId = null;
+
+    @JsonProperty("tenantId")
+    private String tenantId = null;
+
+    @JsonProperty("filingNumber")
+    private String filingNumber = null;
+
+    @JsonProperty("courtId")
+    private String courtId = null;
+
+    @JsonProperty("courtCaseNumber")
+    private String courtCaseNumber = null;
+
+    @JsonProperty("cmpNumber")
+    private String cmpNumber = null;
+
+    @JsonProperty("lprNumber")
+    private String lprNumber = null;
+
+    @JsonProperty("cnrNumber")
+    private String cnrNumber = null;
+
+    @JsonProperty("lifecycleStatus")
+    private LifecycleStatus lifecycleStatus = null;
+
+    @JsonProperty("caseTitle")
+    private String caseTitle = null;
+
+    @JsonProperty("status")
+    private String status = null;
+
+    @JsonProperty("stage")
+    private String stage = null;
+
+    @JsonProperty("filingDate")
+    private Long filingDate = null;
+
+    @JsonProperty("registrationDate")
+    private Long registrationDate = null;
+
+}

--- a/backend/dristi-services/transformer/src/main/java/org/egov/transformer/models/CaseMetaRequest.java
+++ b/backend/dristi-services/transformer/src/main/java/org/egov/transformer/models/CaseMetaRequest.java
@@ -1,0 +1,37 @@
+package org.egov.transformer.models;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.egov.common.contract.request.RequestInfo;
+import org.springframework.validation.annotation.Validated;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * CaseMetaRequest
+ */
+@Validated
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CaseMetaRequest {
+
+    @JsonProperty("RequestInfo")
+    @Valid
+    private RequestInfo requestInfo = null;
+
+    @JsonProperty("tenantId")
+    private String tenantId = null;
+
+    @JsonProperty("filingNumbers")
+    private List<String> filingNumbers = new ArrayList<>();
+
+}

--- a/backend/dristi-services/transformer/src/main/java/org/egov/transformer/service/CaseService.java
+++ b/backend/dristi-services/transformer/src/main/java/org/egov/transformer/service/CaseService.java
@@ -1,5 +1,6 @@
 package org.egov.transformer.service;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.JsonPath;
 import lombok.extern.slf4j.Slf4j;
@@ -119,6 +120,30 @@ public class CaseService {
         } catch (Exception e) {
             log.error("Error executing case search query", e);
             throw new CustomException("Error fetching case: ", ServiceConstants.ERROR_CASE_SEARCH);
+        }
+    }
+
+    /**
+     * Lightweight scalar case-metadata lookup by filingNumber. Hits the dedicated
+     * case/v1/casemeta/_search endpoint, which reads dristi_cases directly (always fresh,
+     * no Redis, no decryption, no child-table joins). Returns null when the case is not found.
+     */
+    public CaseMeta getCaseMeta(String filingNumber, String tenantId, RequestInfo requestInfo) {
+        StringBuilder uri = new StringBuilder();
+        uri.append(properties.getCaseSearchUrlHost()).append(properties.getCaseMetaPath());
+        CaseMetaRequest request = CaseMetaRequest.builder()
+                .requestInfo(requestInfo)
+                .tenantId(tenantId)
+                .filingNumbers(Collections.singletonList(filingNumber))
+                .build();
+        try {
+            Object response = repository.fetchResult(uri, request);
+            List<CaseMeta> cases = objectMapper.convertValue(JsonPath.read(response, "$.cases"),
+                    new TypeReference<List<CaseMeta>>() {});
+            return (cases == null || cases.isEmpty()) ? null : cases.get(0);
+        } catch (Exception e) {
+            log.error("Error executing case meta query", e);
+            throw new CustomException("Error fetching case meta: ", ServiceConstants.ERROR_CASE_SEARCH);
         }
     }
 

--- a/backend/dristi-services/transformer/src/main/java/org/egov/transformer/service/HearingService.java
+++ b/backend/dristi-services/transformer/src/main/java/org/egov/transformer/service/HearingService.java
@@ -265,16 +265,20 @@ public class HearingService {
             return courtCase.getLprNumber();
         }
 
-        String caseRefNumber = hearing.getCaseReferenceNumber();
-
-        if (caseRefNumber != null && !caseRefNumber.isEmpty()) {
-            return caseRefNumber;
+        // Prefer the live court case, as hearing events can arrive stale/out-of-order and clobber
+        // a corrected case number in the open-hearing index. Fall back to the (possibly stale)
+        // value on the hearing event only when the live case has neither number.
+        String courtCaseNumber = courtCase.getCourtCaseNumber();
+        if (courtCaseNumber != null && !courtCaseNumber.isEmpty()) {
+            return courtCaseNumber;
         }
 
-        String courtCaseNumber = courtCase.getCourtCaseNumber();
-        return (courtCaseNumber != null && !courtCaseNumber.isEmpty())
-                ? courtCaseNumber
-                : courtCase.getCmpNumber();
+        String cmpNumber = courtCase.getCmpNumber();
+        if (cmpNumber != null && !cmpNumber.isEmpty()) {
+            return cmpNumber;
+        }
+
+        return hearing.getCaseReferenceNumber();
     }
 
     public void pushHearingToLegacy(HearingRequest hearingRequest) {

--- a/backend/dristi-services/transformer/src/main/java/org/egov/transformer/service/HearingService.java
+++ b/backend/dristi-services/transformer/src/main/java/org/egov/transformer/service/HearingService.java
@@ -261,7 +261,21 @@ public class HearingService {
 
     private String enrichCaseNumber(Hearing hearing, CourtCase courtCase) {
 
+        // Log the candidate values up front so that if an open hearing ends up with an unexpected
+        // case number, we can tell from the logs which source was available and which branch won.
+        log.info("Enriching open-hearing case number for hearingId: {}, filingNumber: {} | lifecycleStatus: {}, "
+                        + "lprNumber: {}, courtCaseNumber: {}, cmpNumber: {}, hearing.caseReferenceNumber: {}",
+                hearing.getHearingId(),
+                hearing.getFilingNumber() != null && !hearing.getFilingNumber().isEmpty() ? hearing.getFilingNumber().get(0) : null,
+                courtCase.getLifecycleStatus(),
+                courtCase.getLprNumber(),
+                courtCase.getCourtCaseNumber(),
+                courtCase.getCmpNumber(),
+                hearing.getCaseReferenceNumber());
+
         if (LifecycleStatus.LPR.equals(courtCase.getLifecycleStatus())) {
+            log.info("Resolved case number from lprNumber (LPR lifecycle): {}, for hearingId: {}",
+                    courtCase.getLprNumber(), hearing.getHearingId());
             return courtCase.getLprNumber();
         }
 
@@ -270,14 +284,21 @@ public class HearingService {
         // value on the hearing event only when the live case has neither number.
         String courtCaseNumber = courtCase.getCourtCaseNumber();
         if (courtCaseNumber != null && !courtCaseNumber.isEmpty()) {
+            log.info("Resolved case number from courtCaseNumber: {}, for hearingId: {}",
+                    courtCaseNumber, hearing.getHearingId());
             return courtCaseNumber;
         }
 
         String cmpNumber = courtCase.getCmpNumber();
         if (cmpNumber != null && !cmpNumber.isEmpty()) {
+            log.info("Resolved case number from cmpNumber: {}, for hearingId: {}",
+                    cmpNumber, hearing.getHearingId());
             return cmpNumber;
         }
 
+        // Live case has neither number; fall back to the (possibly stale) value on the hearing event.
+        log.warn("Live court case has no courtCaseNumber/cmpNumber; falling back to hearing.caseReferenceNumber: {}, "
+                + "for hearingId: {}", hearing.getCaseReferenceNumber(), hearing.getHearingId());
         return hearing.getCaseReferenceNumber();
     }
 

--- a/backend/dristi-services/transformer/src/main/java/org/egov/transformer/service/HearingService.java
+++ b/backend/dristi-services/transformer/src/main/java/org/egov/transformer/service/HearingService.java
@@ -88,7 +88,17 @@ public class HearingService {
         openHearing.setHearingNumber(hearing.getHearingId());
         openHearing.setFilingNumber(hearing.getFilingNumber().get(0));
         openHearing.setCaseTitle(courtCase.getCaseTitle());
-        openHearing.setCaseNumber(enrichCaseNumber(hearing, courtCase));
+        // Resolve the case number from a Redis-first metadata lookup (cache hit avoids the DB
+        // case body; miss falls back to dristi_cases) rather than the search-sourced courtCase.
+        // Kept non-fatal: a failure here must not drop the rest of the open-hearing enrichment.
+        CaseMeta caseMeta = null;
+        try {
+            caseMeta = caseService.getCaseMeta(hearing.getFilingNumber().get(0), hearing.getTenantId(), requestInfo);
+        } catch (Exception ex) {
+            log.error("Error fetching case meta for filingNumber: {}, hearingId: {}; will fall back to hearing case reference number",
+                    hearing.getFilingNumber().get(0), hearing.getHearingId(), ex);
+        }
+        openHearing.setCaseNumber(enrichCaseNumber(hearing, caseMeta));
         openHearing.setStage(courtCase.getStage());
         openHearing.setSubStage(courtCase.getSubstage());
         openHearing.setCaseUuid(courtCase.getId().toString());
@@ -259,37 +269,49 @@ public class HearingService {
 
     }
 
-    private String enrichCaseNumber(Hearing hearing, CourtCase courtCase) {
+    private String enrichCaseNumber(Hearing hearing, CaseMeta caseMeta) {
+
+        String filingNumber = hearing.getFilingNumber() != null && !hearing.getFilingNumber().isEmpty()
+                ? hearing.getFilingNumber().get(0) : null;
+
+        // caseMeta comes from the Redis-first metadata lookup. If it could not be resolved at all,
+        // fall back to the (possibly stale) value carried on the hearing event.
+        if (caseMeta == null) {
+            log.warn("No case metadata resolved (Redis/DB) for filingNumber: {}; falling back to "
+                    + "hearing.caseReferenceNumber: {}, for hearingId: {}",
+                    filingNumber, hearing.getCaseReferenceNumber(), hearing.getHearingId());
+            return hearing.getCaseReferenceNumber();
+        }
 
         // Log the candidate values up front so that if an open hearing ends up with an unexpected
         // case number, we can tell from the logs which source was available and which branch won.
         log.info("Enriching open-hearing case number for hearingId: {}, filingNumber: {} | lifecycleStatus: {}, "
                         + "lprNumber: {}, courtCaseNumber: {}, cmpNumber: {}, hearing.caseReferenceNumber: {}",
                 hearing.getHearingId(),
-                hearing.getFilingNumber() != null && !hearing.getFilingNumber().isEmpty() ? hearing.getFilingNumber().get(0) : null,
-                courtCase.getLifecycleStatus(),
-                courtCase.getLprNumber(),
-                courtCase.getCourtCaseNumber(),
-                courtCase.getCmpNumber(),
+                filingNumber,
+                caseMeta.getLifecycleStatus(),
+                caseMeta.getLprNumber(),
+                caseMeta.getCourtCaseNumber(),
+                caseMeta.getCmpNumber(),
                 hearing.getCaseReferenceNumber());
 
-        if (LifecycleStatus.LPR.equals(courtCase.getLifecycleStatus())) {
+        if (LifecycleStatus.LPR.equals(caseMeta.getLifecycleStatus())) {
             log.info("Resolved case number from lprNumber (LPR lifecycle): {}, for hearingId: {}",
-                    courtCase.getLprNumber(), hearing.getHearingId());
-            return courtCase.getLprNumber();
+                    caseMeta.getLprNumber(), hearing.getHearingId());
+            return caseMeta.getLprNumber();
         }
 
-        // Prefer the live court case, as hearing events can arrive stale/out-of-order and clobber
+        // Prefer the live case, as hearing events can arrive stale/out-of-order and clobber
         // a corrected case number in the open-hearing index. Fall back to the (possibly stale)
         // value on the hearing event only when the live case has neither number.
-        String courtCaseNumber = courtCase.getCourtCaseNumber();
+        String courtCaseNumber = caseMeta.getCourtCaseNumber();
         if (courtCaseNumber != null && !courtCaseNumber.isEmpty()) {
             log.info("Resolved case number from courtCaseNumber: {}, for hearingId: {}",
                     courtCaseNumber, hearing.getHearingId());
             return courtCaseNumber;
         }
 
-        String cmpNumber = courtCase.getCmpNumber();
+        String cmpNumber = caseMeta.getCmpNumber();
         if (cmpNumber != null && !cmpNumber.isEmpty()) {
             log.info("Resolved case number from cmpNumber: {}, for hearingId: {}",
                     cmpNumber, hearing.getHearingId());

--- a/backend/dristi-services/transformer/src/main/resources/application.properties
+++ b/backend/dristi-services/transformer/src/main/resources/application.properties
@@ -117,6 +117,7 @@ egov.wf.process.search=/egov-workflow-v2/egov-wf/process/_search
 #Case Config
 egov.case.host=http://localhost:9090/
 egov.case.path=case/v1/_search
+egov.case.meta.path=case/v1/casemeta/_search
 egov.kafka.order.save.topic=save-order-application
 case.update.kafka.topic=update-case-order-application
 # Elastic Search Config


### PR DESCRIPTION
https://github.com/pucardotorg/dristi/issues/5851

## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->


Prefer the live court case number (courtCaseNumber -> cmpNumber) over the hearing event's caseReferenceNumber when enriching open hearings. Stale/out-of-order hearing events could otherwise overwrite a corrected court case number in the open-hearing index (e.g. a late CREATE event carrying CMP clobbering ST after cognizance). Falls back to the event's caseReferenceNumber only when the live case has neither number.




## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a case metadata search API to retrieve lightweight case details by filing numbers.
  * Updated the transformer service to fetch case metadata using the configured case-meta search endpoint.
* **Bug Fixes**
  * Improved case number resolution for open hearing records by resolving the open-hearing case number via case metadata first.
  * Now prefers the latest court case number, then CMP number, and only falls back to the hearing’s stored reference when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->