### PR TITLE
fix: update assignedRole handling for RESCHEDULE_REQUEST in MainHomeScreen

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/configs/UICustomizations.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/configs/UICustomizations.js
@@ -2111,14 +2111,17 @@ export const UICustomizations = {
       const currentDateInMs = new Date().setHours(23, 59, 59, 999);
       const selectedDateInMs = new Date(requestCriteria?.state?.searchForm?.date).setHours(23, 59, 59, 999);
       const activeTab = additionalDetails?.activeTab;
+      const { assignedRole, ...restModuleSearchCriteria } = requestCriteria?.body?.SearchCriteria?.moduleSearchCriteria || {};
       return {
         ...requestCriteria,
         body: {
           SearchCriteria: {
             ...requestCriteria.body.SearchCriteria,
             moduleSearchCriteria: {
-              ...requestCriteria?.body?.SearchCriteria?.moduleSearchCriteria,
+              ...restModuleSearchCriteria,
               courtId: localStorage.getItem("courtId"),
+              // keep assignedRole for all tabs except RESCHEDULE_REQUEST, where it must be omitted entirely
+              ...(activeTab !== "RESCHEDULE_REQUEST" && { assignedRole }),
             },
             searchReviewProcess: {
               date: activeTab === "REVIEW_PROCESS" ? selectedDateInMs : currentDateInMs,

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/MainHomeScreen.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/MainHomeScreen.js
@@ -703,7 +703,6 @@ const MainHomeScreen = () => {
             isCompleted: false,
             courtId: localStorage.getItem("courtId"),
             assignedRole: assignedRoles,
-            ...(activeTab !== "RESCHEDULE_REQUEST" ? { assignedRole: assignedRoles } : {}),
           },
           limit: 10,
           offset: 0,
@@ -1549,7 +1548,7 @@ const MainHomeScreen = () => {
                 screenType: ["home", "applicationCompositeOrder"],
                 isCompleted: false,
                 courtId: localStorage.getItem("courtId"),
-                ...(activeTab !== "RESCHEDULE_REQUEST" ? { assignedRole: assignedRoles } : {}),
+                assignedRole: assignedRoles,
               },
               searchScrutinyCases: {
                 date: null,


### PR DESCRIPTION
https://github.com/pucardotorg/dristi/issues/5904

## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pending-task searches and counts across home-screen tabs.
  * Reschedule requests now return accurate results without applying an unintended assigned-role filter.
  * Preserved assigned-role filtering for other pending-task tabs to maintain accurate task visibility and totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->