### PR TITLE
fix(summons-svc): party details table for summons to witness (#5871)

### DIFF
--- a/backend/integration-services/summons-svc/src/main/java/digit/util/PdfServiceUtil.java
+++ b/backend/integration-services/summons-svc/src/main/java/digit/util/PdfServiceUtil.java
@@ -26,10 +26,15 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Base64;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static digit.config.ServiceConstants.*;
 
@@ -213,6 +218,16 @@ public class PdfServiceUtil {
                 summonsPdf.setCmpNumber(cmpNumber);
                 summonsPdf.setAccessCode(accessCode);
                 summonsPdf.setCourtCaseNumber(courtCaseNumber);
+
+                // For summons to witness, render the complainant/accused party table
+                // (instead of naming a single respondent) so multiple accused are covered.
+                if (SUMMON.equalsIgnoreCase(taskRequest.getTask().getTaskType())) {
+                    var summonDetails = taskRequest.getTask().getTaskDetails().getSummonDetails();
+                    if (summonDetails != null && WITNESS.equalsIgnoreCase(summonDetails.getDocSubType())) {
+                        summonsPdf.setComplainantList(buildComplainantList(caseDetails));
+                        summonsPdf.setAccusedList(buildAccusedList(caseDetails));
+                    }
+                }
             }
             if (qrCode && taskRequest.getTask().getDocuments() != null && !taskRequest.getTask().getDocuments().isEmpty()) {
                 List<Document> documents = taskRequest.getTask().getDocuments();
@@ -342,6 +357,98 @@ public class PdfServiceUtil {
                 .address(address)
                 .infoPdfUrl(config.getInfoPdfUrl())
                 .helplineNumber(config.getHelplineNumber())
+                .build();
+    }
+
+    private List<PartyDetail> buildComplainantList(JsonNode caseDetails) {
+        List<PartyDetail> complainantList = new ArrayList<>();
+        if (caseDetails == null) {
+            return complainantList;
+        }
+        JsonNode litigants = caseDetails.get("litigants");
+        JsonNode representatives = caseDetails.get("representatives");
+        if (litigants == null || !litigants.isArray()) {
+            return complainantList;
+        }
+        for (JsonNode litigant : litigants) {
+            String partyType = litigant.path("partyType").asText("");
+            if (partyType.contains("complainant")) {
+                complainantList.add(buildPartyDetail(litigant, representatives));
+            }
+        }
+        return complainantList;
+    }
+
+    private List<PartyDetail> buildAccusedList(JsonNode caseDetails) {
+        List<PartyDetail> accusedList = new ArrayList<>();
+        if (caseDetails == null) {
+            return accusedList;
+        }
+        JsonNode litigants = caseDetails.get("litigants");
+        JsonNode representatives = caseDetails.get("representatives");
+        Set<String> joinedIndividualIds = new HashSet<>();
+        if (litigants != null && litigants.isArray()) {
+            for (JsonNode litigant : litigants) {
+                String partyType = litigant.path("partyType").asText("");
+                if (!partyType.contains("respondent")) {
+                    continue;
+                }
+                String individualId = litigant.path("individualId").asText("");
+                if (!individualId.isEmpty()) {
+                    joinedIndividualIds.add(individualId);
+                }
+                accusedList.add(buildPartyDetail(litigant, representatives));
+            }
+        }
+        // Include accused captured in the complaint but not yet joined as litigants.
+        JsonNode respondentFormData = caseDetails.path("additionalDetails").path("respondentDetails").path("formdata");
+        if (respondentFormData.isArray()) {
+            for (JsonNode formData : respondentFormData) {
+                JsonNode data = formData.path("data");
+                String individualId = data.path("respondentVerification").path("individualDetails").path("individualId").asText("");
+                if (!individualId.isEmpty() && joinedIndividualIds.contains(individualId)) {
+                    continue;
+                }
+                String firstName = data.path("respondentFirstName").asText("");
+                String middleName = data.path("respondentMiddleName").asText("");
+                String lastName = data.path("respondentLastName").asText("");
+                String name = Stream.of(firstName, middleName, lastName)
+                        .filter(s -> s != null && !s.isBlank())
+                        .collect(Collectors.joining(" "));
+                accusedList.add(PartyDetail.builder().name(name).listOfAdvocatesRepresenting("").build());
+            }
+        }
+        return accusedList;
+    }
+
+    private PartyDetail buildPartyDetail(JsonNode litigant, JsonNode representatives) {
+        String name = litigant.path("additionalDetails").path("fullName").asText("");
+        String individualId = litigant.path("individualId").asText("");
+        List<String> advocateNames = new ArrayList<>();
+        if (representatives != null && representatives.isArray() && !individualId.isEmpty()) {
+            for (JsonNode representative : representatives) {
+                JsonNode representing = representative.get("representing");
+                if (representing == null || !representing.isArray()) {
+                    continue;
+                }
+                boolean representsLitigant = false;
+                for (JsonNode party : representing) {
+                    if (individualId.equals(party.path("individualId").asText(""))) {
+                        representsLitigant = true;
+                        break;
+                    }
+                }
+                if (representsLitigant) {
+                    String advocateName = representative.path("additionalDetails").path("advocateName").asText("");
+                    if (!advocateName.isBlank()) {
+                        advocateNames.add(advocateName);
+                    }
+                }
+            }
+        }
+        return PartyDetail.builder()
+                .name(name)
+                .listOfAdvocatesRepresenting(String.join(", ", advocateNames))
                 .build();
     }
 

--- a/backend/integration-services/summons-svc/src/main/java/digit/web/models/PartyDetail.java
+++ b/backend/integration-services/summons-svc/src/main/java/digit/web/models/PartyDetail.java
@@ -1,0 +1,25 @@
+package digit.web.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Represents a single party (complainant or accused) rendered in the
+ * summons-to-witness party details table.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class PartyDetail {
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("listOfAdvocatesRepresenting")
+    private String listOfAdvocatesRepresenting;
+
+}

--- a/backend/integration-services/summons-svc/src/main/java/digit/web/models/SummonsPdf.java
+++ b/backend/integration-services/summons-svc/src/main/java/digit/web/models/SummonsPdf.java
@@ -7,6 +7,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 
+import java.util.List;
+
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
@@ -129,5 +131,11 @@ public class SummonsPdf  {
 
     @JsonProperty("partyType")
     private String partyType;
+
+    @JsonProperty("complainantList")
+    private List<PartyDetail> complainantList;
+
+    @JsonProperty("accusedList")
+    private List<PartyDetail> accusedList;
 
 }


### PR DESCRIPTION
## Summary

Addresses https://github.com/pucardotorg/dristi/issues/5871

**Problem:** On a *summons to witness*, the accused/respondent slot printed the **witness's** name. In `PdfServiceUtil` the `respondentName` field is set to the witness for `WITNESS` doc-subtype, and the template's `WHEREAS ... {{respondentName}}` clause then named the witness where the accused should be. Reported on prod (ST/437/2025).

**Fix (court-approved):** Instead of naming a single respondent in the body, the witness-summons templates render a **party details table** (complainants + accused + representing advocates + offence), matching orders/applications, so multiple accused are covered. This PR supplies the data that table needs.

**summons-svc changes:**
- New `PartyDetail` model (`name`, `listOfAdvocatesRepresenting`).
- `SummonsPdf` gains `complainantList` and `accusedList`.
- `PdfServiceUtil` builds both lists from the case's litigants/representatives for witness summons (joined litigants + not-yet-joined accused from the complaint form data). Only populated for `SUMMON` + `WITNESS`; the `respondentName` mapping is unchanged (it still feeds the e-post delivery block, which is correctly the witness).

Paired template + data-config PR: https://github.com/pucardotorg/kerala-configs/pull/772

## Data Changes

No MDMS or workflow changes. No new gateway action (same summons endpoint). The PDF template and data-config changes live in the kerala-configs PR above; pdf-service picks them up via git-sync.

## Preview

Generated directly against pdf-service (`_createnosave`) with multi-party dummy data — both variants render the party table (multiple complainants/accused, empty-advocate handled), the new "In the above mentioned case, involving the above listed parties…" sentence, and no witness-name-in-accused-slot. `summons-witness` = 1 page, `summons-witness-e-post` = 2 pages (delivery block on p2). Confirmed working in QA via the app.

## Other

- Scope: only `summons-witness` and `summons-witness-e-post` (both rendered by summons-svc — it appends `-e-post` for the EPOST channel). QR witness variants are out of scope (different, court-un-approved layout; the WITNESS+qr path is separately mis-routed and untouched here).
- No breaking changes; no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added party details to summons-to-witness PDF content, including separate complainant and accused lists.
  * PDFs now include advocate names alongside each party entry where available.

* **Bug Fixes**
  * Improved handling of accused entries by avoiding duplicates and including additional respondent details when present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->