### PR TITLE
added validation for refApplicationId in order

### DIFF
--- a/backend/dristi-services/order-management/src/main/java/pucar/service/BSSService.java
+++ b/backend/dristi-services/order-management/src/main/java/pucar/service/BSSService.java
@@ -264,6 +264,7 @@ public class BSSService {
                             .requestInfo(request.getRequestInfo())
                             .order(order).build();
 
+                    orderProcessor.validateOrder(orderUpdateRequest);
                     orderProcessor.preProcessOrder(orderUpdateRequest);
 
                     if (order.getNextHearingDate() != null) {

--- a/backend/dristi-services/order-management/src/main/java/pucar/service/CompositeOrderService.java
+++ b/backend/dristi-services/order-management/src/main/java/pucar/service/CompositeOrderService.java
@@ -37,6 +37,14 @@ public class CompositeOrderService implements OrderProcessor {
     }
 
     @Override
+    public void validateOrder(OrderRequest request) {
+        Order order = request.getOrder();
+        for (Order compositeOrderItem : getItemListFormCompositeItem(order)) {
+            orderUtil.validateRefApplicationId(compositeOrderItem);
+        }
+    }
+
+    @Override
     public void preProcessOrder(OrderRequest orderRequest) {
 
         Order order = orderRequest.getOrder();

--- a/backend/dristi-services/order-management/src/main/java/pucar/service/IntermediateOrderService.java
+++ b/backend/dristi-services/order-management/src/main/java/pucar/service/IntermediateOrderService.java
@@ -4,6 +4,7 @@ package pucar.service;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import pucar.util.OrderUtil;
 import pucar.web.models.OrderRequest;
 import pucar.web.models.adiary.CaseDiaryEntry;
 
@@ -14,10 +15,17 @@ import java.util.List;
 public class IntermediateOrderService implements OrderProcessor {
 
     private final OrderStrategyExecutor orderStrategyExecutor;
+    private final OrderUtil orderUtil;
 
     @Autowired
-    public IntermediateOrderService(OrderStrategyExecutor orderStrategyExecutor) {
+    public IntermediateOrderService(OrderStrategyExecutor orderStrategyExecutor, OrderUtil orderUtil) {
         this.orderStrategyExecutor = orderStrategyExecutor;
+        this.orderUtil = orderUtil;
+    }
+
+    @Override
+    public void validateOrder(OrderRequest request) {
+        orderUtil.validateRefApplicationId(request.getOrder());
     }
 
     @Override

--- a/backend/dristi-services/order-management/src/main/java/pucar/service/OrderProcessor.java
+++ b/backend/dristi-services/order-management/src/main/java/pucar/service/OrderProcessor.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 public interface OrderProcessor {
 
+    void validateOrder(OrderRequest request);
     void preProcessOrder(OrderRequest request);
     void postProcessOrder(OrderRequest request);
     List<CaseDiaryEntry> processCommonItems(OrderRequest request);

--- a/backend/dristi-services/order-management/src/main/java/pucar/service/OrderService.java
+++ b/backend/dristi-services/order-management/src/main/java/pucar/service/OrderService.java
@@ -109,6 +109,7 @@ public class OrderService {
         OrderFactory orderFactory = factoryProvider.getFactory(order.getOrderCategory());
         OrderProcessor orderProcessor = orderFactory.createProcessor();
 
+        orderProcessor.validateOrder(request);
         orderProcessor.preProcessOrder(request);
 
         if (E_SIGN.equalsIgnoreCase(request.getOrder().getWorkflow().getAction()) && request.getOrder().getNextHearingDate() != null) {
@@ -294,6 +295,7 @@ public class OrderService {
         request.setOrder(orderResponse.getOrder());
 
         // TODO : this is temporary solution need to have proper implementation
+        orderProcessor.validateOrder(request);
         orderProcessor.preProcessOrder(request);
 
         return orderResponse.getOrder();

--- a/backend/dristi-services/order-management/src/main/java/pucar/util/OrderUtil.java
+++ b/backend/dristi-services/order-management/src/main/java/pucar/util/OrderUtil.java
@@ -129,6 +129,18 @@ public class OrderUtil {
 
     }
 
+    public void validateRefApplicationId(Order order) {
+        String orderType = order.getOrderType();
+        String action = order.getWorkflow() != null ? order.getWorkflow().getAction() : null;
+
+        if (E_SIGN.equalsIgnoreCase(action) && APPROVE_VOLUNTARY_SUBMISSIONS.equalsIgnoreCase(orderType)) {
+            String refApplicationId = getReferenceId(order);
+            if (refApplicationId == null || refApplicationId.isBlank()) {
+                throw new CustomException("REF_APPLICATION_ID_NOT_FOUND", "refApplicationId is required in additionalDetails.formdata for order type: " + orderType);
+            }
+        }
+    }
+
     public String getHearingNumberFormApplicationAdditionalDetails(Object additionalDetails) {
         return Optional.ofNullable(additionalDetails)
                 .filter(Map.class::isInstance)

--- a/backend/dristi-services/order-management/src/main/java/pucar/util/OrderUtil.java
+++ b/backend/dristi-services/order-management/src/main/java/pucar/util/OrderUtil.java
@@ -130,7 +130,7 @@ public class OrderUtil {
     }
 
     private static final Set<String> ORDER_TYPES_REQUIRING_REF_APPLICATION = Set.of(SET_BAIL_TERMS, RESCHEDULE_OF_HEARING_DATE, CHECKOUT_ACCEPTANCE, ASSIGNING_DATE_RESCHEDULED_HEARING,
-            INITIATING_RESCHEDULING_OF_HEARING_DATE);
+            INITIATING_RESCHEDULING_OF_HEARING_DATE, APPROVE_VOLUNTARY_SUBMISSIONS);
 
     public void validateRefApplicationId(Order order) {
         String orderType = order.getOrderType();

--- a/backend/dristi-services/order-management/src/main/java/pucar/util/OrderUtil.java
+++ b/backend/dristi-services/order-management/src/main/java/pucar/util/OrderUtil.java
@@ -129,14 +129,18 @@ public class OrderUtil {
 
     }
 
+    private static final Set<String> ORDER_TYPES_REQUIRING_REF_APPLICATION = Set.of(SET_BAIL_TERMS, RESCHEDULE_OF_HEARING_DATE, CHECKOUT_ACCEPTANCE, ASSIGNING_DATE_RESCHEDULED_HEARING,
+            INITIATING_RESCHEDULING_OF_HEARING_DATE);
+
     public void validateRefApplicationId(Order order) {
         String orderType = order.getOrderType();
         String action = order.getWorkflow() != null ? order.getWorkflow().getAction() : null;
 
-        if (E_SIGN.equalsIgnoreCase(action) && APPROVE_VOLUNTARY_SUBMISSIONS.equalsIgnoreCase(orderType)) {
+        if (E_SIGN.equalsIgnoreCase(action) && ORDER_TYPES_REQUIRING_REF_APPLICATION.contains(orderType)) {
             String refApplicationId = getReferenceId(order);
             if (refApplicationId == null || refApplicationId.isBlank()) {
-                throw new CustomException("REF_APPLICATION_ID_NOT_FOUND", "refApplicationId is required in additionalDetails.formdata for order type: " + orderType);
+                log.error("refApplicationId is required in additionalDetails.formdata for order: {}", order);
+                throw new CustomException("REF_APPLICATION_ID_NOT_FOUND", "Please remove the "+orderType+" item and add again");
             }
         }
     }

--- a/backend/dristi-services/order-management/src/test/java/pucar/util/OrderUtilTest.java
+++ b/backend/dristi-services/order-management/src/test/java/pucar/util/OrderUtilTest.java
@@ -2,7 +2,6 @@ package pucar.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.egov.tracer.model.CustomException;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -14,10 +13,12 @@ import pucar.web.models.*;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+import static pucar.config.ServiceConstants.*;
 
 @ExtendWith(MockitoExtension.class)
 class OrderUtilTest {
@@ -34,22 +35,105 @@ class OrderUtilTest {
     @InjectMocks
     private OrderUtil orderUtil;
 
-    @BeforeEach
-    void setUp() {
-        when(configuration.getOrderHost()).thenReturn("http://order-service");
-        when(configuration.getOrderExistsEndPoint()).thenReturn("/order/exists");
-        when(configuration.getOrderUpdateEndPoint()).thenReturn("/order/update");
-        when(configuration.getOrderSearchEndPoint()).thenReturn("/order/search");
-    }
-
     @Test
     void testFetchOrderDetails_Exception() {
+        when(configuration.getOrderHost()).thenReturn("http://order-service");
+        when(configuration.getOrderExistsEndPoint()).thenReturn("/order/exists");
+
         OrderExistsRequest request = new OrderExistsRequest();
         String url = "http://order-service/order/exists";
 
         when(serviceRequestRepository.fetchResult(new StringBuilder(url), request)).thenThrow(new RuntimeException("Service error"));
 
         assertThrows(CustomException.class, () -> orderUtil.fetchOrderDetails(request));
+    }
+
+    private static final List<String> ORDER_TYPES_REQUIRING_REF_APPLICATION = List.of(
+            SET_BAIL_TERMS, RESCHEDULE_OF_HEARING_DATE, CHECKOUT_ACCEPTANCE,
+            ASSIGNING_DATE_RESCHEDULED_HEARING, INITIATING_RESCHEDULING_OF_HEARING_DATE);
+
+    private Order buildOrder(String orderType, String action, String refApplicationId) {
+        WorkflowObject workflow = null;
+        if (action != null) {
+            workflow = new WorkflowObject();
+            workflow.setAction(action);
+        }
+
+        Object additionalDetails = null;
+        if (refApplicationId != null) {
+            Map<String, Object> formdata = new HashMap<>();
+            formdata.put("refApplicationId", refApplicationId);
+            Map<String, Object> details = new HashMap<>();
+            details.put("formdata", formdata);
+            additionalDetails = details;
+        }
+
+        return Order.builder()
+                .orderType(orderType)
+                .workflow(workflow)
+                .additionalDetails(additionalDetails)
+                .build();
+    }
+
+    @Test
+    void testValidateRefApplicationId_ValidRefApplicationId_DoesNotThrowForEachRequiredOrderType() {
+        for (String orderType : ORDER_TYPES_REQUIRING_REF_APPLICATION) {
+            Order order = buildOrder(orderType, E_SIGN, "APP-123");
+            assertDoesNotThrow(() -> orderUtil.validateRefApplicationId(order),
+                    "Did not expect exception for order type: " + orderType);
+        }
+    }
+
+    @Test
+    void testValidateRefApplicationId_MissingRefApplicationId_ThrowsForEachRequiredOrderType() {
+        for (String orderType : ORDER_TYPES_REQUIRING_REF_APPLICATION) {
+            Order order = buildOrder(orderType, E_SIGN, null);
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> orderUtil.validateRefApplicationId(order),
+                    "Expected exception for order type: " + orderType);
+            assertTrue(exception.getMessage().contains(orderType));
+        }
+    }
+
+    @Test
+    void testValidateRefApplicationId_BlankRefApplicationId_Throws() {
+        Order order = buildOrder(SET_BAIL_TERMS, E_SIGN, "   ");
+
+        CustomException exception = assertThrows(CustomException.class,
+                () -> orderUtil.validateRefApplicationId(order));
+        assertEquals("REF_APPLICATION_ID_NOT_FOUND", exception.getCode());
+        assertTrue(exception.getMessage().contains(SET_BAIL_TERMS));
+    }
+
+    @Test
+    void testValidateRefApplicationId_NullAdditionalDetails_Throws() {
+        Order order = buildOrder(SET_BAIL_TERMS, E_SIGN, null);
+
+        CustomException exception = assertThrows(CustomException.class,
+                () -> orderUtil.validateRefApplicationId(order));
+        assertEquals("REF_APPLICATION_ID_NOT_FOUND", exception.getCode());
+    }
+
+    @Test
+    void testValidateRefApplicationId_NonEsignAction_DoesNotThrow() {
+        Order order = buildOrder(SET_BAIL_TERMS, "SAVE_DRAFT", null);
+
+        assertDoesNotThrow(() -> orderUtil.validateRefApplicationId(order));
+    }
+
+    @Test
+    void testValidateRefApplicationId_NullWorkflow_DoesNotThrow() {
+        Order order = buildOrder(SET_BAIL_TERMS, null, null);
+
+        assertDoesNotThrow(() -> orderUtil.validateRefApplicationId(order));
+    }
+
+    @Test
+    void testValidateRefApplicationId_OrderTypeNotInRequiredSet_DoesNotThrow() {
+        // APPROVE_VOLUNTARY_SUBMISSIONS is no longer part of ORDER_TYPES_REQUIRING_REF_APPLICATION
+        Order order = buildOrder(APPROVE_VOLUNTARY_SUBMISSIONS, E_SIGN, null);
+
+        assertDoesNotThrow(() -> orderUtil.validateRefApplicationId(order));
     }
 
 }

--- a/backend/dristi-services/order-management/src/test/java/pucar/util/OrderUtilTest.java
+++ b/backend/dristi-services/order-management/src/test/java/pucar/util/OrderUtilTest.java
@@ -50,7 +50,7 @@ class OrderUtilTest {
 
     private static final List<String> ORDER_TYPES_REQUIRING_REF_APPLICATION = List.of(
             SET_BAIL_TERMS, RESCHEDULE_OF_HEARING_DATE, CHECKOUT_ACCEPTANCE,
-            ASSIGNING_DATE_RESCHEDULED_HEARING, INITIATING_RESCHEDULING_OF_HEARING_DATE);
+            ASSIGNING_DATE_RESCHEDULED_HEARING, INITIATING_RESCHEDULING_OF_HEARING_DATE,APPROVE_VOLUNTARY_SUBMISSIONS);
 
     private Order buildOrder(String orderType, String action, String refApplicationId) {
         WorkflowObject workflow = null;
@@ -124,14 +124,6 @@ class OrderUtilTest {
     @Test
     void testValidateRefApplicationId_NullWorkflow_DoesNotThrow() {
         Order order = buildOrder(SET_BAIL_TERMS, null, null);
-
-        assertDoesNotThrow(() -> orderUtil.validateRefApplicationId(order));
-    }
-
-    @Test
-    void testValidateRefApplicationId_OrderTypeNotInRequiredSet_DoesNotThrow() {
-        // APPROVE_VOLUNTARY_SUBMISSIONS is no longer part of ORDER_TYPES_REQUIRING_REF_APPLICATION
-        Order order = buildOrder(APPROVE_VOLUNTARY_SUBMISSIONS, E_SIGN, null);
 
         assertDoesNotThrow(() -> orderUtil.validateRefApplicationId(order));
     }


### PR DESCRIPTION
## Requirements



- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->


Added validation for null refApplicationId to resctrict court to pass that order- Issue -https://github.com/pucardotorg/dristi/issues/5887




## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an explicit validation step to require a reference application ID for applicable e-sign workflows.
  * Validation is now triggered during both order updates and item additions, including signed-order flows.
  * Composite orders validate the reference application ID for each eligible sub-order.
* **Bug Fixes**
  * Eligible submissions no longer continue when the required reference application ID is missing or blank; a clear error is returned instead.
* **Tests**
  * Expanded unit tests to cover valid, missing/blank, and null data scenarios for the new reference application ID validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->