### PR TITLE
fix: contain tab content scrolling in home view (cherry-pick)

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/css/src/home/home.scss
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/css/src/home/home.scss
@@ -1411,6 +1411,16 @@
     scrollbar-width: thin;
     scrollbar-color: #c5c5c5 #f9fafb;
   }
+  /* Tabs rendered directly (Review Applications, Scrutinise Cases) have no
+     scroll wrapper of their own, so long tables scroll the whole page and the
+     sidebar scrolls out of view. Direct-child selector keeps the nested
+     .bulk-esign-order-view in the Sign views from becoming a second scroll area. */
+  > .bulk-esign-order-view {
+    max-height: calc(100vh - 84px);
+    overflow-y: auto;
+    scrollbar-width: thin;
+    scrollbar-color: #c5c5c5 #f9fafb;
+  }
   .inbox-search-wrapper {
     .inbox-search-component-wrapper {
       .sections-parent {


### PR DESCRIPTION
## Summary

Cherry-pick of #6881 onto `main`.

Tabs rendered directly in the home view (**Review Applications**, **Scrutinise Cases**) had no scroll wrapper of their own, so long tables scrolled the whole page and the sidebar scrolled out of view.

Adds a direct-child scroll container (`> .bulk-esign-order-view`) capped at `calc(100vh - 84px)`. The direct-child selector is deliberate: it keeps the *nested* `.bulk-esign-order-view` in the Sign views from becoming a second scroll area.

CSS-only change, scoped to `home.scss`. Cherry-picked cleanly with no conflicts.

## Test plan

- [ ] Review Applications tab: long table scrolls within the content area, sidebar stays fixed
- [ ] Scrutinise Cases tab: same
- [ ] Sign views (bulk e-sign): still a single scroll area, no nested double scrollbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)