### PR TITLE
fix: case summary PDF download filename (casenumber_botd-summary)

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/ShowAllTranscriptModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/ShowAllTranscriptModal.js
@@ -9,7 +9,7 @@ import { CloseBtn } from "./ModalComponents";
 const Heading = (props) => {
   return <h1 className="heading-m">{props.heading}</h1>;
 };
-const ShowAllTranscriptModal = ({ setShowAllTranscript, botdOrderList, judgeView = false, filingNumber, cnrNumber, tenantId, courtId }) => {
+const ShowAllTranscriptModal = ({ setShowAllTranscript, botdOrderList, judgeView = false, filingNumber, caseNumber, cnrNumber, tenantId, courtId }) => {
   const { t } = useTranslation();
   const [loader, setLoader] = useState(false);
 
@@ -22,7 +22,7 @@ const ShowAllTranscriptModal = ({ setShowAllTranscript, botdOrderList, judgeView
         filingNumber,
         cnrNumber,
         courtId,
-        fileName: `case-summary-${filingNumber || ""}.pdf`,
+        fileName: `${(caseNumber || filingNumber || "Case").replace(/\//g, "_")}_botd-summary.pdf`,
       });
     } catch (error) {
       console.error("Error downloading case summary PDF:", error);

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/CaseOverviewV2.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/CaseOverviewV2.js
@@ -139,6 +139,13 @@ const CaseOverviewV2 = ({
           botdOrderList={previousBotdOrders}
           judgeView={true}
           filingNumber={filingNumber}
+          caseNumber={
+            caseData?.courtCaseNumber ||
+            caseData?.cmpNumber ||
+            caseDetails?.courtCaseNumber ||
+            caseDetails?.cmpNumber ||
+            filingNumber
+          }
           cnrNumber={cnrNumber}
           tenantId={tenantId}
           courtId={caseData?.courtId || localStorage.getItem("courtId")}


### PR DESCRIPTION
## Summary

Updates the "View All Summaries" case-summary PDF download to use the **case number** instead of the filing number, following the reviewer's requested naming convention `casenumber_botd-summary`.

- `CaseOverviewV2.js` — passes a new `caseNumber` prop (`courtCaseNumber || cmpNumber || filingNumber`, matching the Download Order pattern) to `ShowAllTranscriptModal`.
- `ShowAllTranscriptModal.js` — builds the download filename as `<caseNumber>_botd-summary.pdf`, replacing `/` with `_` (e.g. `ST/188/2026` → `ST_188_2026_botd-summary.pdf`).

Addresses https://github.com/pucardotorg/dristi/issues/5754

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Case summary PDFs now use the case number when available, with improved filename formatting.
  * Added a fallback to filing number when a case number is unavailable.
  * Downloaded summaries now include a clearer BotD summary suffix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->