### PR TITLE
feat: rename BoTD summaries to B-Diary in case overview (#5754) [main cherry-pick]

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/ShowAllTranscriptModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/components/ShowAllTranscriptModal.js
@@ -22,7 +22,7 @@ const ShowAllTranscriptModal = ({ setShowAllTranscript, botdOrderList, judgeView
         filingNumber,
         cnrNumber,
         courtId,
-        fileName: `${(caseNumber || filingNumber || "Case").replace(/\//g, "_")}_botd-summary.pdf`,
+        fileName: `${(caseNumber || filingNumber || "Case").replace(/\//g, "_")}_BDiary.pdf`,
       });
     } catch (error) {
       console.error("Error downloading case summary PDF:", error);
@@ -33,7 +33,7 @@ const ShowAllTranscriptModal = ({ setShowAllTranscript, botdOrderList, judgeView
 
   return (
     <Modal
-      headerBarMain={<Heading heading={judgeView ? t("BOTD_SUMMARIES") : t("ALL_BOTD_TRANSCRIPT")} />}
+      headerBarMain={<Heading heading={t("CS_BDIARY")} />}
       headerBarEnd={<CloseBtn onClick={() => setShowAllTranscript(false)} />}
       actionCancelLabel={null}
       actionCancelOnSubmit={() => {}}

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/CaseOverviewV2.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/AdmittedCases/CaseOverviewV2.js
@@ -83,7 +83,7 @@ const CaseOverviewV2 = ({
                   style={{ color: "#007E7E", cursor: "pointer", fontWeight: 700, fontSize: "16px", lineHeight: "18.75px" }}
                   onClick={() => setShowAllTranscript(true)}
                 >
-                  {t("VIEW_ALL_SUMMARIES")}
+                  {t("VIEW_BDIARY")}
                 </div>
               </div>
               <hr style={{ borderTop: "1px solid #E8E8E8", margin: "10px -15px 0px -15px" }} />


### PR DESCRIPTION
## Requirements

- [x] This PR has a proper title that briefly describes the work done
- [x] I have referenced the github issue(s)
- [x] I performed a self-review of my own code

## Summary

Cherry-pick to `main` of the B-Diary rename from #5754 (develop PR #6860):

- **Modal title** → "B-Diary" (new localization key `CS_BDIARY`).
- **Case Summary download filename** → `<caseNumber>_BDiary.pdf`.
- **"View All Summaries"** card link → "View B-Diary" (new localization key `VIEW_BDIARY`).

Download control style unchanged (existing teal link kept for cross-app consistency). Localization values for `CS_BDIARY` / `VIEW_BDIARY` upserted to environments separately.

Cherry-pick for https://github.com/pucardotorg/dristi/issues/5754

## Preview

UI text only: modal title "B-Diary", card link "View B-Diary", downloaded file `<caseNumber>_BDiary.pdf`.

## Other

No breaking changes, no new dependencies, no MDMS/workflow/config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
