### PR TITLE
fix: let bail bond document previews use full width

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/css/src/submissions/submissionApplication.scss
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/css/src/submissions/submissionApplication.scss
@@ -720,6 +720,10 @@
     overflow: auto;
     border-radius: 8px;
     background: #fafafa;
+
+    .doc-card {
+      max-width: 100%;
+    }
   }
 
   .litigant-details {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/components/BailBondReviewModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/components/BailBondReviewModal.js
@@ -127,7 +127,7 @@ const BailBondReviewModal = ({
       >
         <div className="review-submission-appl-body-main">
           <div className="application-details">
-            <div className="application-view">
+            <div className="application-view doc-preview">
               {showDocument}
               {bailBondPreviewPdf &&
                 documents?.map((docs) => (


### PR DESCRIPTION
## Summary

Document previews in the bail bond flows rendered narrower than the space available to them. Two adjustments:

- **`submissionApplication.scss`** — allow `.doc-card` inside `.doc-viewer` to span the full container width (`max-width: 100%`). `doc-card` is the `docViewerCardClassName` used by the bail bond / witness deposition / digitized document signature pages.
- **`BailBondReviewModal.js`** — add the existing `.doc-preview` class to the document panel, reusing the shared width override already defined in `home/components/reviewCard.scss` (globally imported via `css/src/index.scss`).

Small change; one line of JSX plus a three-line SCSS rule.

## Note for reviewers

The shared `.doc-preview` rule also applies `border: 1px solid #bbbb` to the doc card, so the review modal picks up a border it did not previously have. That is intended to match the other preview surfaces — worth a glance during review.

## Test plan

- [ ] Bail bond review modal: document preview fills the panel width, border looks correct
- [ ] Bail bond signature page: doc card spans the viewer width
- [ ] Witness deposition / digitized document signature pages: no regression in preview width

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document previews in the bail bond review modal.
  * Ensured document cards fit within the available preview area without overflowing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->