### PR TITLE
[enhance 5866]: added non-delivery reasons in for other processes type also

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/components/UpdateDeliveryStatusComponent.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/components/UpdateDeliveryStatusComponent.js
@@ -30,9 +30,9 @@ const UpdateDeliveryStatusComponent = ({
 
   const isIcops = rowData?.taskDetails?.deliveryChannels?.channelCode === "POLICE";
   const isRpad = rowData?.taskDetails?.deliveryChannels?.channelCode === "RPAD";
-  const isSummons = (orderType || rowData?.taskType) === "SUMMONS";
-  const reasonOptions = isSummons ? NON_DELIVERY_REASON_OPTIONS.SUMMONS : NON_DELIVERY_REASON_OPTIONS.WARRANT;
-  const showReasonDropdown = ["SUMMONS", "WARRANT"].includes(rowData?.taskType) && selectedDelievery?.key === "NOT_DELIVERED" && isRpad;
+  const isWarrant = rowData?.taskType === "WARRANT";
+  const reasonOptions = isWarrant ? NON_DELIVERY_REASON_OPTIONS.WARRANT : NON_DELIVERY_REASON_OPTIONS.SUMMONS;
+  const showReasonDropdown = selectedDelievery?.key === "NOT_DELIVERED" && isRpad;
   const showReasonText = showReasonDropdown && selectedReason?.key === "OTHER";
 
   const deliveryOptions = [

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/ReviewSummonsNoticeAndWarrant.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/orders/src/pages/employee/ReviewSummonsNoticeAndWarrant.js
@@ -842,7 +842,7 @@ const ReviewSummonsNoticeAndWarrant = ({ refetchCounts }) => {
                   ? updateStatusDate
                   : convertToDateInputFormat(rowData?.taskDetails?.deliveryChannels?.statusChangeDate),
                 ...(selectedDelievery?.key === "NOT_DELIVERED" &&
-                  rowData?.taskDetails?.deliveryChannels?.channelCode !== "POLICE" &&
+                  rowData?.taskDetails?.deliveryChannels?.channelCode === "RPAD" &&
                   selectedReason?.key && {
                     notDeliveredReason: selectedReason.key,
                     notDeliveredReasonText: reasonText,


### PR DESCRIPTION
https://github.com/pucardotorg/dristi/issues/5866
## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved non-delivery reason handling for warrant and summons tasks.
  * The reason dropdown now appears only when a delivery is marked “Not Delivered” through the RPAD channel.
  * Delivery updates now include non-delivery reason details only for applicable RPAD deliveries, ensuring more accurate status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->