### PR TITLE
fix: include advocate in current-hearing inbox fallback response

### DIFF
--- a/backend/dristi-services/hearing/src/main/java/org/pucar/dristi/service/HearingService.java
+++ b/backend/dristi-services/hearing/src/main/java/org/pucar/dristi/service/HearingService.java
@@ -742,6 +742,11 @@ public class HearingService {
         data.put("outcome", caseFields.getOrDefault("outcome", ""));
         data.put("accessCode", caseFields.getOrDefault("accessCode", ""));
         data.put("caseStatus", caseFields.getOrDefault("caseStatus", ""));
+        try {
+            data.put("advocate", objectMapper.writeValueAsString(h.getAdvocate()));
+        } catch (Exception ex) {
+            data.put("advocate", "{}");
+        }
         return data;
     }
 


### PR DESCRIPTION

## Requirements

https://github.com/pucardotorg/dristi/issues/5878

- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->


buildHearingDataMapFromOpenHearing omitted the advocate field, so on a Redis cache miss (e.g. after a Redis restart) /v1/current-hearing returned hearing data without advocate, unlike the cache-hit and ES fallback (toHearingMap) paths. Serialize h.getAdvocate() into the map to keep all three response paths consistent.



## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hearing data handling so advocate details are safely included even when serialization issues occur.
  * Prevented failures during hearing processing by falling back to a default empty value when advocate information cannot be serialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->