### PR TITLE
fix: make bail bond sign modal PDF fill full width

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/BailBondSignModal.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/BailBondSignModal.js
@@ -439,7 +439,7 @@ export const BailBondSignModal = ({
         >
           <div className="review-submission-appl-body-main">
             <div className="application-details">
-              <div className="application-view">{bailBondLoader ? <Loader /> : <React.Fragment>{MemoizedDocViewers}</React.Fragment>}</div>
+              <div className="application-view doc-preview">{bailBondLoader ? <Loader /> : <React.Fragment>{MemoizedDocViewers}</React.Fragment>}</div>
             </div>
           </div>
         </Modal>


### PR DESCRIPTION
## Summary

Follow-up to #6890, which fixed the bail bond document previews in `BailBondReviewModal` and the bail bond signature page. The same issue remained in `BailBondSignModal` (the sign-bail-bond modal), where the PDF still rendered at only part of the modal width.

Root cause is the same: `DocViewerWrapper` renders its viewer inside a DIGIT `<Card>`, and the base stylesheet caps `.card` at `max-width: 960px`. That cap applies regardless of the `docWidth="100%"` prop, so the PDF stayed pinned to 960px inside a much wider modal.

Fix: add the existing `doc-preview` class alongside `application-view`, matching `DigitalDocumentSignModal` (the Mediation form modal), which already renders full width. `doc-preview` overrides the inner card `max-width` to `100%`.

No stylesheet changes — `doc-preview` already exists in `reviewCard.scss`.

## Changes

- `BailBondSignModal.js` — `application-view` -> `application-view doc-preview`

## Testing

Verified locally: the bail bond PDF now fills the modal width, matching the Mediation form modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved styling and layout for the bail bond document preview during loading and viewing states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->