### PR TITLE
fix: enrich orderStatus in /cause-list API to match old inbox flow

### DIFF
--- a/backend/dristi-services/hearing/src/main/java/org/pucar/dristi/service/HearingService.java
+++ b/backend/dristi-services/hearing/src/main/java/org/pucar/dristi/service/HearingService.java
@@ -500,6 +500,9 @@ public class HearingService {
         if (!allHearings.isEmpty()) {
             boolean partialMiss = allHearings.stream().anyMatch(Map::isEmpty);
             if (!partialMiss) {
+                // Defensive default: hash entries warmed before orderStatus was added to the cache
+                // won't carry the field. Backfill NOT_CREATED so the response stays consistent.
+                allHearings.forEach(h -> h.putIfAbsent("orderStatus", OrderStatus.NOT_CREATED.toString()));
                 allHearings.sort(Comparator
                         .comparingInt((Map<String, Object> h) -> {
                             Object so = h.get("statusOrder");
@@ -556,6 +559,7 @@ public class HearingService {
         map.put("hearingUuid", h.getHearingUuid() != null ? h.getHearingUuid() : "");
         map.put("status", h.getStatus() != null ? h.getStatus() : "");
         map.put("statusOrder", h.getStatusOrder() != null ? h.getStatusOrder() : 99);
+        map.put("orderStatus", h.getOrderStatus() != null ? h.getOrderStatus().toString() : OrderStatus.NOT_CREATED.toString());
         map.put("caseNumber", h.getCaseNumber() != null ? h.getCaseNumber() : "");
         map.put("caseTitle", h.getCaseTitle() != null ? h.getCaseTitle() : "");
         map.put("hearingType", h.getHearingType() != null ? h.getHearingType() : "");

--- a/backend/dristi-services/order-management/src/main/java/pucar/config/ServiceConstants.java
+++ b/backend/dristi-services/order-management/src/main/java/pucar/config/ServiceConstants.java
@@ -57,6 +57,13 @@ public class ServiceConstants {
 
     public static final String LOCAL_DATE_FORMAT="dd-MM-yyyy";
     public static final String ESIGN_DATE_FORMAT = "dd-MMM-yyyy";
+
+    // Cause-list Redis cache key parts. MUST stay in sync with the constants used by
+    // hearing-service (ServiceConstants) and scheduler-svc that own/warm these hashes.
+    public static final String CACHE_KEY_PREFIX = "DRISTI:COURT:";
+    public static final String CACHE_HEARING_PREFIX = ":HEARING:";
+    public static final String DATE_FORMAT_REDIS = "ddMMyyyy";
+    public static final String CACHE_FIELD_ORDER_STATUS = "orderStatus";
     public static final String DATA = "data";
     public static final String OMIT_XML_DECLARATION = "omit-xml-declaration";
 

--- a/backend/dristi-services/order-management/src/main/java/pucar/util/CacheUtil.java
+++ b/backend/dristi-services/order-management/src/main/java/pucar/util/CacheUtil.java
@@ -32,6 +32,24 @@ public class CacheUtil {
         log.info("Fetching from cache with key :: {}", key);
         return redisTemplate.opsForValue().get(key);
     }
+
+    /**
+     * Updates a single field of a Redis hash, but only if the hash already exists.
+     * The cause-list hash is warmed by scheduler-svc; we never create a fresh hash here,
+     * we only keep an existing one in sync so ES remains the source of truth for absent entries.
+     */
+    public void updateHashFieldIfPresent(String key, String field, Object value) {
+        try {
+            if (Boolean.TRUE.equals(redisTemplate.hasKey(key))) {
+                redisTemplate.opsForHash().put(key, field, value);
+                log.info("Updated hash field {} for key {}", field, key);
+            } else {
+                log.info("Hash key {} not present in cache, skipping field {} update", key, field);
+            }
+        } catch (Exception e) {
+            log.error("Error updating hash field {} for key {}", field, key, e);
+        }
+    }
 }
 
 

--- a/backend/dristi-services/order-management/src/main/java/pucar/util/HearingUtil.java
+++ b/backend/dristi-services/order-management/src/main/java/pucar/util/HearingUtil.java
@@ -27,6 +27,7 @@ import pucar.web.models.hearing.*;
 import pucar.web.models.inbox.InboxRequest;
 import pucar.web.models.inbox.OpenHearing;
 
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -504,6 +505,7 @@ public class HearingUtil {
         }
         log.info("Update open hearing index with orderStatus SIGNED");
         esUtil.updateOpenHearingOrderStatus(openHearingList);
+        updateOrderStatusInCache(openHearingList);
     }
 
     public void updateOpenHearingOrderStatusForDraftOrder(Order order) {
@@ -516,6 +518,7 @@ public class HearingUtil {
         }
         log.info("Updated open hearing index with orderStatus DRAFT");
         esUtil.updateOpenHearingOrderStatus(openHearingList);
+        updateOrderStatusInCache(openHearingList);
     }
 
     public void updateOpenHearingOrderStatusForDeletedOrder(Order order) {
@@ -528,6 +531,7 @@ public class HearingUtil {
         }
         log.info("Updated open hearing index with orderStatus NOT_CREATED");
         esUtil.updateOpenHearingOrderStatus(openHearingList);
+        updateOrderStatusInCache(openHearingList);
     }
 
     public void updateOpenHearingOrderStatusForPendingSignOrder(Order order) {
@@ -540,5 +544,35 @@ public class HearingUtil {
         }
         log.info("Updated open hearing index with orderStatus PENDING_SIGN");
         esUtil.updateOpenHearingOrderStatus(openHearingList);
+        updateOrderStatusInCache(openHearingList);
+    }
+
+    /**
+     * Keeps the cause-list Redis hash in sync with the orderStatus we just wrote to ES.
+     * Only updates an already-warmed hash (scheduler-svc owns creation); otherwise ES stays
+     * the source of truth. The key is derived from the hearing's own date (fromDate), courtId
+     * and hearingNumber to match how hearing-service/scheduler-svc build it.
+     */
+    private void updateOrderStatusInCache(List<OpenHearing> openHearingList) {
+        try {
+            if (openHearingList == null || openHearingList.isEmpty()) {
+                return;
+            }
+            OpenHearing openHearing = openHearingList.get(0);
+            if (openHearing.getOrderStatus() == null || openHearing.getHearingNumber() == null
+                    || openHearing.getCourtId() == null || openHearing.getFromDate() == null) {
+                log.info("Skipping cause-list cache orderStatus update, missing key fields for hearing {}",
+                        openHearing.getHearingNumber());
+                return;
+            }
+            String date = dateUtil.getLocalDateFromEpoch(openHearing.getFromDate())
+                    .format(DateTimeFormatter.ofPattern(DATE_FORMAT_REDIS));
+            String hearingKey = CACHE_KEY_PREFIX + openHearing.getCourtId() + ":" + date
+                    + CACHE_HEARING_PREFIX + openHearing.getHearingNumber();
+            cacheUtil.updateHashFieldIfPresent(hearingKey, CACHE_FIELD_ORDER_STATUS,
+                    openHearing.getOrderStatus().toString());
+        } catch (Exception e) {
+            log.error("Failed to update orderStatus in cause-list cache", e);
+        }
     }
 }

--- a/backend/dristi-services/scheduler-svc/src/main/java/digit/service/OpenHearingService.java
+++ b/backend/dristi-services/scheduler-svc/src/main/java/digit/service/OpenHearingService.java
@@ -8,6 +8,7 @@ import digit.util.CaseUtil;
 import digit.util.DateUtil;
 import digit.util.InboxUtil;
 import digit.web.models.OpenHearing;
+import digit.web.models.OrderStatus;
 import digit.web.models.cases.CaseCriteria;
 import digit.web.models.cases.SearchCaseRequest;
 import digit.web.models.inbox.InboxRequest;
@@ -123,6 +124,7 @@ public class OpenHearingService  {
         data.put("hearingUuid", hearing.getHearingUuid() != null ? hearing.getHearingUuid() : "");
         data.put("status", hearing.getStatus() != null ? hearing.getStatus() : "");
         data.put("statusOrder", hearing.getStatusOrder() != null ? hearing.getStatusOrder() : 99);
+        data.put("orderStatus", hearing.getOrderStatus() != null ? hearing.getOrderStatus().toString() : OrderStatus.NOT_CREATED.toString());
         data.put("caseNumber", hearing.getCaseNumber() != null ? hearing.getCaseNumber() : "");
         data.put("caseTitle", hearing.getCaseTitle() != null ? hearing.getCaseTitle() : "");
         data.put("hearingType", hearing.getHearingType() != null ? hearing.getHearingType() : "");

--- a/backend/dristi-services/scheduler-svc/src/main/java/digit/util/EsUtil.java
+++ b/backend/dristi-services/scheduler-svc/src/main/java/digit/util/EsUtil.java
@@ -5,6 +5,7 @@ import com.jayway.jsonpath.JsonPath;
 import digit.config.Configuration;
 import digit.service.CacheService;
 import digit.web.models.OpenHearing;
+import digit.web.models.OrderStatus;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
@@ -99,6 +100,7 @@ public class EsUtil {
                 hearingMap.put("hearingUuid", h.getHearingUuid() != null ? h.getHearingUuid() : "");
                 hearingMap.put("status", h.getStatus() != null ? h.getStatus() : "");
                 hearingMap.put("statusOrder", h.getStatusOrder() != null ? h.getStatusOrder() : 99);
+                hearingMap.put("orderStatus", h.getOrderStatus() != null ? h.getOrderStatus().toString() : OrderStatus.NOT_CREATED.toString());
                 hearingMap.put("caseNumber", h.getCaseNumber() != null ? h.getCaseNumber() : "");
                 hearingMap.put("caseTitle", h.getCaseTitle() != null ? h.getCaseTitle() : "");
                 hearingMap.put("hearingType", h.getHearingType() != null ? h.getHearingType() : "");


### PR DESCRIPTION
The old cause-list flow read directly from the open-hearing-index via the inbox service, so orderStatus was always present and fresh. The new /cause-list API dropped it in three builders and never propagated order-management's intraday orderStatus updates to the Redis cache.

- hearing: emit orderStatus in ES-fallback toHearingMap and backfill a NOT_CREATED default on the cache-hit read path
- scheduler-svc: write orderStatus into the Redis hash at warm time (OpenHearingService + EsUtil)
- order-management: keep the cause-list cache in sync by updating the orderStatus hash field (only if the hash exists) on every order lifecycle change; adds CacheUtil.updateHashFieldIfPresent and the shared cache-key constants

## Requirements

https://github.com/pucardotorg/dristi/issues/5877

- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hearing and cause-list records now include order status in cache-backed views.
  * Cause-list cache entries are now kept in sync when order status changes.

* **Bug Fixes**
  * Missing order status values now default to “Not Created” to avoid blank or inconsistent hearing data.
  * Cache updates now only run when the related record already exists, reducing unnecessary updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->