### PR TITLE
feat: add pagination navigator to top of Today's Hearings table

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/css/src/home/home.scss
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/css/src/home/home.scss
@@ -2412,6 +2412,11 @@
   }
 }
 
+.table-pagination.table-pagination-top {
+  padding: 8px 8px;
+  border-bottom: 1px solid #e8e8e8;
+}
+
 .pending-envelope-submission-modal {
   .popup-module-main {
     .popup-module-action-bar {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/HomeHearingsTab.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/HomeHearingsTab.js
@@ -649,6 +649,73 @@ const HomeHearingsTab = ({
 
   const { data: hearingLink } = useGetHearingLink();
 
+  const renderPagination = () => (
+    <div className="pagination-info">
+      <span style={{ color: "#505a5f" }}>Rows per page:</span>
+      <select
+        value={rowsPerPage}
+        onChange={(e) => {
+          setRowsPerPage(Number(e.target.value));
+          setPage(0);
+        }}
+      >
+        {[10, 20, 30, 40, 50].map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+      </select>
+
+      <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
+        <span style={{ color: "#505a5f" }}>
+          {hearingCount === 0 ? "0 of 0" : `${page * rowsPerPage + 1}–${Math.min((page + 1) * rowsPerPage, hearingCount)} of ${hearingCount}`}
+        </span>
+
+        {page > 0 && (
+          <button
+            style={{
+              background: "transparent",
+              border: "none",
+              fontSize: "16px",
+              cursor: "pointer",
+              padding: 0,
+              margin: 0,
+              display: "flex",
+              alignItems: "center",
+            }}
+            onClick={() => setPage((prev) => prev - 1)}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#505a5f" class="cp" width="18px" height="18px">
+              <path d="M0 0h24v24H0z" fill="none"></path>
+              <path d="M11.67 3.87L9.9 2.1 0 12l9.9 9.9 1.77-1.77L3.54 12z"></path>
+            </svg>
+          </button>
+        )}
+
+        {(page + 1) * rowsPerPage < hearingCount && (
+          <button
+            style={{
+              background: "transparent",
+              border: "none",
+              fontSize: "16px",
+              cursor: "pointer",
+              padding: 0,
+              margin: 0,
+              display: "flex",
+              alignItems: "center",
+            }}
+            onClick={() => setPage((prev) => prev + 1)}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#505a5f" width="18px" height="18px">
+              <path d="M0 0h24v24H0z" fill="none" />
+              <path d="M5.88 4.12 13.76 12l-7.88 7.88L8 22l10-10L8 2z" />
+            </svg>
+          </button>
+        )}
+      </div>
+    </div>
+  );
+
   if (isEpostUser) {
     history.push(homePath);
   }
@@ -821,6 +888,7 @@ const HomeHearingsTab = ({
         </div>
       </div>
       <div className="main-table-card">
+        <div className="table-pagination table-pagination-top">{renderPagination()}</div>
         <div className="table-scroll">
           <table className="main-table">
             <thead>
@@ -852,72 +920,7 @@ const HomeHearingsTab = ({
               )}
             </tbody>
           </table>
-          <div className="table-pagination">
-            <div className="pagination-info">
-              <span style={{ color: "#505a5f" }}>Rows per page:</span>
-              <select
-                value={rowsPerPage}
-                onChange={(e) => {
-                  setRowsPerPage(Number(e.target.value));
-                  setPage(0);
-                }}
-              >
-                {[10, 20, 30, 40, 50].map((option) => (
-                  <option key={option} value={option}>
-                    {option}
-                  </option>
-                ))}
-              </select>
-
-              <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
-                <span style={{ color: "#505a5f" }}>
-                  {hearingCount === 0 ? "0 of 0" : `${page * rowsPerPage + 1}–${Math.min((page + 1) * rowsPerPage, hearingCount)} of ${hearingCount}`}
-                </span>
-
-                {page > 0 && (
-                  <button
-                    style={{
-                      background: "transparent",
-                      border: "none",
-                      fontSize: "16px",
-                      cursor: "pointer",
-                      padding: 0,
-                      margin: 0,
-                      display: "flex",
-                      alignItems: "center",
-                    }}
-                    onClick={() => setPage((prev) => prev - 1)}
-                  >
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#505a5f" class="cp" width="18px" height="18px">
-                      <path d="M0 0h24v24H0z" fill="none"></path>
-                      <path d="M11.67 3.87L9.9 2.1 0 12l9.9 9.9 1.77-1.77L3.54 12z"></path>
-                    </svg>
-                  </button>
-                )}
-
-                {(page + 1) * rowsPerPage < hearingCount && (
-                  <button
-                    style={{
-                      background: "transparent",
-                      border: "none",
-                      fontSize: "16px",
-                      cursor: "pointer",
-                      padding: 0,
-                      margin: 0,
-                      display: "flex",
-                      alignItems: "center",
-                    }}
-                    onClick={() => setPage((prev) => prev + 1)}
-                  >
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#505a5f" width="18px" height="18px">
-                      <path d="M0 0h24v24H0z" fill="none" />
-                      <path d="M5.88 4.12 13.76 12l-7.88 7.88L8 22l10-10L8 2z" />
-                    </svg>
-                  </button>
-                )}
-              </div>
-            </div>
-          </div>
+          <div className="table-pagination">{renderPagination()}</div>
         </div>
       </div>
       {showEndHearingModal.openEndHearingModal && (


### PR DESCRIPTION
## Summary

Replicates the page-view navigator (rows-per-page selector + page count + prev/next arrows) — currently only at the **bottom** of the Today's Hearings ("All Hearings") table — at the **top** of the table as well, per court-staff request.

Addresses https://github.com/pucardotorg/dristi/issues/5922

## Changes

- **`HomeHearingsTab.js`** — extracted the pagination markup into a single `renderPagination()` helper (removes ~65 lines of duplication) and rendered it both above and below the table. Both copies share the same `page` / `rowsPerPage` / `hearingCount` state and handlers, so they stay in sync.
- **`home.scss`** — added a `.table-pagination-top` modifier (tighter padding + bottom border) so the top copy reads as a header strip; it inherits `justify-content: flex-end`, so it right-aligns above the table.

## Scope

Per the discussion on the ticket (standup decision), this change is intentionally confined to the **Today's Hearings** page only — it does not touch the shared `InboxSearchComposer` component used elsewhere.

## Notes

- The top navigator sits above the scroll container (which has a sticky table header), so it remains visible while the list scrolls.
- No data-layer / API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination controls above and below the hearings table.
  * Added distinct styling for the top pagination controls, including spacing and a separating border.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->