### PR TITLE
fix: let bail bond document previews use full width (cherry-pick)

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/css/src/submissions/submissionApplication.scss
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/css/src/submissions/submissionApplication.scss
@@ -720,6 +720,10 @@
     overflow: auto;
     border-radius: 8px;
     background: #fafafa;
+
+    .doc-card {
+      max-width: 100%;
+    }
   }
 
   .litigant-details {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/components/BailBondReviewModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/components/BailBondReviewModal.js
@@ -127,7 +127,7 @@ const BailBondReviewModal = ({
       >
         <div className="review-submission-appl-body-main">
           <div className="application-details">
-            <div className="application-view">
+            <div className="application-view doc-preview">
               {showDocument}
               {bailBondPreviewPdf &&
                 documents?.map((docs) => (


### PR DESCRIPTION
## Summary

Cherry-pick of #6890 onto `main`.

Document previews in the bail bond flows rendered narrower than the space available to them. Two adjustments:

- **`submissionApplication.scss`** — allow `.doc-card` inside `.doc-viewer` to span the full container width (`max-width: 100%`).
- **`BailBondReviewModal.js`** — add the existing `.doc-preview` class to the document panel, reusing the shared width override in `home/components/reviewCard.scss`.

Cherry-picked cleanly with no conflicts.

## Note for reviewers

The shared `.doc-preview` rule also applies `border: 1px solid #bbbb` to the doc card, so the review modal picks up a border it did not previously have. Intended, but worth a glance.

## Test plan

- [ ] Bail bond review modal: document preview fills the panel width, border looks correct
- [ ] Bail bond signature page: doc card spans the viewer width
- [ ] Witness deposition / digitized document signature pages: no regression in preview width

🤖 Generated with [Claude Code](https://claude.com/claude-code)