### PR TITLE
style: move case summary Download to bottom-left download-order link (#5754)

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/ShowAllTranscriptModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/ShowAllTranscriptModal.js
@@ -79,14 +79,13 @@ const ShowAllTranscriptModal = ({ setShowAllTranscript, botdOrderList, judgeView
           ))
         )}
       </div>
-      <div className="submit-bar-div" style={{ display: "flex", justifyContent: "flex-end", gap: "12px" }}>
-        <SubmitBar
-          variation="primary"
-          onSubmit={handleDownloadCaseSummary}
-          className="primary-label-btn"
-          style={{ width: "120px" }}
-          label={t("CS_COMMON_DOWNLOAD")}
-        ></SubmitBar>
+      <div className="submit-bar-div" style={{ display: "flex", width: "100%", justifyContent: "space-between", alignItems: "center" }}>
+        <div
+          onClick={handleDownloadCaseSummary}
+          style={{ fontWeight: 700, fontSize: "16px", lineHeight: "18.75px", color: "#007E7E", cursor: "pointer" }}
+        >
+          {t("CS_COMMON_DOWNLOAD")}
+        </div>
         <SubmitBar
           variation="primary"
           onSubmit={() => setShowAllTranscript(false)}


### PR DESCRIPTION
## Requirements

- [x] This PR has a proper title that briefly describes the work done
- [x] I have referenced the github issue(s)
- [x] I performed a self-review of my own code

## Summary

Per UAT feedback on the Case Summary PDF feature (#5754), the **Download** control in the BoTD Summaries modal is restyled to match the existing `DOWNLOAD_ORDER_LINK` element.

- Previously: Download was a primary button placed next to **Back** (bottom-right).
- Now: Download is a teal (`#007E7E`) bold text-link positioned at the **bottom-left** of the modal footer, with **Back** remaining the primary button on the right (`justifyContent: "space-between"`).

Download behaviour (Case Summary PDF generation + full-screen loader) is unchanged. Only the footer layout/styling of `ShowAllTranscriptModal.js` is affected.

Addresses https://github.com/pucardotorg/dristi/issues/5754

## Preview

Verified working in the DEV environment (branch build deployed via the Common Deployment Pipeline). The Download link now renders at the bottom-left matching the requested `DOWNLOAD_ORDER_LINK` style.

## Other

- No breaking changes, no new dependencies, no MDMS/workflow/config changes.
- Reuses the existing `CS_COMMON_DOWNLOAD` localization key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the transcript modal’s bottom action area so the case summary download control is now easier to click and better aligned.
  * Updated the modal layout to display the action row with improved spacing and positioning for a cleaner experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->