### PR TITLE
feat: Case Summary PDF Generation (#5754)

### DIFF
--- a/backend/ui-integration-services/dristi-pdf/src/api.js
+++ b/backend/ui-integration-services/dristi-pdf/src/api.js
@@ -689,10 +689,34 @@ async function search_ctc_applications(
   }
 }
 
+async function search_botd_orders(tenantId, requestinfo, criteria, pagination) {
+  try {
+    return await axios({
+      method: "post",
+      url: URL.resolve(
+        config.host.orderManagement,
+        config.paths.botd_orders_search,
+      ),
+      data: {
+        RequestInfo: requestinfo,
+        criteria,
+        pagination,
+        tenantId,
+      },
+    });
+  } catch (error) {
+    logger.error(
+      `Error in ${config.paths.botd_orders_search}: ${error.message}`,
+    );
+    throw error;
+  }
+}
+
 module.exports = {
   pool,
   create_pdf,
   create_pdf_v2,
+  search_botd_orders,
   search_hrms,
   search_case,
   search_case_v2,

--- a/backend/ui-integration-services/dristi-pdf/src/app.js
+++ b/backend/ui-integration-services/dristi-pdf/src/app.js
@@ -16,6 +16,7 @@ const digitisation = require("./routes/digitisation");
 const templateConfiguration = require("./routes/templateConfiguration");
 const ctcApplications = require("./routes/ctcApplications");
 const ctcCertification = require("./routes/ctcCertification");
+const caseSummary = require("./routes/caseSummary");
 // var {listenConsumer} = require("./consumer")
 
 var app = express();
@@ -40,6 +41,7 @@ app.use(config.app.contextPath + "/digitisation", digitisation);
 app.use(config.app.contextPath + "/template-configuration", templateConfiguration); 
 app.use(config.app.contextPath + "/ctc-applications", ctcApplications);
 app.use(config.app.contextPath + "/ctc-certification", ctcCertification);
+app.use(config.app.contextPath + "/case-summary", caseSummary);
 // catch 404 and forward to error handler
 app.use(function (req, res, next) {
   next(createError(404));

--- a/backend/ui-integration-services/dristi-pdf/src/caseSummaryHandlers/caseSummary.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseSummaryHandlers/caseSummary.js
@@ -1,0 +1,157 @@
+const config = require("../config");
+const { search_case_v2, search_botd_orders, create_pdf } = require("../api");
+const { renderError } = require("../utils/renderError");
+const { handleApiCall } = require("../utils/handleApiCall");
+const {
+  getCourtAndJudgeDetails,
+  getCaseNumber,
+} = require("../utils/commonUtils");
+const { getComplaintAndAccusedList } = require("../applicationHandlers/getCaseDetails");
+const { formatDate } = require("../applicationHandlers/formatDate");
+const { logger } = require("../logger");
+
+// pdf-service fills values into a JSON string template, so free text with
+// double quotes/backslashes/control chars can break rendering. Sanitize it.
+function sanitizeText(str) {
+  if (!str) return "";
+  return str
+    .toString()
+    .replace(/\\/g, " ")
+    .replace(/"/g, "'")
+    .replace(/[\r\t]/g, " ");
+}
+
+// Convert a hearing type code (e.g. "EVIDENCE_HEARING") into a readable label.
+function toTitleCase(str) {
+  if (!str) return "";
+  return str
+    .toString()
+    .toLowerCase()
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+async function caseSummary(req, res) {
+  const tenantId = req.query.tenantId;
+  const filingNumber = req.query.filingNumber;
+  const cnrNumber = req.query.cnrNumber;
+  const courtId = req.query.courtId;
+  const requestInfo = req.body.RequestInfo;
+
+  const missingFields = [];
+  if (!tenantId) missingFields.push("tenantId");
+  if (!filingNumber) missingFields.push("filingNumber");
+  if (requestInfo === undefined) missingFields.push("requestInfo");
+
+  if (missingFields.length > 0) {
+    return renderError(
+      res,
+      `${missingFields.join(", ")} are mandatory to generate the PDF`,
+      400,
+    );
+  }
+
+  try {
+    // 1. Case details
+    const resCase = await handleApiCall(
+      res,
+      () =>
+        search_case_v2(
+          [
+            {
+              filingNumber,
+              ...(cnrNumber && { cnrNumber }),
+              ...(courtId && { courtId }),
+            },
+          ],
+          tenantId,
+          requestInfo,
+        ),
+      "Failed to query case service",
+    );
+    const courtCase = resCase?.data?.criteria?.[0]?.responseList?.[0];
+    if (!courtCase) {
+      return renderError(res, "Court case not found", 404);
+    }
+
+    // 2. Court details (for court name in the header)
+    const courtCaseJudgeDetails = await getCourtAndJudgeDetails(
+      res,
+      tenantId,
+      "Judge",
+      courtId || courtCase?.courtId,
+      requestInfo,
+    );
+    const courtName = courtCaseJudgeDetails?.mdmsCourtRoom?.courtName || "";
+
+    // 3. Party details table (complainant / accused with advocates)
+    const { complainantList, accusedList } = getComplaintAndAccusedList(
+      courtCase || {},
+    );
+
+    // 4. BoTD summaries for each published order (chronological order)
+    const resBotd = await handleApiCall(
+      res,
+      () =>
+        search_botd_orders(tenantId, requestInfo, {
+          filingNumber,
+          tenantId,
+        }),
+      "Failed to query BoTD orders",
+    );
+    const botdOrderList = resBotd?.data?.botdOrderList || [];
+    const hearings = [...botdOrderList]
+      .sort((a, b) => (a?.createdDate || 0) - (b?.createdDate || 0))
+      .map((order) => ({
+        date: order?.createdDate
+          ? formatDate(new Date(order.createdDate), "DD-MM-YYYY")
+          : "",
+        purpose: toTitleCase(order?.hearingType),
+        businessOfTheDay: sanitizeText(order?.businessOfTheDay),
+      }));
+
+    const currentDate = new Date();
+    const formattedToday = formatDate(currentDate, "DD-MM-YYYY");
+
+    const data = {
+      Data: [
+        {
+          courtName,
+          caseNumber: getCaseNumber(courtCase),
+          caseName: courtCase?.caseTitle || "",
+          date: formattedToday,
+          complainantList,
+          accusedList,
+          hearings,
+        },
+      ],
+    };
+
+    const pdfKey = config.pdf.case_summary;
+    const pdfResponse = await handleApiCall(
+      res,
+      () => create_pdf(tenantId, pdfKey, data, req.body),
+      "Failed to generate Case Summary PDF",
+    );
+    const filename = `${pdfKey}_${new Date().getTime()}`;
+    res.writeHead(200, {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": `attachment; filename=${filename}.pdf`,
+    });
+    pdfResponse.data
+      .pipe(res)
+      .on("finish", () => {
+        res.end();
+      })
+      .on("error", (err) => {
+        return renderError(res, "Failed to send PDF response", 500, err);
+      });
+  } catch (ex) {
+    logger.error(`Error in caseSummary: ${ex.message}`);
+    return renderError(res, "Failed to create Case Summary PDF", 500, ex);
+  }
+}
+
+module.exports = caseSummary;

--- a/backend/ui-integration-services/dristi-pdf/src/config.js
+++ b/backend/ui-integration-services/dristi-pdf/src/config.js
@@ -326,6 +326,7 @@ module.exports = {
     application_ctc_certification_qr:
       process.env.APPLICATION_CTC_CERTIFICATION_QR ||
       "application-ctc-certification-qr",
+    case_summary: process.env.CASE_SUMMARY || "case-summary",
   },
 
   app: {
@@ -358,6 +359,8 @@ module.exports = {
       process.env.DRISTI_DIGITALIZED_DOCUMENTS_HOST || "http://localhost:8333",
     ctcApplications:
       process.env.DRISTI_CTC_APPLICATIONS_HOST || "http://localhost:8098",
+    orderManagement:
+      process.env.DRISTI_ORDER_MANAGEMENT_HOST || "http://localhost:8092",
   },
 
   paths: {
@@ -386,6 +389,7 @@ module.exports = {
     digitalized_documents_search: "/digitalized-documents/v1/_search",
     template_configuration_search: "/template-configuration/v1/_search",
     ctc_applications_search: "/ctc/applications/_search", // TODO : verify the path
+    botd_orders_search: "/order-management/v1/getBotdOrders",
 
     // TODO : Add mdms response and role action to support folder
   },

--- a/backend/ui-integration-services/dristi-pdf/src/routes/caseSummary.js
+++ b/backend/ui-integration-services/dristi-pdf/src/routes/caseSummary.js
@@ -1,0 +1,13 @@
+const express = require("express");
+const router = express.Router();
+const asyncMiddleware = require("../utils/asyncMiddleware");
+const caseSummary = require("../caseSummaryHandlers/caseSummary");
+
+router.post(
+  "",
+  asyncMiddleware(async function (req, res) {
+    await caseSummary(req, res);
+  }),
+);
+
+module.exports = router;

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/Utils/index.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/Utils/index.js
@@ -312,6 +312,43 @@ export const downloadCombinedDocuments = async (documents, fileName = "combined-
   }
 };
 
+export const downloadCaseSummaryPdf = async ({ tenantId, filingNumber, cnrNumber, courtId, fileName = "case-summary.pdf" }) => {
+  const token = localStorage.getItem("token");
+  const userInfo = Digit.UserService.getUser()?.info;
+  const response = await axiosInstance.post(
+    "/egov-pdf/case-summary",
+    {
+      RequestInfo: {
+        authToken: token,
+        userInfo,
+        msgId: `${Date.now()}|${Digit.StoreData.getCurrentLanguage()}`,
+        apiId: "Dristi",
+      },
+    },
+    {
+      params: {
+        tenantId,
+        filingNumber,
+        ...(cnrNumber && { cnrNumber }),
+        ...(courtId && { courtId }),
+      },
+      responseType: "blob",
+      headers: {
+        "auth-token": `${token}`,
+      },
+    }
+  );
+  const blob = new Blob([response.data], { type: response.data.type || "application/pdf" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = fileName;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+};
+
 export const cleanString = (input) => {
   return input.trim().replace(/\s+/g, " ");
 };

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/ShowAllTranscriptModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/ShowAllTranscriptModal.js
@@ -1,7 +1,7 @@
 import { TextArea } from "@egovernments/digit-ui-components";
 import React, { useEffect, useState } from "react";
 import Modal from "./Modal";
-import { SubmitBar } from "@egovernments/digit-ui-react-components";
+import { Loader, SubmitBar } from "@egovernments/digit-ui-react-components";
 import { useTranslation } from "react-i18next";
 import { DateUtils, downloadCaseSummaryPdf } from "../Utils";
 import { CloseBtn } from "./ModalComponents";
@@ -11,12 +11,12 @@ const Heading = (props) => {
 };
 const ShowAllTranscriptModal = ({ setShowAllTranscript, botdOrderList, judgeView = false, filingNumber, cnrNumber, tenantId, courtId }) => {
   const { t } = useTranslation();
-  const [isDownloading, setIsDownloading] = useState(false);
+  const [loader, setLoader] = useState(false);
 
   const handleDownloadCaseSummary = async () => {
-    if (isDownloading) return;
+    if (loader) return;
     try {
-      setIsDownloading(true);
+      setLoader(true);
       await downloadCaseSummaryPdf({
         tenantId: tenantId || window?.Digit?.ULBService?.getCurrentTenantId(),
         filingNumber,
@@ -27,7 +27,7 @@ const ShowAllTranscriptModal = ({ setShowAllTranscript, botdOrderList, judgeView
     } catch (error) {
       console.error("Error downloading case summary PDF:", error);
     } finally {
-      setIsDownloading(false);
+      setLoader(false);
     }
   };
 
@@ -81,11 +81,11 @@ const ShowAllTranscriptModal = ({ setShowAllTranscript, botdOrderList, judgeView
       </div>
       <div className="submit-bar-div" style={{ display: "flex", justifyContent: "flex-end", gap: "12px" }}>
         <SubmitBar
-          variation="secondary"
+          variation="primary"
           onSubmit={handleDownloadCaseSummary}
-          className="secondary-label-btn"
-          label={isDownloading ? t("CS_DOWNLOADING") : t("CS_COMMON_DOWNLOAD")}
-          disabled={isDownloading}
+          className="primary-label-btn"
+          style={{ width: "120px" }}
+          label={t("CS_COMMON_DOWNLOAD")}
         ></SubmitBar>
         <SubmitBar
           variation="primary"
@@ -94,6 +94,25 @@ const ShowAllTranscriptModal = ({ setShowAllTranscript, botdOrderList, judgeView
           label={t("CS_COMMON_BACK")}
         ></SubmitBar>
       </div>
+      {loader && (
+        <div
+          style={{
+            width: "100vw",
+            height: "100vh",
+            zIndex: "9999",
+            position: "fixed",
+            right: "0",
+            top: "0",
+            display: "flex",
+            background: "rgb(234 234 245 / 50%)",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+          className="submit-loader"
+        >
+          <Loader />
+        </div>
+      )}
     </Modal>
   );
 };

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/ShowAllTranscriptModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/ShowAllTranscriptModal.js
@@ -1,16 +1,35 @@
 import { TextArea } from "@egovernments/digit-ui-components";
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import Modal from "./Modal";
 import { SubmitBar } from "@egovernments/digit-ui-react-components";
 import { useTranslation } from "react-i18next";
-import { DateUtils } from "../Utils";
+import { DateUtils, downloadCaseSummaryPdf } from "../Utils";
 import { CloseBtn } from "./ModalComponents";
 
 const Heading = (props) => {
   return <h1 className="heading-m">{props.heading}</h1>;
 };
-const ShowAllTranscriptModal = ({ setShowAllTranscript, botdOrderList, judgeView = false }) => {
+const ShowAllTranscriptModal = ({ setShowAllTranscript, botdOrderList, judgeView = false, filingNumber, cnrNumber, tenantId, courtId }) => {
   const { t } = useTranslation();
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  const handleDownloadCaseSummary = async () => {
+    if (isDownloading) return;
+    try {
+      setIsDownloading(true);
+      await downloadCaseSummaryPdf({
+        tenantId: tenantId || window?.Digit?.ULBService?.getCurrentTenantId(),
+        filingNumber,
+        cnrNumber,
+        courtId,
+        fileName: `case-summary-${filingNumber || ""}.pdf`,
+      });
+    } catch (error) {
+      console.error("Error downloading case summary PDF:", error);
+    } finally {
+      setIsDownloading(false);
+    }
+  };
 
   return (
     <Modal
@@ -60,7 +79,14 @@ const ShowAllTranscriptModal = ({ setShowAllTranscript, botdOrderList, judgeView
           ))
         )}
       </div>
-      <div className="submit-bar-div">
+      <div className="submit-bar-div" style={{ display: "flex", justifyContent: "flex-end", gap: "12px" }}>
+        <SubmitBar
+          variation="secondary"
+          onSubmit={handleDownloadCaseSummary}
+          className="secondary-label-btn"
+          label={isDownloading ? t("CS_DOWNLOADING") : t("CS_COMMON_DOWNLOAD")}
+          disabled={isDownloading}
+        ></SubmitBar>
         <SubmitBar
           variation="primary"
           onSubmit={() => setShowAllTranscript(false)}

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/CaseOverviewV2.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/CaseOverviewV2.js
@@ -134,7 +134,15 @@ const CaseOverviewV2 = ({
         </div>
       )}
       {showAllTranscript && (
-        <ShowAllTranscriptModal setShowAllTranscript={setShowAllTranscript} botdOrderList={previousBotdOrders} judgeView={true} />
+        <ShowAllTranscriptModal
+          setShowAllTranscript={setShowAllTranscript}
+          botdOrderList={previousBotdOrders}
+          judgeView={true}
+          filingNumber={filingNumber}
+          cnrNumber={cnrNumber}
+          tenantId={tenantId}
+          courtId={caseData?.courtId || localStorage.getItem("courtId")}
+        />
       )}
     </div>
   );

--- a/support/v1.21.0-sprint-35/deployment.md
+++ b/support/v1.21.0-sprint-35/deployment.md
@@ -1,0 +1,11 @@
+# Deployment notes - v1.21.0-sprint-35
+
+## Restarts
+need to restart egov-accesscontrol, pdf-service
+
+- egov-accesscontrol → to load the new role-actions (mdms-data/5754-role-action.json5, action 2806 `/egov-pdf/case-summary` for EMPLOYEE + CITIZEN)
+- pdf-service → to load the new `case-summary` data/format config from kerala-configs (add both file paths to DATA_CONFIG_URLS / FORMAT_CONFIG_URLS)
+
+## Config changes
+- dristi-pdf: add env `DRISTI_ORDER_MANAGEMENT_HOST=http://order-management.egov:8080`
+  (#5754 Case Summary PDF now calls order-management `/order-management/v1/getBotdOrders` for BoTD summaries)

--- a/support/v1.21.0-sprint-35/mdms-data/5754-role-action.json5
+++ b/support/v1.21.0-sprint-35/mdms-data/5754-role-action.json5
@@ -1,0 +1,41 @@
+[
+  {
+    "tenantId": "kl",
+    "schemaCode": "ACCESSCONTROL-ACTIONS-TEST.actions-test",
+    "uniqueIdentifier": "2806",
+    "data": {
+      "id": 2806,
+      "url": "/egov-pdf/case-summary",
+      "code": "2806",
+      "name": "case summary pdf",
+      "displayName": "case summary pdf"
+    },
+    "isActive": true
+  },
+  {
+    "tenantId": "kl",
+    "schemaCode": "ACCESSCONTROL-ROLEACTIONS.roleactions",
+    "uniqueIdentifier": "586",
+    "data": {
+      "id": 586,
+      "actionid": 2806,
+      "rolecode": "EMPLOYEE",
+      "tenantid": "kl",
+      "actioncode": "2806"
+    },
+    "isActive": true
+  },
+  {
+    "tenantId": "kl",
+    "schemaCode": "ACCESSCONTROL-ROLEACTIONS.roleactions",
+    "uniqueIdentifier": "587",
+    "data": {
+      "id": 587,
+      "actionid": 2806,
+      "rolecode": "CITIZEN",
+      "tenantid": "kl",
+      "actioncode": "2806"
+    },
+    "isActive": true
+  }
+]


### PR DESCRIPTION
## Summary

Adds **Case Summary PDF** generation. On the case Overview → "View All Summaries" (BoTD Summaries) modal, a new **Download** button generates a Case Summary PDF containing:
- Header (court name, case number, case title, date)
- Case-party details table (complainants/accused with advocates, offence)
- Hearing-wise **BoTD** table (date + purpose + business-of-the-day per published order)

Implementation:
- **dristi-pdf**: new `/case-summary` endpoint (`caseSummaryHandlers/caseSummary.js`, `routes/caseSummary.js`), `search_botd_orders` helper calling order-management `/order-management/v1/getBotdOrders`, and config additions (`case_summary` pdf key, `orderManagement` host, `botd_orders_search` path).
- **frontend** (dristi module): `downloadCaseSummaryPdf` util, Download button in `ShowAllTranscriptModal` (primary styling + full-screen loader), identifiers passed from `CaseOverviewV2`.
- PDF template (`case-summary` data/format config) is in the companion **kerala-configs** PR.

Verified end-to-end on DEV (200 + correct PDF for `KL-002677-2026`, via the gateway).

Addresses https://github.com/pucardotorg/dristi/issues/5754

## Data Changes

- MDMS role-action: `support/v1.21.0-sprint-35/mdms-data/5754-role-action.json5` — action `2806` `/egov-pdf/case-summary` mapped to `EMPLOYEE` + `CITIZEN`.
- Deployment steps: `support/v1.21.0-sprint-35/deployment.md`
  - Restart **egov-accesscontrol** (load new role-actions) and **pdf-service** (load new `case-summary` config; add both file paths to `DATA_CONFIG_URLS` / `FORMAT_CONFIG_URLS`).
  - **dristi-pdf** new env: `DRISTI_ORDER_MANAGEMENT_HOST=http://order-management.egov:8080`.

## Preview

Verified on DEV — generated PDF matches the finalized template (header + party table + hearing-wise BoTD). Requires the companion kerala-configs PR for the PDF template.

## Other

- **Dependency added:** dristi-pdf now calls the `order-management` service (BoTD summaries).
- **Config change:** requires `DRISTI_ORDER_MANAGEMENT_HOST` env on dristi-pdf.
- **Access control:** requires the new `/egov-pdf/case-summary` action + role mappings (see Data Changes) to be present in each environment's MDMS.
- Localization: reuses existing keys (`CS_COMMON_DOWNLOAD`, `CS_COMMON_BACK`) — no new keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added case summary PDF generation and download support from the case overview flow.
  * Users can now request and download a “Case Summary” document directly in the interface.

* **Bug Fixes**
  * Improved download handling with loading feedback and safer error handling during PDF generation.

* **Documentation**
  * Added deployment notes and configuration guidance for the new case summary flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->