### PR TITLE
feat(orders): show reason for non-delivery on process view

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/css/src/dristi/pages/citizen/caseType.scss
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/css/src/dristi/pages/citizen/caseType.scss
@@ -765,6 +765,11 @@
   }
 }
 
+.application-info.wide-label-info .info-row .info-key {
+  width: 220px;
+  flex-shrink: 0;
+}
+
 .review-summon-order {
   margin: 0px;
   font-family: Roboto;

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/components/ApplicationInfoComponent.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/components/ApplicationInfoComponent.js
@@ -2,11 +2,11 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
-const ApplicationInfoComponent = ({ infos, links }) => {
+const ApplicationInfoComponent = ({ infos, links, className = "" }) => {
   const { t } = useTranslation();
   return (
     <React.Fragment>
-      <div className="application-info" style={{ flexWrap: "wrap" }}>
+      <div className={`application-info ${className}`} style={{ flexWrap: "wrap" }}>
         <div className={`info-row-wrapper ${links && links?.length > 0 ? "with-link" : ""}`}>
           {infos &&
             infos?.map((info, index) => (

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/components/ReviewNoticeModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/components/ReviewNoticeModal.js
@@ -93,7 +93,7 @@ function ReviewNoticeModal({ t, handleCloseNoticeModal, rowData, infos }) {
       actionSaveOnSubmit={() => {}}
       popupStyles={{ minWidth: "880px", width: "80%", maxHeight: "95vh" }}
     >
-      {infos && <ApplicationInfoComponent infos={infos} />}
+      {infos && <ApplicationInfoComponent infos={infos} className="wide-label-info" />}
       {showDocument}
       <div style={{ display: "flex", width: "100%", justifyContent: "space-between", alignItems: "center", marginTop: "16px" }}>
         <div

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/components/UpdateDeliveryStatusComponent.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/components/UpdateDeliveryStatusComponent.js
@@ -2,22 +2,8 @@ import { CardLabel, Dropdown, LabelFieldPair, TextInput } from "@egovernments/di
 import React, { useEffect, useState } from "react";
 import ApplicationInfoComponent from "./ApplicationInfoComponent";
 import { convertToDateInputFormat } from "../utils/index";
+import { NON_DELIVERY_REASON_OPTIONS } from "../utils/constants";
 import { sanitizeData } from "@egovernments/digit-ui-module-dristi/src/Utils";
-
-const SUMMONS_REASON_OPTIONS = [
-  { key: "ADDRESS_NOT_FOUND", value: "Address not found" },
-  { key: "DOOR_LOCKED", value: "Door locked" },
-  { key: "PERSON_NOT_PRESENT", value: "Person not present" },
-  { key: "DELIVERY_REFUSED", value: "Delivery Refused" },
-  { key: "OTHER", value: "Other" },
-];
-
-const WARRANT_REASON_OPTIONS = [
-  { key: "ACCUSED_NOT_FOUND", value: "Accused not found" },
-  { key: "SHO_SOUGHT_TIME", value: "SHO sought time" },
-  { key: "ACCUSED_ABSCONDING", value: "Accused absconding" },
-  { key: "OTHER", value: "Other" },
-];
 
 const UpdateDeliveryStatusComponent = ({
   t,
@@ -45,7 +31,7 @@ const UpdateDeliveryStatusComponent = ({
   const isIcops = rowData?.taskDetails?.deliveryChannels?.channelCode === "POLICE";
   const isRpad = rowData?.taskDetails?.deliveryChannels?.channelCode === "RPAD";
   const isSummons = (orderType || rowData?.taskType) === "SUMMONS";
-  const reasonOptions = isSummons ? SUMMONS_REASON_OPTIONS : WARRANT_REASON_OPTIONS;
+  const reasonOptions = isSummons ? NON_DELIVERY_REASON_OPTIONS.SUMMONS : NON_DELIVERY_REASON_OPTIONS.WARRANT;
   const showReasonDropdown = ["SUMMONS", "WARRANT"].includes(rowData?.taskType) && selectedDelievery?.key === "NOT_DELIVERED" && isRpad;
   const showReasonText = showReasonDropdown && selectedReason?.key === "OTHER";
 
@@ -90,7 +76,7 @@ const UpdateDeliveryStatusComponent = ({
 
       {showReasonDropdown && (
         <LabelFieldPair className="case-label-field-pair">
-          <CardLabel className="case-input-label">{`${t("Reason for Non-Delivery")} *`}</CardLabel>
+          <CardLabel className="case-input-label">{`${t("REASON_FOR_NON_DELIVERY")} *`}</CardLabel>
           <Dropdown
             t={t}
             option={reasonOptions}

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/ReviewSummonsNoticeAndWarrant.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/ReviewSummonsNoticeAndWarrant.js
@@ -21,7 +21,7 @@ import isEqual from "lodash/isEqual";
 import ReviewNoticeModal from "../../components/ReviewNoticeModal";
 import useDownloadCasePdf from "@egovernments/digit-ui-module-dristi/src/hooks/dristi/useDownloadCasePdf";
 import { DateUtils, isLPRCase, getDisplayCaseNumber } from "@egovernments/digit-ui-module-dristi/src/Utils";
-import { ORDER_TYPES, CHANNEL_IDS, DELIVERY_CHANNELS, TASK_TYPES } from "../../utils/constants";
+import { ORDER_TYPES, CHANNEL_IDS, DELIVERY_CHANNELS, TASK_TYPES, getNonDeliveryReasonLabel } from "../../utils/constants";
 import { CloseBtn, Heading } from "@egovernments/digit-ui-module-dristi/src/components/ModalComponents";
 import CustomToast from "@egovernments/digit-ui-module-dristi/src/components/CustomToast";
 import { UploadModal } from "@egovernments/digit-ui-module-common";
@@ -765,6 +765,11 @@ const ReviewSummonsNoticeAndWarrant = ({ refetchCounts }) => {
   const ReviewInfo = useMemo(() => {
     if (rowData?.taskDetails || nextHearingDate) {
       const caseDetails = handleTaskDetails(rowData?.taskDetails);
+      const nonDeliveryReasonLabel = getNonDeliveryReasonLabel(
+        rowData?.taskType,
+        caseDetails?.deliveryChannels?.notDeliveredReason,
+        caseDetails?.deliveryChannels?.notDeliveredReasonText
+      );
       return [
         { key: "ISSUE_TO", value: getPartyNameForInfos(orderDetails, compositeItem, orderType, rowData, taskType) },
         { key: "CHANNEL_DETAILS_TEXT", value: caseDetails?.deliveryChannels?.channelName },
@@ -776,10 +781,13 @@ const ReviewSummonsNoticeAndWarrant = ({ refetchCounts }) => {
         { key: "SENT_ON", value: reverseToDDMMYYYY(caseDetails?.deliveryChannels?.statusChangeDate) || "N/A" },
         { key: "STATUS", value: rowData?.status },
         { key: "STATUS_UPDATED_ON", value: reverseToDDMMYYYY(caseDetails?.deliveryChannels?.statusChangeDate) || "N/A" },
+        // Show the recorded reason for non-delivery only when one exists (RPAD summons/warrant marked NOT_DELIVERED).
+        // Reuses the same REASON_FOR_NON_DELIVERY localization key as the update-status modal.
+        ...(nonDeliveryReasonLabel ? [{ key: "REASON_FOR_NON_DELIVERY", value: nonDeliveryReasonLabel }] : []),
         { key: "REMARKS", value: caseDetails?.remarks?.remark ? caseDetails?.remarks?.remark : "N/A" },
       ];
     }
-  }, [rowData?.taskDetails, rowData?.status, nextHearingDate, orderDetails, compositeItem, orderType, taskType]);
+  }, [rowData?.taskDetails, rowData?.status, rowData?.taskType, nextHearingDate, orderDetails, compositeItem, orderType, taskType]);
 
   const links = useMemo(() => {
     return [{ text: "View order", link: "" }];

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/utils/constants.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/utils/constants.js
@@ -46,3 +46,35 @@ export const DELIVERY_CHANNELS = {
   POLICE: "Police",
   RPAD: "RPAD",
 };
+
+// Reason-for-non-delivery options, keyed by task type. Shared between the
+// "Update Delivery Status" dropdown and the read-only process info card so both
+// stay in sync (single source of truth).
+export const NON_DELIVERY_REASON_OPTIONS = {
+  SUMMONS: [
+    { key: "ADDRESS_NOT_FOUND", value: "Address not found" },
+    { key: "DOOR_LOCKED", value: "Door locked" },
+    { key: "PERSON_NOT_PRESENT", value: "Person not present" },
+    { key: "DELIVERY_REFUSED", value: "Delivery Refused" },
+    { key: "OTHER", value: "Other" },
+  ],
+  WARRANT: [
+    { key: "ACCUSED_NOT_FOUND", value: "Accused not found" },
+    { key: "SHO_SOUGHT_TIME", value: "SHO sought time" },
+    { key: "ACCUSED_ABSCONDING", value: "Accused absconding" },
+    { key: "OTHER", value: "Other" },
+  ],
+};
+
+// Resolves a stored non-delivery reason key to its display label for a given task type.
+// For the "OTHER" reason, appends the user-entered free text when present.
+export const getNonDeliveryReasonLabel = (taskType, reasonKey, reasonText) => {
+  if (!reasonKey) return "";
+  const options = NON_DELIVERY_REASON_OPTIONS[taskType] || [];
+  const matchedOption = options.find((option) => option.key === reasonKey);
+  const label = matchedOption?.value || reasonKey;
+  if (reasonKey === "OTHER" && reasonText) {
+    return `${label} - ${reasonText}`;
+  }
+  return label;
+};


### PR DESCRIPTION
## Summary

Displays the recorded **reason for non-delivery** on the process view (Summons/Warrant), addressing the follow-up requirement from the "Undelivered Reason Recording" work.

- Show the recorded non-delivery reason in the process info card (`ReviewInfo` → `ReviewNoticeModal`), rendered **before Remarks**, and **only when a reason exists** (RPAD summons/warrant marked `NOT_DELIVERED`).
- Centralize the summons/warrant reason options into a single shared source of truth — `NON_DELIVERY_REASON_OPTIONS` + `getNonDeliveryReasonLabel()` in `orders/utils/constants.js` — reused by both the update-status dropdown and the read-only display (previously duplicated inside `UpdateDeliveryStatusComponent`).
- Reuse the existing `REASON_FOR_NON_DELIVERY` localization key for the label in both the modal and the info card.
- Widen the info-card label column via a **scoped** wrapper class (`.application-info.wide-label-info`) so the longer "Reason for Non-Delivery" label does not wrap — no impact on other info cards.

Addresses https://github.com/pucardotorg/dristi/issues/5874
Related to https://github.com/pucardotorg/dristi/issues/5784

## Data Changes

None. The reason values are already persisted inside `taskDetails.deliveryChannels` (`notDeliveredReason` / `notDeliveredReasonText`) by the earlier undelivered-reason recording work.

## Files changed

- `orders/src/utils/constants.js` — shared reason options + label resolver
- `orders/src/components/UpdateDeliveryStatusComponent.js` — consume shared constant; label key
- `orders/src/pages/employee/ReviewSummonsNoticeAndWarrant.js` — reason row in `ReviewInfo`
- `orders/src/components/ApplicationInfoComponent.js` — optional `className` passthrough
- `orders/src/components/ReviewNoticeModal.js` — apply scoped wrapper class
- `css/.../caseType.scss` — scoped wider label column

## Localization

No new keys required — reuses `REASON_FOR_NON_DELIVERY` and the existing reason value strings.

## Preview

Reason for Non-Delivery now shows above Remarks on the View Summons/Warrant modal when the process was marked Not Delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved the display of non-delivery reasons for summons and warrant notices.
  * Added support for showing additional details when “Other” is selected.
  * Non-delivery reason labels are now consistently translated across forms and review screens.
  * Updated application information layouts to better accommodate wider labels without disrupting alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->