### PR TITLE
Cherry-pick to main: QA-completed tickets ready for UAT release (Jul 29)

### DIFF
--- a/backend/dristi-services/case/src/main/java/org/pucar/dristi/config/Configuration.java
+++ b/backend/dristi-services/case/src/main/java/org/pucar/dristi/config/Configuration.java
@@ -158,6 +158,9 @@ public class Configuration {
 	@Value("${case.kafka.edit.topic}")
 	private String caseEditTopic;
 
+	@Value("${egov.case.register.evidence.topic}")
+	private String registerEvidenceTopic;
+
 	@Value("${witness.kafka.create.topic}")
 	private String witnessCreateTopic;
 

--- a/backend/dristi-services/case/src/main/java/org/pucar/dristi/config/ServiceConstants.java
+++ b/backend/dristi-services/case/src/main/java/org/pucar/dristi/config/ServiceConstants.java
@@ -3,6 +3,8 @@ package org.pucar.dristi.config;
 import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
 
 @Component
 public class ServiceConstants {
@@ -267,6 +269,81 @@ public class ServiceConstants {
     public static final String FILING = "FILING";
     public static final String LP = "LP";
     public static final String POA_JOIN_CASE = "poaJoinCase";
+
+    // Registration bulk evidence creation
+    public static final String CASE_OWNER_FILING_STATUS = "caseOwner";
+    public static final String TYPE_DEPOSITION = "TYPE DEPOSITION";
+    public static final String CASE_FILING = "CASE_FILING";
+
+    // JSON field names on caseDetails / additionalDetails
+    public static final String FORMDATA = "formdata";
+    public static final String DATA = "data";
+    public static final String DOCUMENT = "document";
+    public static final String UUID_KEY = "uuid";
+
+    // Evidence artifact types (VAKALATNAMA_DOC declared above)
+    public static final String BOUNCED_CHEQUE = "BOUNCED_CHEQUE";
+    public static final String PROOF_OF_DEPOSIT_OF_CHEQUE = "PROOF_OF_DEPOSIT_OF_CHEQUE";
+    public static final String RETURN_MEMO = "RETURN_MEMO";
+    public static final String DEBT_LIABILITY = "DEBT_LIABILITY";
+    public static final String DEMAND_NOTICE = "DEMAND_NOTICE";
+    public static final String PROOF_OF_ACK_OF_LEGAL_NOTICE = "PROOF_OF_ACK_OF_LEGAL_NOTICE";
+    public static final String PROOF_OF_DISPATCH_OF_LEGAL_NOTICE = "PROOF_OF_DISPATCH_OF_LEGAL_NOTICE";
+    public static final String PROOF_OF_REPLY_TO_LEGAL_NOTICE = "PROOF_OF_REPLY_TO_LEGAL_NOTICE";
+    public static final String SWORN_STATEMENT = "SWORN_STATEMENT";
+    public static final String AFFIDAVIT_UNDER_225 = "AFFIDAVIT_UNDER_225";
+    public static final String COMPLAINANT_PIP_AFFIDAVIT = "COMPLAINANT_PIP_AFFIDAVIT";
+
+    // e-filing upload keys
+    public static final String BOUNCED_CHEQUE_FILE_UPLOAD = "bouncedChequeFileUpload";
+    public static final String DEPOSIT_CHEQUE_FILE_UPLOAD = "depositChequeFileUpload";
+    public static final String RETURN_MEMO_FILE_UPLOAD = "returnMemoFileUpload";
+    public static final String DEBT_LIABILITY_FILE_UPLOAD = "debtLiabilityFileUpload";
+    public static final String LEGAL_DEMAND_NOTICE_FILE_UPLOAD = "legalDemandNoticeFileUpload";
+    public static final String PROOF_OF_ACKNOWLEDGMENT_FILE_UPLOAD = "proofOfAcknowledgmentFileUpload";
+    public static final String PROOF_OF_DISPATCH_FILE_UPLOAD = "proofOfDispatchFileUpload";
+    public static final String PROOF_OF_REPLY_FILE_UPLOAD = "proofOfReplyFileUpload";
+    public static final String SWORN_STATEMENT_KEY = "swornStatement";
+    public static final String INQUIRY_AFFIDAVIT_FILE_UPLOAD = "inquiryAffidavitFileUpload";
+    public static final String VAKALATNAMA_FILE_UPLOAD = "vakalatnamaFileUpload";
+    public static final String PIP_AFFIDAVIT_FILE_UPLOAD = "pipAffidavitFileUpload";
+
+    // caseDetails / additionalDetails section names
+    public static final String CHEQUE_DETAILS = "chequeDetails";
+    public static final String DEBT_LIABILITY_DETAILS = "debtLiabilityDetails";
+    public static final String DEMAND_NOTICE_DETAILS = "demandNoticeDetails";
+    public static final String PRAYER_SWORN_STATEMENT = "prayerSwornStatement";
+    public static final String RESPONDENT_DETAILS = "respondentDetails";
+
+    // e-filing upload key -> evidence artifactType
+    public static final Map<String, String> REGISTRATION_DOC_TYPE_MAPPING = Map.ofEntries(
+            Map.entry(BOUNCED_CHEQUE_FILE_UPLOAD, BOUNCED_CHEQUE),
+            Map.entry(DEPOSIT_CHEQUE_FILE_UPLOAD, PROOF_OF_DEPOSIT_OF_CHEQUE),
+            Map.entry(RETURN_MEMO_FILE_UPLOAD, RETURN_MEMO),
+            Map.entry(DEBT_LIABILITY_FILE_UPLOAD, DEBT_LIABILITY),
+            Map.entry(LEGAL_DEMAND_NOTICE_FILE_UPLOAD, DEMAND_NOTICE),
+            Map.entry(PROOF_OF_ACKNOWLEDGMENT_FILE_UPLOAD, PROOF_OF_ACK_OF_LEGAL_NOTICE),
+            Map.entry(PROOF_OF_DISPATCH_FILE_UPLOAD, PROOF_OF_DISPATCH_OF_LEGAL_NOTICE),
+            Map.entry(PROOF_OF_REPLY_FILE_UPLOAD, PROOF_OF_REPLY_TO_LEGAL_NOTICE),
+            Map.entry(SWORN_STATEMENT_KEY, SWORN_STATEMENT),
+            Map.entry(INQUIRY_AFFIDAVIT_FILE_UPLOAD, AFFIDAVIT_UNDER_225),
+            Map.entry(VAKALATNAMA_FILE_UPLOAD, VAKALATNAMA_DOC),
+            Map.entry(PIP_AFFIDAVIT_FILE_UPLOAD, COMPLAINANT_PIP_AFFIDAVIT)
+    );
+
+    // caseDetails section -> upload keys under formdata[].data
+    public static final Map<String, List<String>> CASE_DETAILS_EVIDENCE_SECTIONS = Map.of(
+            CHEQUE_DETAILS, List.of(BOUNCED_CHEQUE_FILE_UPLOAD, DEPOSIT_CHEQUE_FILE_UPLOAD, RETURN_MEMO_FILE_UPLOAD),
+            DEBT_LIABILITY_DETAILS, List.of(DEBT_LIABILITY_FILE_UPLOAD),
+            DEMAND_NOTICE_DETAILS, List.of(LEGAL_DEMAND_NOTICE_FILE_UPLOAD, PROOF_OF_ACKNOWLEDGMENT_FILE_UPLOAD, PROOF_OF_DISPATCH_FILE_UPLOAD, PROOF_OF_REPLY_FILE_UPLOAD)
+    );
+
+    // additionalDetails section -> upload keys under formdata[].data
+    public static final Map<String, List<String>> ADDITIONAL_DETAILS_EVIDENCE_SECTIONS = Map.of(
+            PRAYER_SWORN_STATEMENT, List.of(SWORN_STATEMENT_KEY),
+            RESPONDENT_DETAILS, List.of(INQUIRY_AFFIDAVIT_FILE_UPLOAD)
+    );
+
     private ServiceConstants() {
     }
 }

--- a/backend/dristi-services/case/src/main/java/org/pucar/dristi/kafka/CaseUpdateConsumer.java
+++ b/backend/dristi-services/case/src/main/java/org/pucar/dristi/kafka/CaseUpdateConsumer.java
@@ -6,6 +6,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.egov.tracer.model.CustomException;
 import org.pucar.dristi.service.CaseService;
 import org.pucar.dristi.service.PaymentUpdateService;
+import org.pucar.dristi.web.models.CaseRequest;
 import org.pucar.dristi.web.models.CourtCase;
 import org.pucar.dristi.web.models.analytics.CaseOutcome;
 import org.pucar.dristi.web.models.analytics.CaseOverallStatus;
@@ -90,6 +91,17 @@ public class CaseUpdateConsumer {
             caseService.updateJoinCaseRejected(taskRequest);
         } catch (CustomException e) {
             logger.info("Error while listening to join case reject on topic ; {}: ", topic, e);
+        }
+    }
+
+    @KafkaListener(topics = {"${egov.case.register.evidence.topic}"})
+    public void createRegistrationEvidences(ConsumerRecord<String, Object> payload, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
+        try {
+            logger.info("Received case register evidence request on topic : {} ", topic);
+            CaseRequest caseRequest = objectMapper.convertValue(payload.value(), CaseRequest.class);
+            caseService.createRegistrationEvidences(caseRequest);
+        } catch (final Exception e) {
+            logger.error("Error while listening to case register evidence on topic : {}: ", topic, e);
         }
     }
 

--- a/backend/dristi-services/case/src/main/java/org/pucar/dristi/service/CaseService.java
+++ b/backend/dristi-services/case/src/main/java/org/pucar/dristi/service/CaseService.java
@@ -602,6 +602,8 @@ public class CaseService {
                 caseRequest.getCases().setCaseType(CMP);
                 updateCaseConversion(caseRequest);
                 producer.push(config.getCaseReferenceUpdateTopic(), createHearingUpdateRequest(caseRequest));
+                // On successful registration, asynchronously create one evidence artifact per e-filed document.
+                producer.push(config.getRegisterEvidenceTopic(), caseRequest);
             }
             //todo: enhance for files delete
             removeInactiveDocuments(documentToDelete, caseRequest.getCases().getTenantId());
@@ -2645,6 +2647,172 @@ public class CaseService {
             evidenceUtil.createEvidence(evidenceRequest);
 
         }
+    }
+
+    /**
+     * Creates one evidence artifact for every complainant-side document e-filed for the case, triggered
+     * asynchronously when a case is registered (PENDING_REGISTRATION -> PENDING_RESPONSE via the REGISTER action).
+     * Each document failure is isolated so one bad document does not block the rest.
+     */
+    public void createRegistrationEvidences(CaseRequest caseRequest) {
+        CourtCase courtCase = caseRequest.getCases();
+        RequestInfo requestInfo = caseRequest.getRequestInfo();
+        try {
+            log.info("Method=createRegistrationEvidences, Result=IN_PROGRESS, CaseId={}", courtCase.getId());
+
+            String sourceId = resolveComplainantIndividualId(courtCase, requestInfo);
+            String asUser = resolveEfilingCreatorMainUser(courtCase);
+
+            List<RegistrationEvidenceDocument> documents = collectRegistrationDocuments(courtCase);
+
+            for (RegistrationEvidenceDocument evidenceDocument : documents) {
+                Document document = evidenceDocument.document();
+                try {
+                    if (evidenceValidator.validateEvidenceCreate(courtCase, requestInfo, Collections.singletonList(document))) {
+                        log.info("Evidence already exists for fileStore={}, skipping", document.getFileStore());
+                        continue;
+                    }
+                    evidenceUtil.createEvidence(buildRegistrationEvidenceRequest(courtCase, requestInfo, evidenceDocument, sourceId, asUser));
+                } catch (Exception e) {
+                    log.error("Error creating registration evidence for fileStore={}, artifactType={}", document.getFileStore(), evidenceDocument.artifactType(), e);
+                }
+            }
+            log.info("Method=createRegistrationEvidences, Result=SUCCESS, CaseId={}", courtCase.getId());
+        } catch (Exception e) {
+            log.error("Error in createRegistrationEvidences for CaseId={}", courtCase.getId(), e);
+        }
+    }
+
+    private String resolveComplainantIndividualId(CourtCase courtCase, RequestInfo requestInfo) {
+        try {
+            String createdBy = Optional.ofNullable(courtCase.getAuditdetails()).map(AuditDetails::getCreatedBy).orElse(null);
+            if (createdBy == null) {
+                return null;
+            }
+            List<Individual> individuals = individualService.getIndividuals(requestInfo, Collections.singletonList(createdBy));
+            if (individuals != null && !individuals.isEmpty()) {
+                return individuals.get(0).getIndividualId();
+            }
+        } catch (Exception e) {
+            log.error("Error resolving complainant individualId for registration evidence, CaseId={}", courtCase.getId(), e);
+        }
+        return null;
+    }
+
+    private String resolveEfilingCreatorMainUser(CourtCase courtCase) {
+        // If an advocate office (advocate or its jr. advocate/clerk) created the case, use the case-owner advocate's uuid.
+        if (courtCase.getRepresentatives() != null) {
+            for (AdvocateMapping representative : courtCase.getRepresentatives()) {
+                if (CASE_OWNER_FILING_STATUS.equalsIgnoreCase(representative.getAdvocateFilingStatus()) && representative.getAdditionalDetails() != null) {
+                    JsonNode uuidNode = objectMapper.convertValue(representative.getAdditionalDetails(), JsonNode.class).path(UUID_KEY);
+                    if (!uuidNode.isMissingNode() && !uuidNode.isNull()) {
+                        return uuidNode.asText();
+                    }
+                }
+            }
+        }
+        // else the complainant created the case: use the creator's uuid.
+        return Optional.ofNullable(courtCase.getAuditdetails()).map(AuditDetails::getCreatedBy).orElse(null);
+    }
+
+    private List<RegistrationEvidenceDocument> collectRegistrationDocuments(CourtCase courtCase) {
+        List<RegistrationEvidenceDocument> result = new ArrayList<>();
+
+        JsonNode caseDetails = courtCase.getCaseDetails() == null ? null : objectMapper.convertValue(courtCase.getCaseDetails(), JsonNode.class);
+        collectFromFormdataSections(caseDetails, CASE_DETAILS_EVIDENCE_SECTIONS, result);
+
+        JsonNode additionalDetails = courtCase.getAdditionalDetails() == null ? null : objectMapper.convertValue(courtCase.getAdditionalDetails(), JsonNode.class);
+        collectFromFormdataSections(additionalDetails, ADDITIONAL_DETAILS_EVIDENCE_SECTIONS, result);
+
+        collectAdvocateBlockDocuments(courtCase, result);
+
+        return result;
+    }
+
+    private void collectFromFormdataSections(JsonNode root, Map<String, List<String>> sections, List<RegistrationEvidenceDocument> result) {
+        if (root == null || root.isMissingNode()) {
+            return;
+        }
+        for (Map.Entry<String, List<String>> section : sections.entrySet()) {
+            JsonNode formdata = root.path(section.getKey()).path(FORMDATA);
+            if (!formdata.isArray()) {
+                continue;
+            }
+            for (JsonNode form : formdata) {
+                JsonNode data = form.path(DATA);
+                for (String key : section.getValue()) {
+                    addJsonDocuments(data.path(key).path(DOCUMENT), key, result);
+                }
+            }
+        }
+    }
+
+    private void addJsonDocuments(JsonNode documentsNode, String key, List<RegistrationEvidenceDocument> result) {
+        String artifactType = REGISTRATION_DOC_TYPE_MAPPING.get(key);
+        if (artifactType == null || documentsNode == null || documentsNode.isMissingNode()) {
+            return;
+        }
+        if (documentsNode.isArray()) {
+            for (JsonNode docNode : documentsNode) {
+                addRegistrationDocument(objectMapper.convertValue(docNode, Document.class), artifactType, result);
+            }
+        } else if (documentsNode.isObject()) {
+            addRegistrationDocument(objectMapper.convertValue(documentsNode, Document.class), artifactType, result);
+        }
+    }
+
+    private void collectAdvocateBlockDocuments(CourtCase courtCase, List<RegistrationEvidenceDocument> result) {
+        if (courtCase.getAdvocateDetailBlock() == null) {
+            return;
+        }
+        for (AdvocateDetailBlock block : courtCase.getAdvocateDetailBlock()) {
+            if (block == null || block.getDocuments() == null) {
+                continue;
+            }
+            Documents documents = block.getDocuments();
+            List<Document> vakalatnama = documents.getVakalatnama();
+            List<Document> pipAffidavit = documents.getPipAffidavit();
+            // frontend parity: prefer vakalatnama, fall back to PIP affidavit
+            if (vakalatnama != null && !vakalatnama.isEmpty()) {
+                vakalatnama.forEach(document -> addRegistrationDocument(document, VAKALATNAMA_DOC, result));
+            } else if (pipAffidavit != null && !pipAffidavit.isEmpty()) {
+                pipAffidavit.forEach(document -> addRegistrationDocument(document, COMPLAINANT_PIP_AFFIDAVIT, result));
+            }
+        }
+    }
+
+    private void addRegistrationDocument(Document document, String artifactType, List<RegistrationEvidenceDocument> result) {
+        if (artifactType != null && document != null && document.getFileStore() != null) {
+            result.add(new RegistrationEvidenceDocument(document, artifactType));
+        }
+    }
+
+    private EvidenceRequest buildRegistrationEvidenceRequest(CourtCase courtCase, RequestInfo requestInfo, RegistrationEvidenceDocument evidenceDocument, String sourceId, String asUser) {
+        Document document = evidenceDocument.document();
+        org.egov.common.contract.models.Document workflowDocument = objectMapper.convertValue(document, org.egov.common.contract.models.Document.class);
+
+        WorkflowObject workflowObject = new WorkflowObject();
+        workflowObject.setAction(TYPE_DEPOSITION);
+        workflowObject.setDocuments(Collections.singletonList(workflowDocument));
+
+        return EvidenceRequest.builder()
+                .requestInfo(requestInfo)
+                .artifact(Artifact.builder()
+                        .artifactType(evidenceDocument.artifactType())
+                        .sourceType(COMPLAINANT)
+                        .sourceID(sourceId)
+                        .asUser(asUser)
+                        .caseId(courtCase.getId().toString())
+                        .filingNumber(courtCase.getFilingNumber())
+                        .cnrNumber(courtCase.getCnrNumber())
+                        .tenantId(courtCase.getTenantId())
+                        .filingType(CASE_FILING)
+                        .comments(new ArrayList<>())
+                        .isEvidence(false)
+                        .file(document)
+                        .workflow(workflowObject)
+                        .build())
+                .build();
     }
 
     private Object modifyAdditionalDetails(RequestInfo requestInfo, CourtCase courtCase, RepresentingJoinCase representingJoinCase, JoinCaseRepresentative joinCaseRepresentative) {

--- a/backend/dristi-services/case/src/main/java/org/pucar/dristi/web/models/RegistrationEvidenceDocument.java
+++ b/backend/dristi-services/case/src/main/java/org/pucar/dristi/web/models/RegistrationEvidenceDocument.java
@@ -1,0 +1,8 @@
+package org.pucar.dristi.web.models;
+
+/**
+ * Internal holder pairing an e-filed {@link Document} with the evidence artifactType it should be
+ * created as during case registration (see CaseService.createRegistrationEvidences).
+ */
+public record RegistrationEvidenceDocument(Document document, String artifactType) {
+}

--- a/backend/dristi-services/case/src/main/resources/application.properties
+++ b/backend/dristi-services/case/src/main/resources/application.properties
@@ -149,6 +149,7 @@ egov.case.overall.status.topic.v2=case-overall-status-topic-v2
 egov.case.outcome.topic=case-outcome-topic
 task.join.case.approved.topic=join-case-approved-state
 task.join.case.rejected.topic=join-case-rejected-state
+egov.case.register.evidence.topic=case-register-evidence
 
 witness.kafka.update.topic=update-witness-application
 witness.kafka.create.topic=save-witness-application

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processAccusedEvidence.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processAccusedEvidence.js
@@ -1,9 +1,15 @@
 const { search_evidence_v2 } = require("../../api");
-const { filterCaseBundleBySection } = require("../utils/filterCaseBundleBySection");
+const {
+  filterCaseBundleBySection,
+} = require("../utils/filterCaseBundleBySection");
 const { applyDocketToDocument } = require("../utils/applyDocketToDocument");
-const { duplicateExistingFileStore } = require("../utils/duplicateExistingFileStore");
+const {
+  duplicateExistingFileStore,
+} = require("../utils/duplicateExistingFileStore");
 const { getDynamicSectionNumber } = require("../utils/getDynamicSectionNumber");
-const { combineMultipleFilestores } = require("../utils/combineMultipleFilestores");
+const {
+  combineMultipleFilestores,
+} = require("../utils/combineMultipleFilestores");
 const { logger } = require("../../logger");
 
 async function processAccusedEvidence(
@@ -13,26 +19,28 @@ async function processAccusedEvidence(
   requestInfo,
   TEMP_FILES_DIR,
   indexCopy,
-  messagesMap
+  messagesMap,
 ) {
-  logger.info(`[processAccusedEvidence] Started | filingNumber: ${courtCase?.filingNumber}`);
+  logger.info(
+    `[processAccusedEvidence] Started | filingNumber: ${courtCase?.filingNumber}`,
+  );
   const complainantDepositionSection = filterCaseBundleBySection(
     caseBundleMaster,
-    "accusedevidencedepositions"
+    "accusedevidencedepositions",
   );
 
   const accusedEvidenceSection = filterCaseBundleBySection(
     caseBundleMaster,
-    "accusedevidence"
+    "accusedevidence",
   );
 
   const sectionPosition = indexCopy.sections?.findIndex(
-    (s) => s.name === "accusedevidence"
+    (s) => s.name === "accusedevidence",
   );
 
   const dynamicSectionNumber = getDynamicSectionNumber(
     indexCopy,
-    sectionPosition
+    sectionPosition,
   );
 
   const accusedEvidenceLineItems = [];
@@ -53,12 +61,12 @@ async function processAccusedEvidence(
         sortBy: complainantDepositionSection[0].sorton,
         order: "asc",
         limit: 100,
-      }
+      },
     );
 
     const courtList = courtDocs?.data?.artifacts?.filter(
       (artifact) =>
-        artifact?.additionalDetails?.witnessDetails?.ownerType === "ACCUSED"
+        artifact?.additionalDetails?.witnessDetails?.ownerType === "ACCUSED",
     );
 
     if (courtList?.length !== 0) {
@@ -73,7 +81,7 @@ async function processAccusedEvidence(
             tenantId,
             evidenceFileStoreId,
             requestInfo,
-            TEMP_FILES_DIR
+            TEMP_FILES_DIR,
           );
           return {
             sourceId: evidenceFileStoreId,
@@ -82,7 +90,7 @@ async function processAccusedEvidence(
             createPDF: false,
             content: "accusedevidencedepositions",
           };
-        })
+        }),
       );
       accusedEvidenceLineItems.push(...innerLineItems);
     }
@@ -106,7 +114,7 @@ async function processAccusedEvidence(
         sortBy: section.sorton,
         order: "asc",
         limit: 100,
-      }
+      },
     );
 
     const accusedList = accusedDocs?.data?.artifacts;
@@ -125,7 +133,7 @@ async function processAccusedEvidence(
               [evidenceFileStoreId, sealFileStore],
               tenantId,
               requestInfo,
-              TEMP_FILES_DIR
+              TEMP_FILES_DIR,
             );
           }
 
@@ -135,37 +143,39 @@ async function processAccusedEvidence(
             const sourceUuid = evidence?.auditdetails?.createdBy;
 
             const sourceLitigant = courtCase.litigants?.find(
-              (litigant) => litigant.additionalDetails.uuid === sourceUuid
+              (litigant) => litigant.additionalDetails.uuid === sourceUuid,
             );
             const sourceRepresentative = courtCase.representatives?.find(
-              (rep) => rep.additionalDetails.uuid === sourceUuid
+              (rep) => rep.additionalDetails.uuid === sourceUuid,
             );
             let docketNameOfFiling;
             let docketCounselFor;
 
             if (sourceLitigant) {
               docketNameOfFiling =
-                sourceLitigant.additionalDetails?.fullName || "";
+                sourceLitigant?.additionalDetails?.fullName || "";
               docketCounselFor = "";
             } else if (sourceRepresentative) {
-              const docketNameOfComplainants = sourceRepresentative.representing
-                ?.map((lit) => lit.additionalDetails.fullName)
-                ?.filter(Boolean)
-                .join(", ");
+              const docketNameOfComplainants =
+                sourceRepresentative?.representing
+                  ?.map((lit) => lit?.additionalDetails?.fullName)
+                  ?.filter(Boolean)
+                  .join(", ");
               docketNameOfFiling =
-                sourceRepresentative.additionalDetails?.advocateName || "";
-              docketCounselFor = `COUNSEL FOR THE ${evidence.sourceType} - ${docketNameOfComplainants}`;
+                sourceRepresentative?.additionalDetails?.advocateName || "";
+              docketCounselFor = `COUNSEL FOR THE ${evidence?.sourceType} - ${docketNameOfComplainants}`;
             } else {
               const complainant = courtCase.litigants?.find((litigant) =>
-                litigant.partyType.includes("complainant.primary")
+                litigant?.partyType?.includes("complainant.primary"),
               );
               const docketNameOfComplainants =
-                complainant.additionalDetails.fullName;
+                complainant?.additionalDetails?.fullName || "";
               docketNameOfFiling =
                 courtCase.representatives?.find((adv) =>
-                  adv.representing?.find(
-                    (party) => party.individualId === complainant.individualId
-                  )
+                  adv?.representing?.some(
+                    (party) =>
+                      party?.individualId === complainant?.individualId,
+                  ),
                 )?.additionalDetails?.advocateName || docketNameOfComplainants;
               docketCounselFor =
                 docketNameOfFiling === docketNameOfComplainants
@@ -199,21 +209,21 @@ async function processAccusedEvidence(
                 docketCounselFor: docketCounselFor,
                 docketNameOfFiling: docketNameOfFiling,
                 docketDateOfSubmission: new Date(
-                  evidence.createdDate
+                  evidence.createdDate,
                 ).toLocaleDateString("en-IN"),
                 documentPath: documentPath,
               },
               courtCase,
               tenantId,
               requestInfo,
-              TEMP_FILES_DIR
+              TEMP_FILES_DIR,
             );
           } else {
             newEvidenceFileStoreId = await duplicateExistingFileStore(
               tenantId,
               evidenceFileStoreId,
               requestInfo,
-              TEMP_FILES_DIR
+              TEMP_FILES_DIR,
             );
           }
 
@@ -224,14 +234,14 @@ async function processAccusedEvidence(
             createPDF: false,
             content: "accusedevidence",
           };
-        })
+        }),
       );
       accusedEvidenceLineItems.push(...innerLineItems);
     }
   }
 
   const accusedEvidenceIndexSection = indexCopy.sections?.find(
-    (section) => section.name === "accusedevidence"
+    (section) => section.name === "accusedevidence",
   );
   accusedEvidenceIndexSection.lineItems =
     accusedEvidenceLineItems?.filter(Boolean);

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processAdditionalFilings.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processAdditionalFilings.js
@@ -1,7 +1,11 @@
 const { search_evidence_v2 } = require("../../api");
-const { filterCaseBundleBySection } = require("../utils/filterCaseBundleBySection");
+const {
+  filterCaseBundleBySection,
+} = require("../utils/filterCaseBundleBySection");
 const { applyDocketToDocument } = require("../utils/applyDocketToDocument");
-const { duplicateExistingFileStore } = require("../utils/duplicateExistingFileStore");
+const {
+  duplicateExistingFileStore,
+} = require("../utils/duplicateExistingFileStore");
 const { getDynamicSectionNumber } = require("../utils/getDynamicSectionNumber");
 const { logger } = require("../../logger");
 
@@ -12,25 +16,27 @@ async function processAdditionalFilings(
   requestInfo,
   TEMP_FILES_DIR,
   indexCopy,
-  messagesMap
+  messagesMap,
 ) {
-  logger.info(`[processAdditionalFilings] Started | filingNumber: ${courtCase?.filingNumber}`);
+  logger.info(
+    `[processAdditionalFilings] Started | filingNumber: ${courtCase?.filingNumber}`,
+  );
   const additionalFilingsSection = filterCaseBundleBySection(
     caseBundleMaster,
-    "additionalfilings"
+    "additionalfilings",
   );
 
   const sectionPosition = indexCopy.sections?.findIndex(
-    (s) => s.name === "additionalfilings"
+    (s) => s.name === "additionalfilings",
   );
 
   const additionalFilingsIndexSection = indexCopy.sections?.find(
-    (section) => section.name === "additionalfilings"
+    (section) => section.name === "additionalfilings",
   );
 
   const dynamicSectionNumber = getDynamicSectionNumber(
     indexCopy,
-    sectionPosition
+    sectionPosition,
   );
 
   if (additionalFilingsSection?.length !== 0) {
@@ -51,7 +57,7 @@ async function processAdditionalFilings(
         sortBy: section.sorton,
         order: "asc",
         limit: 100,
-      }
+      },
     );
 
     const directList = directDocs?.data?.artifacts;
@@ -72,7 +78,7 @@ async function processAdditionalFilings(
         sortBy: section.sorton,
         order: "asc",
         limit: 100,
-      }
+      },
     );
 
     const applicationList = applicationDocs?.data?.artifacts;
@@ -80,7 +86,7 @@ async function processAdditionalFilings(
     const newList = [...(directList || []), ...(applicationList || [])];
 
     const combinedList = newList.sort(
-      (a, b) => a.auditdetails.createdTime - b.auditdetails.createdTime
+      (a, b) => a.auditdetails.createdTime - b.auditdetails.createdTime,
     );
 
     if (combinedList?.length !== 0) {
@@ -97,37 +103,39 @@ async function processAdditionalFilings(
             const sourceUuid = evidence?.auditdetails?.createdBy;
 
             const sourceLitigant = courtCase.litigants?.find(
-              (litigant) => litigant.additionalDetails.uuid === sourceUuid
+              (litigant) => litigant.additionalDetails.uuid === sourceUuid,
             );
             const sourceRepresentative = courtCase.representatives?.find(
-              (rep) => rep.additionalDetails.uuid === sourceUuid
+              (rep) => rep.additionalDetails.uuid === sourceUuid,
             );
             let docketNameOfFiling;
             let docketCounselFor;
 
             if (sourceLitigant) {
               docketNameOfFiling =
-                sourceLitigant.additionalDetails?.fullName || "";
+                sourceLitigant?.additionalDetails?.fullName || "";
               docketCounselFor = "";
             } else if (sourceRepresentative) {
-              const docketNameOfComplainants = sourceRepresentative.representing
-                ?.map((lit) => lit.additionalDetails.fullName)
-                ?.filter(Boolean)
-                .join(", ");
+              const docketNameOfComplainants =
+                sourceRepresentative?.representing
+                  ?.map((lit) => lit?.additionalDetails?.fullName)
+                  ?.filter(Boolean)
+                  .join(", ");
               docketNameOfFiling =
-                sourceRepresentative.additionalDetails?.advocateName || "";
-              docketCounselFor = `COUNSEL FOR THE ${evidence.sourceType} - ${docketNameOfComplainants}`;
+                sourceRepresentative?.additionalDetails?.advocateName || "";
+              docketCounselFor = `COUNSEL FOR THE ${evidence?.sourceType} - ${docketNameOfComplainants}`;
             } else {
               const complainant = courtCase.litigants?.find((litigant) =>
-                litigant.partyType.includes("complainant.primary")
+                litigant?.partyType?.includes("complainant.primary"),
               );
               const docketNameOfComplainants =
-                complainant.additionalDetails.fullName;
+                complainant?.additionalDetails?.fullName || "";
               docketNameOfFiling =
                 courtCase.representatives?.find((adv) =>
-                  adv.representing?.find(
-                    (party) => party.individualId === complainant.individualId
-                  )
+                  adv?.representing?.some(
+                    (party) =>
+                      party?.individualId === complainant?.individualId,
+                  ),
                 )?.additionalDetails?.advocateName || docketNameOfComplainants;
               docketCounselFor =
                 docketNameOfFiling === docketNameOfComplainants
@@ -156,21 +164,21 @@ async function processAdditionalFilings(
                 docketCounselFor: docketCounselFor,
                 docketNameOfFiling: docketNameOfFiling,
                 docketDateOfSubmission: new Date(
-                  evidence.createdDate
+                  evidence.createdDate,
                 ).toLocaleDateString("en-IN"),
                 documentPath: documentPath,
               },
               courtCase,
               tenantId,
               requestInfo,
-              TEMP_FILES_DIR
+              TEMP_FILES_DIR,
             );
           } else {
             newEvidenceFileStoreId = await duplicateExistingFileStore(
               tenantId,
               evidenceFileStoreId,
               requestInfo,
-              TEMP_FILES_DIR
+              TEMP_FILES_DIR,
             );
           }
           return {
@@ -180,7 +188,7 @@ async function processAdditionalFilings(
             createPDF: false,
             content: "additionalfilings",
           };
-        })
+        }),
       );
       additionalFilingsIndexSection.lineItems =
         additionalFilingsLineItems?.filter(Boolean);

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processAffidavitSection.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processAffidavitSection.js
@@ -1,5 +1,7 @@
 const { applyDocketToDocument } = require("../utils/applyDocketToDocument");
-const { filterCaseBundleBySection } = require("../utils/filterCaseBundleBySection");
+const {
+  filterCaseBundleBySection,
+} = require("../utils/filterCaseBundleBySection");
 const { getDynamicSectionNumber } = require("../utils/getDynamicSectionNumber");
 const { logger } = require("../../logger");
 
@@ -9,25 +11,27 @@ async function processAffidavitSection(
   tenantId,
   requestInfo,
   TEMP_FILES_DIR,
-  indexCopy
+  indexCopy,
 ) {
-  logger.info(`[processAffidavitSection] Started | filingNumber: ${courtCase?.filingNumber}`);
+  logger.info(
+    `[processAffidavitSection] Started | filingNumber: ${courtCase?.filingNumber}`,
+  );
   const affidavitsSection = filterCaseBundleBySection(
     caseBundleMaster,
-    "affidavit"
+    "affidavit",
   );
 
   const sectionPosition = indexCopy.sections?.findIndex(
-    (s) => s.name === "affidavit"
+    (s) => s.name === "affidavit",
   );
 
   const dynamicSectionNumber = getDynamicSectionNumber(
     indexCopy,
-    sectionPosition
+    sectionPosition,
   );
 
   const sortedAffidavitsSection = [...affidavitsSection].sort(
-    (secA, secB) => secA.sorton - secB.sorton
+    (secA, secB) => secA.sorton - secB.sorton,
   );
 
   const affidavitsLineItems = (
@@ -44,16 +48,17 @@ async function processAffidavitSection(
             const index = ind + i;
             if (section.docketpagerequired === "yes") {
               const complainant = courtCase.litigants?.find((litigant) =>
-                litigant.partyType.includes("complainant.primary")
+                litigant?.partyType?.includes("complainant.primary"),
               );
               const docketComplainantName =
-                complainant.additionalDetails.fullName;
-              const docketNameOfAdvocate = courtCase.representatives?.find(
-                (adv) =>
-                  adv.representing?.find(
-                    (party) => party.individualId === complainant.individualId
-                  )
-              )?.additionalDetails?.advocateName;
+                complainant?.additionalDetails?.fullName || "";
+              const docketNameOfAdvocate =
+                courtCase.representatives?.find((adv) =>
+                  adv?.representing?.some(
+                    (party) =>
+                      party?.individualId === complainant?.individualId,
+                  ),
+                )?.additionalDetails?.advocateName || "";
 
               const docketCounselFor = docketNameOfAdvocate
                 ? `COUNSEL FOR THE COMPLAINANT - ${docketComplainantName}`
@@ -81,14 +86,14 @@ async function processAffidavitSection(
                     docketNameOfFiling:
                       docketNameOfAdvocate || docketComplainantName,
                     docketDateOfSubmission: new Date(
-                      courtCase.registrationDate
+                      courtCase.registrationDate,
                     ).toLocaleDateString("en-IN"),
                     documentPath: documentPath,
                   },
                   courtCase,
                   tenantId,
                   requestInfo,
-                  TEMP_FILES_DIR
+                  TEMP_FILES_DIR,
                 );
 
               return {
@@ -107,17 +112,17 @@ async function processAffidavitSection(
                 content: "affidavit",
               };
             }
-          })
+          }),
         );
         return innerItems;
-      })
+      }),
     )
   ).flat();
 
   // update index
 
   const affidavitsIndexSection = indexCopy.sections?.find(
-    (section) => section.name === "affidavit"
+    (section) => section.name === "affidavit",
   );
   affidavitsIndexSection.lineItems = affidavitsLineItems?.filter(Boolean);
 }

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processBailDocuments.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processBailDocuments.js
@@ -84,13 +84,13 @@ async function processBailDocuments(
             let newApplicationFileStoreId = combinedFileStore;
 
             if (section.docketpagerequired === "yes") {
-              const sourceUuid = application.auditDetails.createdBy;
+              const sourceUuid = application?.auditDetails?.createdBy;
 
               const sourceLitigant = courtCase.litigants?.find(
-                (litigant) => litigant.additionalDetails.uuid === sourceUuid
+                (litigant) => litigant?.additionalDetails?.uuid === sourceUuid
               );
               const sourceRepresentative = courtCase.representatives?.find(
-                (rep) => rep.additionalDetails.uuid === sourceUuid
+                (rep) => rep?.additionalDetails?.uuid === sourceUuid
               );
 
               let docketNameOfFiling;
@@ -98,33 +98,33 @@ async function processBailDocuments(
 
               if (sourceLitigant) {
                 docketNameOfFiling =
-                  sourceLitigant.additionalDetails?.fullName || "";
+                  sourceLitigant?.additionalDetails?.fullName || "";
                 docketCounselFor = "";
               } else if (sourceRepresentative) {
                 const docketNameOfComplainants =
-                  sourceRepresentative.representing
-                    ?.map((lit) => lit.additionalDetails.fullName)
+                  sourceRepresentative?.representing
+                    ?.map((lit) => lit?.additionalDetails?.fullName)
                     ?.filter(Boolean)
                     .join(", ");
                 const partyType =
-                  sourceRepresentative.representing[0].partyType.includes(
+                  sourceRepresentative?.representing?.[0]?.partyType?.includes(
                     "complainant"
                   )
                     ? "COMPLAINANT"
                     : "ACCUSED";
                 docketNameOfFiling =
-                  sourceRepresentative.additionalDetails?.advocateName || "";
+                  sourceRepresentative?.additionalDetails?.advocateName || "";
                 docketCounselFor = `COUNSEL FOR THE ${partyType} - ${docketNameOfComplainants}`;
               } else {
                 const complainant = courtCase.litigants?.find((litigant) =>
-                  litigant.partyType.includes("complainant.primary")
+                  litigant?.partyType?.includes("complainant.primary")
                 );
                 const docketNameOfComplainants =
-                  complainant.additionalDetails.fullName;
+                  complainant?.additionalDetails?.fullName || "";
                 docketNameOfFiling =
                   courtCase.representatives?.find((adv) =>
-                    adv.representing?.find(
-                      (party) => party.individualId === complainant.individualId
+                    adv?.representing?.some(
+                      (party) => party?.individualId === complainant?.individualId
                     )
                   )?.additionalDetails?.advocateName ||
                   docketNameOfComplainants;
@@ -215,49 +215,47 @@ async function processBailDocuments(
 
                 if (section.docketpagerequired === "yes") {
                   const sourceUuid =
-                    submitBailApplication.auditDetails.createdBy;
+                  submitBailApplication?.auditDetails?.createdBy;
 
-                  const sourceLitigant = courtCase.litigants?.find(
-                    (litigant) => litigant.additionalDetails.uuid === sourceUuid
-                  );
-                  const sourceRepresentative = courtCase.representatives?.find(
-                    (rep) => rep.additionalDetails.uuid === sourceUuid
-                  );
-
+                const sourceLitigant = courtCase.litigants?.find(
+                  (litigant) => litigant?.additionalDetails?.uuid === sourceUuid
+                );
+                const sourceRepresentative = courtCase.representatives?.find(
+                  (rep) => rep?.additionalDetails?.uuid === sourceUuid
                   let docketNameOfFiling;
                   let docketCounselFor;
 
                   if (sourceLitigant) {
                     docketNameOfFiling =
-                      sourceLitigant.additionalDetails?.fullName || "";
+                      sourceLitigant?.additionalDetails?.fullName || "";
                     docketCounselFor = "";
                   } else if (sourceRepresentative) {
                     const docketNameOfComplainants =
-                      sourceRepresentative.representing
-                        ?.map((lit) => lit.additionalDetails.fullName)
+                      sourceRepresentative?.representing
+                        ?.map((lit) => lit?.additionalDetails?.fullName)
                         ?.filter(Boolean)
                         ?.join(", ");
                     const partyType =
-                      sourceRepresentative.representing[0].partyType.includes(
+                      sourceRepresentative?.representing?.[0]?.partyType?.includes(
                         "complainant"
                       )
                         ? "COMPLAINANT"
                         : "ACCUSED";
                     docketNameOfFiling =
-                      sourceRepresentative.additionalDetails?.advocateName ||
+                      sourceRepresentative?.additionalDetails?.advocateName ||
                       "";
                     docketCounselFor = `COUNSEL FOR THE ${partyType} - ${docketNameOfComplainants}`;
                   } else {
                     const complainant = courtCase.litigants?.find((litigant) =>
-                      litigant.partyType.includes("complainant.primary")
+                      litigant?.partyType?.includes("complainant.primary")
                     );
                     const docketNameOfComplainants =
-                      complainant.additionalDetails.fullName;
+                      complainant?.additionalDetails?.fullName || "";
                     docketNameOfFiling =
                       courtCase.representatives?.find((adv) =>
-                        adv.representing?.find(
+                        adv?.representing?.some(
                           (party) =>
-                            party.individualId === complainant.individualId
+                            party?.individualId === complainant?.individualId
                         )
                       )?.additionalDetails?.advocateName ||
                       docketNameOfComplainants;

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processBailDocuments.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processBailDocuments.js
@@ -222,6 +222,8 @@ async function processBailDocuments(
                 );
                 const sourceRepresentative = courtCase.representatives?.find(
                   (rep) => rep?.additionalDetails?.uuid === sourceUuid
+                );
+                
                   let docketNameOfFiling;
                   let docketCounselFor;
 

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processComplainantEvidence.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processComplainantEvidence.js
@@ -1,9 +1,15 @@
 const { search_evidence_v2 } = require("../../api");
-const { filterCaseBundleBySection } = require("../utils/filterCaseBundleBySection");
+const {
+  filterCaseBundleBySection,
+} = require("../utils/filterCaseBundleBySection");
 const { applyDocketToDocument } = require("../utils/applyDocketToDocument");
-const { duplicateExistingFileStore } = require("../utils/duplicateExistingFileStore");
+const {
+  duplicateExistingFileStore,
+} = require("../utils/duplicateExistingFileStore");
 const { getDynamicSectionNumber } = require("../utils/getDynamicSectionNumber");
-const { combineMultipleFilestores } = require("../utils/combineMultipleFilestores");
+const {
+  combineMultipleFilestores,
+} = require("../utils/combineMultipleFilestores");
 const { logger } = require("../../logger");
 
 async function processComplainantEvidence(
@@ -13,26 +19,28 @@ async function processComplainantEvidence(
   requestInfo,
   TEMP_FILES_DIR,
   indexCopy,
-  messagesMap
+  messagesMap,
 ) {
-  logger.info(`[processComplainantEvidence] Started | filingNumber: ${courtCase?.filingNumber}`);
+  logger.info(
+    `[processComplainantEvidence] Started | filingNumber: ${courtCase?.filingNumber}`,
+  );
   const complainantDepositionSection = filterCaseBundleBySection(
     caseBundleMaster,
-    "complainantevidencedepositions"
+    "complainantevidencedepositions",
   );
 
   const complainantEvidenceSection = filterCaseBundleBySection(
     caseBundleMaster,
-    "complainantevidence"
+    "complainantevidence",
   );
 
   const sectionPosition = indexCopy.sections?.findIndex(
-    (s) => s.name === "complainantevidence"
+    (s) => s.name === "complainantevidence",
   );
 
   const dynamicSectionNumber = getDynamicSectionNumber(
     indexCopy,
-    sectionPosition
+    sectionPosition,
   );
 
   const complainantEvidenceLineItems = [];
@@ -53,12 +61,13 @@ async function processComplainantEvidence(
         sortBy: complainantDepositionSection[0].sorton,
         order: "asc",
         limit: 100,
-      }
+      },
     );
 
     const courtList = courtDocs?.data?.artifacts?.filter(
       (artifact) =>
-        artifact?.additionalDetails?.witnessDetails?.ownerType === "COMPLAINANT"
+        artifact?.additionalDetails?.witnessDetails?.ownerType ===
+        "COMPLAINANT",
     );
 
     if (courtList?.length !== 0) {
@@ -73,7 +82,7 @@ async function processComplainantEvidence(
             tenantId,
             evidenceFileStoreId,
             requestInfo,
-            TEMP_FILES_DIR
+            TEMP_FILES_DIR,
           );
           return {
             sourceId: evidenceFileStoreId,
@@ -82,7 +91,7 @@ async function processComplainantEvidence(
             createPDF: false,
             content: "complainantevidencedepositions",
           };
-        })
+        }),
       );
       complainantEvidenceLineItems.push(...innerLineItems);
     }
@@ -106,7 +115,7 @@ async function processComplainantEvidence(
         sortBy: section.sorton,
         order: "asc",
         limit: 100,
-      }
+      },
     );
 
     const complainantList = complainantDocs?.data?.artifacts;
@@ -124,7 +133,7 @@ async function processComplainantEvidence(
               [evidenceFileStoreId, sealFileStore],
               tenantId,
               requestInfo,
-              TEMP_FILES_DIR
+              TEMP_FILES_DIR,
             );
           }
 
@@ -134,37 +143,39 @@ async function processComplainantEvidence(
             const sourceUuid = evidence?.auditdetails?.createdBy;
 
             const sourceLitigant = courtCase.litigants?.find(
-              (litigant) => litigant.additionalDetails.uuid === sourceUuid
+              (litigant) => litigant.additionalDetails.uuid === sourceUuid,
             );
             const sourceRepresentative = courtCase.representatives?.find(
-              (rep) => rep.additionalDetails.uuid === sourceUuid
+              (rep) => rep.additionalDetails.uuid === sourceUuid,
             );
             let docketNameOfFiling;
             let docketCounselFor;
 
             if (sourceLitigant) {
               docketNameOfFiling =
-                sourceLitigant.additionalDetails?.fullName || "";
+                sourceLitigant?.additionalDetails?.fullName || "";
               docketCounselFor = "";
             } else if (sourceRepresentative) {
-              const docketNameOfComplainants = sourceRepresentative.representing
-                ?.map((lit) => lit.additionalDetails.fullName)
-                ?.filter(Boolean)
-                ?.join(", ");
+              const docketNameOfComplainants =
+                sourceRepresentative?.representing
+                  ?.map((lit) => lit?.additionalDetails?.fullName)
+                  ?.filter(Boolean)
+                  ?.join(", ");
               docketNameOfFiling =
-                sourceRepresentative.additionalDetails?.advocateName || "";
-              docketCounselFor = `COUNSEL FOR THE ${evidence.sourceType} - ${docketNameOfComplainants}`;
+                sourceRepresentative?.additionalDetails?.advocateName || "";
+              docketCounselFor = `COUNSEL FOR THE ${evidence?.sourceType} - ${docketNameOfComplainants}`;
             } else {
               const complainant = courtCase.litigants?.find((litigant) =>
-                litigant.partyType.includes("complainant.primary")
+                litigant?.partyType?.includes("complainant.primary"),
               );
               const docketNameOfComplainants =
-                complainant.additionalDetails.fullName;
+                complainant?.additionalDetails?.fullName || "";
               docketNameOfFiling =
                 courtCase.representatives?.find((adv) =>
-                  adv.representing?.find(
-                    (party) => party.individualId === complainant.individualId
-                  )
+                  adv?.representing?.some(
+                    (party) =>
+                      party?.individualId === complainant?.individualId,
+                  ),
                 )?.additionalDetails?.advocateName || docketNameOfComplainants;
               docketCounselFor =
                 docketNameOfFiling === docketNameOfComplainants
@@ -181,7 +192,7 @@ async function processComplainantEvidence(
               ];
 
             const evidencePosition = !complainantEvidenceLineItems?.filter(
-              Boolean
+              Boolean,
             )?.length
               ? "1"
               : "2";
@@ -199,21 +210,21 @@ async function processComplainantEvidence(
                 docketCounselFor: docketCounselFor,
                 docketNameOfFiling: docketNameOfFiling,
                 docketDateOfSubmission: new Date(
-                  evidence.createdDate
+                  evidence.createdDate,
                 ).toLocaleDateString("en-IN"),
                 documentPath: documentPath,
               },
               courtCase,
               tenantId,
               requestInfo,
-              TEMP_FILES_DIR
+              TEMP_FILES_DIR,
             );
           } else {
             newEvidenceFileStoreId = await duplicateExistingFileStore(
               tenantId,
               evidenceFileStoreId,
               requestInfo,
-              TEMP_FILES_DIR
+              TEMP_FILES_DIR,
             );
           }
 
@@ -224,14 +235,14 @@ async function processComplainantEvidence(
             createPDF: false,
             content: "complainantevidence",
           };
-        })
+        }),
       );
       complainantEvidenceLineItems.push(...innerLineItems);
     }
   }
 
   const complainantEvidenceIndexSection = indexCopy.sections?.find(
-    (section) => section.name === "complainantevidence"
+    (section) => section.name === "complainantevidence",
   );
   complainantEvidenceIndexSection.lineItems =
     complainantEvidenceLineItems?.filter(Boolean);

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processComplaintSection.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processComplaintSection.js
@@ -1,4 +1,6 @@
-const { filterCaseBundleBySection } = require("../utils/filterCaseBundleBySection");
+const {
+  filterCaseBundleBySection,
+} = require("../utils/filterCaseBundleBySection");
 const { applyDocketToDocument } = require("../utils/applyDocketToDocument");
 const { getDynamicSectionNumber } = require("../utils/getDynamicSectionNumber");
 const { logger } = require("../../logger");
@@ -9,31 +11,35 @@ async function processComplaintSection(
   tenantId,
   requestInfo,
   TEMP_FILES_DIR,
-  indexCopy
+  indexCopy,
 ) {
-  logger.info(`[processComplaintSection] Started | filingNumber: ${courtCase?.filingNumber}`);
+  logger.info(
+    `[processComplaintSection] Started | filingNumber: ${courtCase?.filingNumber}`,
+  );
   const complaintSection = filterCaseBundleBySection(
     caseBundleMaster,
-    "complaint"
+    "complaint",
   );
 
   const sectionPosition = indexCopy.sections?.findIndex(
-    (s) => s.name === "complaint"
+    (s) => s.name === "complaint",
   );
 
   const dynamicSectionNumber = getDynamicSectionNumber(
     indexCopy,
-    sectionPosition
+    sectionPosition,
   );
 
   if (complaintSection?.length !== 0) {
     const section = complaintSection[0];
 
     const complaintFileStoreId = courtCase.documents?.find(
-      (doc) => doc.documentType === "case.complaint.signed"
+      (doc) => doc.documentType === "case.complaint.signed",
     )?.fileStore;
     if (!complaintFileStoreId) {
-      logger.error(`[processComplaintSection] No complaint document found | filingNumber: ${courtCase?.filingNumber}, expected documentType: case.complaint.signed`);
+      logger.error(
+        `[processComplaintSection] No complaint document found | filingNumber: ${courtCase?.filingNumber}, expected documentType: case.complaint.signed`,
+      );
       throw new Error("no case complaint");
     }
 
@@ -41,14 +47,16 @@ async function processComplaintSection(
 
     if (section.docketpagerequired === "yes") {
       const complainant = courtCase.litigants?.find((litigant) =>
-        litigant.partyType.includes("complainant.primary")
+        litigant?.partyType?.includes("complainant.primary"),
       );
-      const docketComplainantName = complainant.additionalDetails.fullName;
-      const docketNameOfAdvocate = courtCase.representatives?.find((adv) =>
-        adv.representing?.find(
-          (party) => party.individualId === complainant.individualId
-        )
-      )?.additionalDetails?.advocateName;
+      const docketComplainantName =
+        complainant?.additionalDetails?.fullName || "";
+      const docketNameOfAdvocate =
+        courtCase.representatives?.find((adv) =>
+          adv?.representing?.some(
+            (party) => party?.individualId === complainant?.individualId,
+          ),
+        )?.additionalDetails?.advocateName || "";
 
       const docketCounselFor = docketNameOfAdvocate
         ? `COUNSEL FOR THE COMPLAINANT - ${docketComplainantName}`
@@ -61,21 +69,21 @@ async function processComplaintSection(
           docketCounselFor: docketCounselFor,
           docketNameOfFiling: docketNameOfAdvocate || docketComplainantName,
           docketDateOfSubmission: new Date(
-            courtCase.registrationDate
+            courtCase.registrationDate,
           ).toLocaleDateString("en-IN"),
           documentPath: `${dynamicSectionNumber} ${section.section}`,
         },
         courtCase,
         tenantId,
         requestInfo,
-        TEMP_FILES_DIR
+        TEMP_FILES_DIR,
       );
     }
 
     // update index
 
     const complaintIndexSection = indexCopy.sections?.find(
-      (section) => section.name === "complaint"
+      (section) => section.name === "complaint",
     );
     complaintIndexSection.lineItems = complaintIndexSection.lineItems || [];
     complaintIndexSection.lineItems[0] = {

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processDisposedApplications.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processDisposedApplications.js
@@ -1,8 +1,14 @@
 const { search_application_v2, search_order_v2 } = require("../../api");
-const { filterCaseBundleBySection } = require("../utils/filterCaseBundleBySection");
+const {
+  filterCaseBundleBySection,
+} = require("../utils/filterCaseBundleBySection");
 const { applyDocketToDocument } = require("../utils/applyDocketToDocument");
-const { combineMultipleFilestores } = require("../utils/combineMultipleFilestores");
-const { duplicateExistingFileStore } = require("../utils/duplicateExistingFileStore");
+const {
+  combineMultipleFilestores,
+} = require("../utils/combineMultipleFilestores");
+const {
+  duplicateExistingFileStore,
+} = require("../utils/duplicateExistingFileStore");
 const { getDynamicSectionNumber } = require("../utils/getDynamicSectionNumber");
 const { logger } = require("../../logger");
 
@@ -18,35 +24,37 @@ async function processDisposedApplications(
   requestInfo,
   TEMP_FILES_DIR,
   indexCopy,
-  messagesMap
+  messagesMap,
 ) {
-  logger.info(`[processDisposedApplications] Started | filingNumber: ${courtCase?.filingNumber}`);
+  logger.info(
+    `[processDisposedApplications] Started | filingNumber: ${courtCase?.filingNumber}`,
+  );
   const applicationSection = filterCaseBundleBySection(
     caseBundleMaster,
-    "applications"
+    "applications",
   );
 
   const applicationObjectionSection = filterCaseBundleBySection(
     caseBundleMaster,
-    "applicationobjections"
+    "applicationobjections",
   );
 
   const applicationOrderSection = filterCaseBundleBySection(
     caseBundleMaster,
-    "applicationsorders"
+    "applicationsorders",
   );
 
   const sectionPosition = indexCopy.sections?.findIndex(
-    (s) => s.name === "applications"
+    (s) => s.name === "applications",
   );
 
   const dynamicSectionNumber = getDynamicSectionNumber(
     indexCopy,
-    sectionPosition
+    sectionPosition,
   );
 
   const applicationsIndexSection = indexCopy.sections?.find(
-    (section) => section.name === "applications"
+    (section) => section.name === "applications",
   );
 
   if (applicationSection?.length !== 0) {
@@ -65,7 +73,7 @@ async function processDisposedApplications(
         sortBy: section.sorton,
         order: "asc",
         limit: 100,
-      }
+      },
     );
 
     const rejectedApplications = await search_application_v2(
@@ -82,7 +90,7 @@ async function processDisposedApplications(
         sortBy: section.sorton,
         order: "asc",
         limit: 100,
-      }
+      },
     );
 
     const completedList = completedApplications?.data?.applicationList || [];
@@ -106,7 +114,7 @@ async function processDisposedApplications(
       const applicationLineItems = await Promise.all(
         applicationList?.map(async (application, index) => {
           let applicationFileStoreId = application?.documents?.find(
-            (doc) => doc?.documentType === "SIGNED"
+            (doc) => doc?.documentType === "SIGNED",
           )?.fileStore;
 
           if (
@@ -114,7 +122,7 @@ async function processDisposedApplications(
             !applicationFileStoreId
           ) {
             applicationFileStoreId = application?.documents?.find(
-              (doc) => doc?.documentType === "CONDONATION_DOC"
+              (doc) => doc?.documentType === "CONDONATION_DOC",
             )?.fileStore;
           }
 
@@ -125,13 +133,13 @@ async function processDisposedApplications(
           let newApplicationFileStoreId = applicationFileStoreId;
 
           if (section.docketpagerequired === "yes") {
-            const sourceUuid = application.auditDetails.createdBy;
+            const sourceUuid = application?.auditDetails?.createdBy;
 
             const sourceLitigant = courtCase.litigants?.find(
-              (litigant) => litigant.additionalDetails.uuid === sourceUuid
+              (litigant) => litigant?.additionalDetails?.uuid === sourceUuid,
             );
             const sourceRepresentative = courtCase.representatives?.find(
-              (rep) => rep.additionalDetails.uuid === sourceUuid
+              (rep) => rep?.additionalDetails?.uuid === sourceUuid,
             );
 
             let docketNameOfFiling;
@@ -139,33 +147,35 @@ async function processDisposedApplications(
 
             if (sourceLitigant) {
               docketNameOfFiling =
-                sourceLitigant.additionalDetails?.fullName || "";
+                sourceLitigant?.additionalDetails?.fullName || "";
               docketCounselFor = "";
             } else if (sourceRepresentative) {
-              const docketNameOfComplainants = sourceRepresentative.representing
-                ?.map((lit) => lit.additionalDetails.fullName)
-                ?.filter(Boolean)
-                ?.join(", ");
+              const docketNameOfComplainants =
+                sourceRepresentative?.representing
+                  ?.map((lit) => lit?.additionalDetails?.fullName)
+                  ?.filter(Boolean)
+                  ?.join(", ");
               const partyType =
-                sourceRepresentative.representing[0].partyType.includes(
-                  "complainant"
+                sourceRepresentative?.representing?.[0]?.partyType?.includes(
+                  "complainant",
                 )
                   ? "COMPLAINANT"
                   : "ACCUSED";
               docketNameOfFiling =
-                sourceRepresentative.additionalDetails?.advocateName || "";
+                sourceRepresentative?.additionalDetails?.advocateName || "";
               docketCounselFor = `COUNSEL FOR THE ${partyType} - ${docketNameOfComplainants}`;
             } else {
               const complainant = courtCase.litigants?.find((litigant) =>
-                litigant.partyType.includes("complainant.primary")
+                litigant?.partyType?.includes("complainant.primary"),
               );
               const docketNameOfComplainants =
-                complainant.additionalDetails.fullName;
+                complainant?.additionalDetails?.fullName || "";
               docketNameOfFiling =
                 courtCase.representatives?.find((adv) =>
-                  adv.representing?.find(
-                    (party) => party.individualId === complainant.individualId
-                  )
+                  adv?.representing?.some(
+                    (party) =>
+                      party?.individualId === complainant?.individualId,
+                  ),
                 )?.additionalDetails?.advocateName || docketNameOfComplainants;
               docketCounselFor =
                 docketNameOfFiling === docketNameOfComplainants
@@ -188,14 +198,14 @@ async function processDisposedApplications(
                 docketCounselFor: docketCounselFor,
                 docketNameOfFiling: docketNameOfFiling,
                 docketDateOfSubmission: new Date(
-                  application.createdDate
+                  application.createdDate,
                 ).toLocaleDateString("en-IN"),
                 documentPath: documentPath,
               },
               courtCase,
               tenantId,
               requestInfo,
-              TEMP_FILES_DIR
+              TEMP_FILES_DIR,
             );
           }
 
@@ -216,7 +226,7 @@ async function processDisposedApplications(
                 let newObjectionDocumentFileStoreId =
                   objectionDocumentFileStoreId;
                 if (objectionSection.docketpagerequired === "yes") {
-                  const sourceUuid = doc.auditdetails.createdBy;
+                  const sourceUuid = doc?.auditdetails?.createdBy;
 
                   const litigants = courtCase?.litigants?.map((litigant) => ({
                     ...litigant,
@@ -224,16 +234,18 @@ async function processDisposedApplications(
                       courtCase?.representatives?.filter((rep) =>
                         rep?.representing?.some(
                           (complainant) =>
-                            complainant?.individualId === litigant?.individualId
-                        )
+                            complainant?.individualId ===
+                            litigant?.individualId,
+                        ),
                       ) || [],
                   }));
 
                   const sourceLitigant = litigants?.find(
-                    (litigant) => litigant.additionalDetails.uuid === sourceUuid
+                    (litigant) =>
+                      litigant?.additionalDetails?.uuid === sourceUuid,
                   );
                   const sourceRepresentative = courtCase.representatives?.find(
-                    (rep) => rep.additionalDetails.uuid === sourceUuid
+                    (rep) => rep?.additionalDetails?.uuid === sourceUuid,
                   );
 
                   const docketNameOfFiling = doc.additionalDetails.author || "";
@@ -243,14 +255,14 @@ async function processDisposedApplications(
                     docketCounselFor = "";
                   } else if (sourceRepresentative) {
                     const partyType =
-                      sourceRepresentative.representing[0].partyType.includes(
-                        "complainant"
+                      sourceRepresentative?.representing?.[0]?.partyType?.includes(
+                        "complainant",
                       )
                         ? "COMPLAINANT"
                         : "ACCUSED";
                     const docketNameOfComplainants =
-                      sourceRepresentative.representing
-                        ?.map((lit) => lit.additionalDetails.fullName)
+                      sourceRepresentative?.representing
+                        ?.map((lit) => lit?.additionalDetails?.fullName)
                         ?.filter(Boolean)
                         ?.join(", ");
                     docketCounselFor = `COUNSEL FOR THE ${partyType} - ${docketNameOfComplainants}`;
@@ -277,14 +289,14 @@ async function processDisposedApplications(
                       docketCounselFor: docketCounselFor,
                       docketNameOfFiling: docketNameOfFiling,
                       docketDateOfSubmission: new Date(
-                        doc.auditdetails.createdTime
+                        doc.auditdetails.createdTime,
                       ).toLocaleDateString("en-IN"),
                       documentPath: documentPath,
                     },
                     courtCase,
                     tenantId,
                     requestInfo,
-                    TEMP_FILES_DIR
+                    TEMP_FILES_DIR,
                   );
                 }
                 objectionFileStoreIds.push(newObjectionDocumentFileStoreId);
@@ -293,7 +305,7 @@ async function processDisposedApplications(
                 [newApplicationFileStoreId, ...objectionFileStoreIds],
                 tenantId,
                 requestInfo,
-                TEMP_FILES_DIR
+                TEMP_FILES_DIR,
               );
             }
           }
@@ -322,7 +334,7 @@ async function processDisposedApplications(
                   applicationNumber: application.applicationNumber,
                   status: "PUBLISHED",
                   tenantId,
-                }
+                },
               );
               responseOrderList = responseOrder?.data?.list;
             }
@@ -335,7 +347,7 @@ async function processDisposedApplications(
               orderList?.map((order) => {
                 if (order?.documents?.length !== 0) {
                   const document = order?.documents?.find(
-                    (doc) => doc?.documentType === "SIGNED"
+                    (doc) => doc?.documentType === "SIGNED",
                   );
                   if (document?.fileStore) {
                     fileStoreIds.push(document?.fileStore);
@@ -347,7 +359,7 @@ async function processDisposedApplications(
                 [newApplicationFileStoreId, ...fileStoreIds],
                 tenantId,
                 requestInfo,
-                TEMP_FILES_DIR
+                TEMP_FILES_DIR,
               );
             }
           }
@@ -357,7 +369,7 @@ async function processDisposedApplications(
               tenantId,
               applicationFileStoreId,
               requestInfo,
-              TEMP_FILES_DIR
+              TEMP_FILES_DIR,
             );
           }
 
@@ -368,7 +380,7 @@ async function processDisposedApplications(
             createPDF: false,
             content: "applications",
           };
-        })
+        }),
       );
       applicationsIndexSection.lineItems =
         applicationLineItems?.filter(Boolean);

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processExamination.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processExamination.js
@@ -1,4 +1,6 @@
-const { filterCaseBundleBySection } = require("../utils/filterCaseBundleBySection");
+const {
+  filterCaseBundleBySection,
+} = require("../utils/filterCaseBundleBySection");
 const { search_digitalizedDocuments } = require("../../api");
 const { applyDocketToDocument } = require("../utils/applyDocketToDocument");
 const { getDynamicSectionNumber } = require("../utils/getDynamicSectionNumber");
@@ -10,23 +12,25 @@ async function processExamination(
   tenantId,
   requestInfo,
   TEMP_FILES_DIR,
-  indexCopy
+  indexCopy,
 ) {
-  logger.info(`[processExamination] Started | filingNumber: ${courtCase?.filingNumber}`);
+  logger.info(
+    `[processExamination] Started | filingNumber: ${courtCase?.filingNumber}`,
+  );
   const section = filterCaseBundleBySection(
     caseBundleMaster,
-    "digitalizedDocuments"
+    "digitalizedDocuments",
   );
   const sortedSection = [...section].sort(
-    (secA, secB) => secA.sorton - secB.sorton
+    (secA, secB) => secA.sorton - secB.sorton,
   );
 
   const sectionPosition = indexCopy.sections?.findIndex(
-    (s) => s.name === "digitalizedDocuments"
+    (s) => s.name === "digitalizedDocuments",
   );
   const dynamicSectionNumber = getDynamicSectionNumber(
     indexCopy,
-    sectionPosition
+    sectionPosition,
   );
 
   if (!sortedSection || sortedSection.length === 0) return;
@@ -39,7 +43,7 @@ async function processExamination(
       courtId: courtCase.courtId,
       tenantId,
       status: "COMPLETED",
-    }
+    },
   );
 
   const filteredDocuments = (type) => {
@@ -79,16 +83,16 @@ async function processExamination(
 
         if (section.docketpagerequired === "yes" && index === 0) {
           const complainant = courtCase.litigants?.find((litigant) =>
-            litigant.partyType?.includes("complainant.primary")
+            litigant?.partyType?.includes("complainant.primary"),
           );
 
           const docketComplainantName =
             complainant?.additionalDetails?.fullName || "";
 
           const docketAdvocate = courtCase.representatives?.find((adv) =>
-            adv.representing?.some(
-              (party) => party.individualId === complainant?.individualId
-            )
+            adv?.representing?.some(
+              (party) => party?.individualId === complainant?.individualId,
+            ),
           );
 
           const docketNameOfAdvocate =
@@ -109,14 +113,14 @@ async function processExamination(
               docketCounselFor,
               docketNameOfFiling: docketNameOfAdvocate || docketComplainantName,
               docketDateOfSubmission: new Date(
-                courtCase.registrationDate
+                courtCase.registrationDate,
               ).toLocaleDateString("en-IN"),
               documentPath,
             },
             courtCase,
             tenantId,
             requestInfo,
-            TEMP_FILES_DIR
+            TEMP_FILES_DIR,
           );
         }
 
@@ -127,13 +131,13 @@ async function processExamination(
           createPDF: false,
           content: "digitalizedDocuments",
         };
-      })
+      }),
     );
     allDocumentsLineItems.push(...digitizedDocumentsLineItems);
   }
 
   const digitalizedDocumentsIndexSection = indexCopy.sections?.find(
-    (section) => section.name === "digitalizedDocuments"
+    (section) => section.name === "digitalizedDocuments",
   );
 
   if (digitalizedDocumentsIndexSection) {

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processFilingsSection.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processFilingsSection.js
@@ -11,28 +11,30 @@ async function processFilingsSection(
   tenantId,
   requestInfo,
   TEMP_FILES_DIR,
-  indexCopy
+  indexCopy,
 ) {
-  logger.info(`[processFilingsSection] Started | filingNumber: ${courtCase?.filingNumber}`);
+  logger.info(
+    `[processFilingsSection] Started | filingNumber: ${courtCase?.filingNumber}`,
+  );
   const sectionPosition = indexCopy.sections?.findIndex(
-    (s) => s.name === "filings"
+    (s) => s.name === "filings",
   );
 
   const dynamicSectionNumber = getDynamicSectionNumber(
     indexCopy,
-    sectionPosition
+    sectionPosition,
   );
 
   const filingsSection = filterCaseBundleBySection(caseBundleMaster, "filings");
   const sortedFilingSection = [...filingsSection].sort(
-    (secA, secB) => secA.sorton - secB.sorton
+    (secA, secB) => secA.sorton - secB.sorton,
   );
   let validIndex = 1;
   const filingsLineItems = [];
 
   for (const section of sortedFilingSection) {
     const documentFileStoreId = courtCase.documents?.find(
-      (doc) => doc.documentType === section.doctype
+      (doc) => doc.documentType === section.doctype,
     )?.fileStore;
 
     if (!documentFileStoreId) continue;
@@ -41,15 +43,16 @@ async function processFilingsSection(
 
     if (section.docketpagerequired === "yes") {
       const complainant = courtCase.litigants?.find((litigant) =>
-        litigant.partyType.includes("complainant.primary")
+        litigant?.partyType?.includes("complainant.primary"),
       );
       const docketComplainantName =
         complainant?.additionalDetails?.fullName || "";
-      const docketNameOfAdvocate = courtCase.representatives?.find((adv) =>
-        adv.representing?.find(
-          (party) => party.individualId === complainant.individualId
-        )
-      )?.additionalDetails?.advocateName;
+      const docketNameOfAdvocate =
+        courtCase.representatives?.find((adv) =>
+          adv?.representing?.some(
+            (party) => party?.individualId === complainant?.individualId,
+          ),
+        )?.additionalDetails?.advocateName || "";
 
       const docketCounselFor = docketNameOfAdvocate
         ? `COUNSEL FOR THE COMPLAINANT - ${docketComplainantName}`
@@ -65,14 +68,14 @@ async function processFilingsSection(
           docketCounselFor: docketCounselFor,
           docketNameOfFiling: docketNameOfAdvocate || docketComplainantName,
           docketDateOfSubmission: new Date(
-            courtCase.registrationDate
+            courtCase.registrationDate,
           ).toLocaleDateString("en-IN"),
           documentPath,
         },
         courtCase,
         tenantId,
         requestInfo,
-        TEMP_FILES_DIR
+        TEMP_FILES_DIR,
       );
     }
 
@@ -90,7 +93,7 @@ async function processFilingsSection(
   // update index
 
   const filingsIndexSection = indexCopy.sections?.find(
-    (section) => section.name === "filings"
+    (section) => section.name === "filings",
   );
   filingsIndexSection.lineItems = filingsLineItems?.filter(Boolean);
 }

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processMandatorySubmissions.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processMandatorySubmissions.js
@@ -1,7 +1,11 @@
 const { search_application_v2, search_order_v2 } = require("../../api");
-const { filterCaseBundleBySection } = require("../utils/filterCaseBundleBySection");
+const {
+  filterCaseBundleBySection,
+} = require("../utils/filterCaseBundleBySection");
 const { applyDocketToDocument } = require("../utils/applyDocketToDocument");
-const { combineMultipleFilestores } = require("../utils/combineMultipleFilestores");
+const {
+  combineMultipleFilestores,
+} = require("../utils/combineMultipleFilestores");
 const { getDynamicSectionNumber } = require("../utils/getDynamicSectionNumber");
 const { logger } = require("../../logger");
 
@@ -12,21 +16,23 @@ async function processMandatorySubmissions(
   requestInfo,
   TEMP_FILES_DIR,
   indexCopy,
-  messagesMap
+  messagesMap,
 ) {
-  logger.info(`[processMandatorySubmissions] Started | filingNumber: ${courtCase?.filingNumber}`);
+  logger.info(
+    `[processMandatorySubmissions] Started | filingNumber: ${courtCase?.filingNumber}`,
+  );
   const mandatorySubmissionsSection = filterCaseBundleBySection(
     caseBundleMaster,
-    "mandatorysubmissions"
+    "mandatorysubmissions",
   );
 
   const sectionPosition = indexCopy.sections?.findIndex(
-    (s) => s.name === "mandatorysubmissions"
+    (s) => s.name === "mandatorysubmissions",
   );
 
   const dynamicSectionNumber = getDynamicSectionNumber(
     indexCopy,
-    sectionPosition
+    sectionPosition,
   );
 
   const mandatorySubmissionsLineItems = [];
@@ -48,7 +54,7 @@ async function processMandatorySubmissions(
         sortBy: "createdDate",
         order: "asc",
         limit: 100,
-      }
+      },
     );
 
     const orderList = resOrder?.data?.list;
@@ -71,7 +77,7 @@ async function processMandatorySubmissions(
               sortBy: section.sorton,
               order: "asc",
               limit: 100,
-            }
+            },
           );
 
           const applicationList =
@@ -100,18 +106,18 @@ async function processMandatorySubmissions(
                     fileStores,
                     tenantId,
                     requestInfo,
-                    TEMP_FILES_DIR
+                    TEMP_FILES_DIR,
                   );
                   if (section.docketpagerequired === "yes") {
                     const sourceUuid = application.auditDetails.createdBy;
 
                     const sourceLitigant = courtCase.litigants?.find(
                       (litigant) =>
-                        litigant.additionalDetails.uuid === sourceUuid
+                        litigant.additionalDetails.uuid === sourceUuid,
                     );
                     const sourceRepresentative =
                       courtCase.representatives?.find(
-                        (rep) => rep.additionalDetails.uuid === sourceUuid
+                        (rep) => rep.additionalDetails.uuid === sourceUuid,
                       );
 
                     let docketNameOfFiling;
@@ -119,37 +125,37 @@ async function processMandatorySubmissions(
 
                     if (sourceLitigant) {
                       docketNameOfFiling =
-                        sourceLitigant.additionalDetails?.fullName || "";
+                        sourceLitigant?.additionalDetails?.fullName || "";
                       docketCounselFor = "";
                     } else if (sourceRepresentative) {
                       const docketNameOfComplainants =
-                        sourceRepresentative.representing
-                          ?.map((lit) => lit.additionalDetails.fullName)
+                        sourceRepresentative?.representing
+                          ?.map((lit) => lit?.additionalDetails?.fullName)
                           ?.filter(Boolean)
                           ?.join(", ");
                       const partyType =
-                        sourceRepresentative.representing[0].partyType.includes(
-                          "complainant"
+                        sourceRepresentative?.representing?.[0]?.partyType?.includes(
+                          "complainant",
                         )
                           ? "COMPLAINANT"
                           : "ACCUSED";
                       docketNameOfFiling =
-                        sourceRepresentative.additionalDetails?.advocateName ||
+                        sourceRepresentative?.additionalDetails?.advocateName ||
                         "";
                       docketCounselFor = `COUNSEL FOR THE ${partyType} - ${docketNameOfComplainants}`;
                     } else {
                       const complainant = courtCase.litigants?.find(
                         (litigant) =>
-                          litigant.partyType.includes("complainant.primary")
+                          litigant?.partyType?.includes("complainant.primary"),
                       );
                       const docketNameOfComplainants =
-                        complainant.additionalDetails.fullName;
+                        complainant?.additionalDetails?.fullName || "";
                       docketNameOfFiling =
                         courtCase.representatives?.find((adv) =>
-                          adv.representing?.find(
+                          adv?.representing?.some(
                             (party) =>
-                              party.individualId === complainant.individualId
-                          )
+                              party?.individualId === complainant?.individualId,
+                          ),
                         )?.additionalDetails?.advocateName ||
                         docketNameOfComplainants;
                       docketCounselFor =
@@ -172,14 +178,14 @@ async function processMandatorySubmissions(
                           docketCounselFor: docketCounselFor,
                           docketNameOfFiling: docketNameOfFiling,
                           docketDateOfSubmission: new Date(
-                            application.createdDate
+                            application.createdDate,
                           ).toLocaleDateString("en-IN"),
                           documentPath: documentPath,
                         },
                         courtCase,
                         tenantId,
                         requestInfo,
-                        TEMP_FILES_DIR
+                        TEMP_FILES_DIR,
                       );
 
                     return {
@@ -201,19 +207,19 @@ async function processMandatorySubmissions(
                 } else {
                   return null;
                 }
-              })
+              }),
             );
             mandatorySubmissionsLineItems.push(
-              ...innerLineItems?.filter(Boolean)
+              ...innerLineItems?.filter(Boolean),
             );
           }
-        })
+        }),
       );
     }
   }
 
   const mandatorySubmissionsIndexSection = indexCopy.sections?.find(
-    (section) => section.name === "mandatorysubmissions"
+    (section) => section.name === "mandatorysubmissions",
   );
   mandatorySubmissionsIndexSection.lineItems =
     mandatorySubmissionsLineItems?.filter(Boolean);

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processPaymentReceipts.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processPaymentReceipts.js
@@ -1,8 +1,12 @@
-const { filterCaseBundleBySection } = require("../utils/filterCaseBundleBySection");
+const {
+  filterCaseBundleBySection,
+} = require("../utils/filterCaseBundleBySection");
 const { applyDocketToDocument } = require("../utils/applyDocketToDocument");
 const { getDynamicSectionNumber } = require("../utils/getDynamicSectionNumber");
 const { search_task_v2, search_task_mangement } = require("../../api");
-const { duplicateExistingFileStore } = require("../utils/duplicateExistingFileStore");
+const {
+  duplicateExistingFileStore,
+} = require("../utils/duplicateExistingFileStore");
 const { logger } = require("../../logger");
 
 async function processPaymentReceipts(
@@ -11,33 +15,35 @@ async function processPaymentReceipts(
   tenantId,
   requestInfo,
   TEMP_FILES_DIR,
-  indexCopy
+  indexCopy,
 ) {
-  logger.info(`[processPaymentReceipts] Started | filingNumber: ${courtCase?.filingNumber}`);
+  logger.info(
+    `[processPaymentReceipts] Started | filingNumber: ${courtCase?.filingNumber}`,
+  );
   const paymentReceiptSection = filterCaseBundleBySection(
     caseBundleMaster,
-    "paymentreceipts"
+    "paymentreceipts",
   );
 
   const sectionPosition = indexCopy.sections?.findIndex(
-    (s) => s.name === "paymentreceipts"
+    (s) => s.name === "paymentreceipts",
   );
 
   const paymentReceiptsIndexSection = indexCopy.sections?.find(
-    (section) => section.name === "paymentreceipts"
+    (section) => section.name === "paymentreceipts",
   );
 
   const dynamicSectionNumber = getDynamicSectionNumber(
     indexCopy,
-    sectionPosition
+    sectionPosition,
   );
 
   const casePaymentReceipt = courtCase.documents
     ?.filter((doc) => doc.documentType === "PAYMENT_RECEIPT")
     ?.sort((a, b) =>
       (a?.additionalDetails?.consumerCode || "").localeCompare(
-        b?.additionalDetails?.consumerCode || ""
-      )
+        b?.additionalDetails?.consumerCode || "",
+      ),
     );
   const genericTaskDocument = await search_task_v2(
     tenantId,
@@ -53,7 +59,7 @@ async function processPaymentReceipts(
       sortBy: "createdDate",
       order: "asc",
       limit: 100,
-    }
+    },
   );
 
   const taskReceipts = genericTaskDocument.data.list
@@ -72,13 +78,13 @@ async function processPaymentReceipts(
       sortBy: "last_modified_time",
       order: "asc",
       limit: 100,
-    }
+    },
   );
 
   const taskMangementReceipts =
     taskMangementData?.data?.taskManagementRecords
       ?.map((task) =>
-        task?.documents?.find?.((d) => d?.documentType === "PAYMENT_RECEIPT")
+        task?.documents?.find?.((d) => d?.documentType === "PAYMENT_RECEIPT"),
       )
       ?.filter(Boolean) || [];
 
@@ -102,14 +108,16 @@ async function processPaymentReceipts(
 
         if (section.docketpagerequired === "yes") {
           const complainant = courtCase.litigants?.find((litigant) =>
-            litigant.partyType.includes("complainant.primary")
+            litigant?.partyType?.includes("complainant.primary"),
           );
-          const docketComplainantName = complainant.additionalDetails.fullName;
-          const docketNameOfAdvocate = courtCase.representatives?.find((adv) =>
-            adv.representing?.find(
-              (party) => party.individualId === complainant.individualId
-            )
-          )?.additionalDetails?.advocateName;
+          const docketComplainantName =
+            complainant?.additionalDetails?.fullName || "";
+          const docketNameOfAdvocate =
+            courtCase.representatives?.find((adv) =>
+              adv?.representing?.some(
+                (party) => party?.individualId === complainant?.individualId,
+              ),
+            )?.additionalDetails?.advocateName || "";
 
           const docketCounselFor = docketNameOfAdvocate
             ? `COUNSEL FOR THE COMPLAINANT - ${docketComplainantName}`
@@ -122,7 +130,7 @@ async function processPaymentReceipts(
               docketCounselFor: docketCounselFor,
               docketNameOfFiling: docketNameOfAdvocate || docketComplainantName,
               docketDateOfSubmission: new Date(
-                courtCase.registrationDate
+                courtCase.registrationDate,
               ).toLocaleDateString("en-IN"),
               documentPath: `${dynamicSectionNumber}.${
                 index + 1
@@ -133,14 +141,14 @@ async function processPaymentReceipts(
             courtCase,
             tenantId,
             requestInfo,
-            TEMP_FILES_DIR
+            TEMP_FILES_DIR,
           );
         } else {
           newFileStoreId = await duplicateExistingFileStore(
             tenantId,
             paymentReceiptFileStoreId,
             requestInfo,
-            TEMP_FILES_DIR
+            TEMP_FILES_DIR,
           );
         }
 
@@ -151,7 +159,7 @@ async function processPaymentReceipts(
           content: "paymentreceipts",
           sortParam: index + 1,
         };
-      })
+      }),
     );
     paymentReceiptsIndexSection.lineItems =
       paymentReceiptLineItems?.filter(Boolean);

--- a/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processPendingApplicationsSection.js
+++ b/backend/ui-integration-services/dristi-pdf/src/caseBundle/sections/processPendingApplicationsSection.js
@@ -1,8 +1,14 @@
 const { search_application_v2 } = require("../../api");
-const { filterCaseBundleBySection } = require("../utils/filterCaseBundleBySection");
+const {
+  filterCaseBundleBySection,
+} = require("../utils/filterCaseBundleBySection");
 const { applyDocketToDocument } = require("../utils/applyDocketToDocument");
-const { combineMultipleFilestores } = require("../utils/combineMultipleFilestores");
-const { duplicateExistingFileStore } = require("../utils/duplicateExistingFileStore");
+const {
+  combineMultipleFilestores,
+} = require("../utils/combineMultipleFilestores");
+const {
+  duplicateExistingFileStore,
+} = require("../utils/duplicateExistingFileStore");
 const { getDynamicSectionNumber } = require("../utils/getDynamicSectionNumber");
 const { logger } = require("../../logger");
 
@@ -18,30 +24,32 @@ async function processPendingApplicationsSection(
   requestInfo,
   TEMP_FILES_DIR,
   indexCopy,
-  messagesMap
+  messagesMap,
 ) {
-  logger.info(`[processPendingApplicationsSection] Started | filingNumber: ${courtCase?.filingNumber}`);
+  logger.info(
+    `[processPendingApplicationsSection] Started | filingNumber: ${courtCase?.filingNumber}`,
+  );
   const pendingReviewApplicationSection = filterCaseBundleBySection(
     caseBundleMaster,
-    "pendingapplications"
+    "pendingapplications",
   );
 
   const pendingReviewApplicationObjectionSection = filterCaseBundleBySection(
     caseBundleMaster,
-    "pendingapplicationobjections"
+    "pendingapplicationobjections",
   );
 
   const sectionPosition = indexCopy.sections?.findIndex(
-    (s) => s.name === "pendingapplications"
+    (s) => s.name === "pendingapplications",
   );
 
   const pendingApplicationsIndexSection = indexCopy.sections?.find(
-    (section) => section.name === "pendingapplications"
+    (section) => section.name === "pendingapplications",
   );
 
   const dynamicSectionNumber = getDynamicSectionNumber(
     indexCopy,
-    sectionPosition
+    sectionPosition,
   );
 
   if (pendingReviewApplicationSection?.length !== 0) {
@@ -60,7 +68,7 @@ async function processPendingApplicationsSection(
         sortBy: section.sorton,
         order: "asc",
         limit: 100,
-      }
+      },
     );
 
     // Search for PENDINGAPPROVAL applications
@@ -78,7 +86,7 @@ async function processPendingApplicationsSection(
         sortBy: section.sorton,
         order: "asc",
         limit: 100,
-      }
+      },
     );
 
     const pendingDocUploadApplications = await search_application_v2(
@@ -95,7 +103,7 @@ async function processPendingApplicationsSection(
         sortBy: section.sorton,
         order: "asc",
         limit: 100,
-      }
+      },
     );
 
     // Combine both application lists
@@ -128,14 +136,14 @@ async function processPendingApplicationsSection(
       const pendingApplicationLineItems = await Promise.all(
         applicationList?.map(async (application, index) => {
           let applicationFileStoreId = application?.documents?.find(
-            (doc) => doc?.documentType === "SIGNED"
+            (doc) => doc?.documentType === "SIGNED",
           )?.fileStore;
           if (
             application.applicationType === "DELAY_CONDONATION" &&
             !applicationFileStoreId
           ) {
             applicationFileStoreId = application?.documents?.find(
-              (doc) => doc?.documentType === "CONDONATION_DOC"
+              (doc) => doc?.documentType === "CONDONATION_DOC",
             )?.fileStore;
           }
           if (!applicationFileStoreId) {
@@ -145,13 +153,13 @@ async function processPendingApplicationsSection(
           let newApplicationFileStoreId = applicationFileStoreId;
 
           if (section.docketpagerequired === "yes") {
-            const sourceUuid = application.auditDetails.createdBy;
+            const sourceUuid = application?.auditDetails?.createdBy;
 
             const sourceLitigant = courtCase.litigants?.find(
-              (litigant) => litigant.additionalDetails.uuid === sourceUuid
+              (litigant) => litigant?.additionalDetails?.uuid === sourceUuid,
             );
             const sourceRepresentative = courtCase.representatives?.find(
-              (rep) => rep.additionalDetails.uuid === sourceUuid
+              (rep) => rep?.additionalDetails?.uuid === sourceUuid,
             );
 
             let docketNameOfFiling;
@@ -159,33 +167,35 @@ async function processPendingApplicationsSection(
 
             if (sourceLitigant) {
               docketNameOfFiling =
-                sourceLitigant.additionalDetails?.fullName || "";
+                sourceLitigant?.additionalDetails?.fullName || "";
               docketCounselFor = "";
             } else if (sourceRepresentative) {
-              const docketNameOfComplainants = sourceRepresentative.representing
-                ?.map((lit) => lit.additionalDetails.fullName)
-                ?.filter(Boolean)
-                ?.join(", ");
+              const docketNameOfComplainants =
+                sourceRepresentative?.representing
+                  ?.map((lit) => lit?.additionalDetails?.fullName)
+                  ?.filter(Boolean)
+                  ?.join(", ");
               const partyType =
-                sourceRepresentative.representing[0].partyType.includes(
-                  "complainant"
+                sourceRepresentative?.representing?.[0]?.partyType?.includes(
+                  "complainant",
                 )
                   ? "COMPLAINANT"
                   : "ACCUSED";
               docketNameOfFiling =
-                sourceRepresentative.additionalDetails?.advocateName || "";
+                sourceRepresentative?.additionalDetails?.advocateName || "";
               docketCounselFor = `COUNSEL FOR THE ${partyType} - ${docketNameOfComplainants}`;
             } else {
               const complainant = courtCase.litigants?.find((litigant) =>
-                litigant.partyType.includes("complainant.primary")
+                litigant?.partyType?.includes("complainant.primary"),
               );
               const docketNameOfComplainants =
-                complainant.additionalDetails.fullName;
+                complainant?.additionalDetails?.fullName || "";
               docketNameOfFiling =
                 courtCase.representatives?.find((adv) =>
-                  adv.representing?.find(
-                    (party) => party.individualId === complainant.individualId
-                  )
+                  adv?.representing?.some(
+                    (party) =>
+                      party?.individualId === complainant?.individualId,
+                  ),
                 )?.additionalDetails?.advocateName || docketNameOfComplainants;
               docketCounselFor =
                 docketNameOfFiling === docketNameOfComplainants
@@ -208,14 +218,14 @@ async function processPendingApplicationsSection(
                 docketCounselFor: docketCounselFor,
                 docketNameOfFiling: docketNameOfFiling,
                 docketDateOfSubmission: new Date(
-                  application.createdDate
+                  application.createdDate,
                 ).toLocaleDateString("en-IN"),
                 documentPath: documentPath,
               },
               courtCase,
               tenantId,
               requestInfo,
-              TEMP_FILES_DIR
+              TEMP_FILES_DIR,
             );
           }
 
@@ -245,16 +255,18 @@ async function processPendingApplicationsSection(
                       courtCase?.representatives?.filter((rep) =>
                         rep?.representing?.some(
                           (complainant) =>
-                            complainant?.individualId === litigant?.individualId
-                        )
+                            complainant?.individualId ===
+                            litigant?.individualId,
+                        ),
                       ) || [],
                   }));
 
                   const sourceLitigant = litigants?.find(
-                    (litigant) => litigant.additionalDetails.uuid === sourceUuid
+                    (litigant) =>
+                      litigant.additionalDetails.uuid === sourceUuid,
                   );
                   const sourceRepresentative = courtCase.representatives?.find(
-                    (rep) => rep.additionalDetails.uuid === sourceUuid
+                    (rep) => rep.additionalDetails.uuid === sourceUuid,
                   );
 
                   const docketNameOfFiling = doc.additionalDetails.author || "";
@@ -265,7 +277,7 @@ async function processPendingApplicationsSection(
                   } else if (sourceRepresentative) {
                     const partyType =
                       sourceRepresentative.representing[0].partyType.includes(
-                        "complainant"
+                        "complainant",
                       )
                         ? "COMPLAINANT"
                         : "ACCUSED";
@@ -298,14 +310,14 @@ async function processPendingApplicationsSection(
                       docketCounselFor: docketCounselFor,
                       docketNameOfFiling: docketNameOfFiling,
                       docketDateOfSubmission: new Date(
-                        doc.auditdetails.createdTime
+                        doc.auditdetails.createdTime,
                       ).toLocaleDateString("en-IN"),
                       documentPath: documentPath,
                     },
                     courtCase,
                     tenantId,
                     requestInfo,
-                    TEMP_FILES_DIR
+                    TEMP_FILES_DIR,
                   );
                 }
                 objectionFileStoreIds.push(newObjectionDocumentFileStoreId);
@@ -314,7 +326,7 @@ async function processPendingApplicationsSection(
                 [newApplicationFileStoreId, ...objectionFileStoreIds],
                 tenantId,
                 requestInfo,
-                TEMP_FILES_DIR
+                TEMP_FILES_DIR,
               );
             }
           }
@@ -324,7 +336,7 @@ async function processPendingApplicationsSection(
               tenantId,
               applicationFileStoreId,
               requestInfo,
-              TEMP_FILES_DIR
+              TEMP_FILES_DIR,
             );
           }
           return {
@@ -334,7 +346,7 @@ async function processPendingApplicationsSection(
             createPDF: false,
             content: "pendingapplications",
           };
-        })
+        }),
       );
       pendingApplicationsIndexSection.lineItems =
         pendingApplicationLineItems?.filter(Boolean);

--- a/frontend/micro-ui/web/micro-ui-internals/packages/css/src/home/home.scss
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/css/src/home/home.scss
@@ -2412,6 +2412,11 @@
   }
 }
 
+.table-pagination.table-pagination-top {
+  padding: 8px 8px;
+  border-bottom: 1px solid #e8e8e8;
+}
+
 .pending-envelope-submission-modal {
   .popup-module-main {
     .popup-module-action-bar {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EfilingValidationUtils.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/citizen/FileCase/EfilingValidationUtils.js
@@ -3478,7 +3478,7 @@ export const updateCaseDetails = async ({
               caseId: litigant?.caseId,
               partyCategory: litigant?.partyCategory,
               individualId: litigant?.individualId,
-              partyType: litigant?.partyType?.includes("complainant") ? "complainant.primary" : "respondent.primary",
+              partyType: litigant?.partyType,
               documents: complainant?.vakalathnamaDoc,
             };
             representings.push(representingData);

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/admission/CaseFileAdmission.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/admission/CaseFileAdmission.js
@@ -149,8 +149,9 @@ function CaseFileAdmission({ t, path }) {
     return allAdvocates?.[caseDetails?.litigants?.find((litigant) => litigant?.partyType === "complainant.primary")?.additionalDetails?.uuid];
   }, [allAdvocates, caseDetails]);
 
+  // Currently for DCA application through efiling, primary complainant is targeted as per current flow.
   const complainantPrimaryUUId = useMemo(
-    () => caseDetails?.litigants?.find((item) => item?.partyType === "complainant.primary").additionalDetails?.uuid || "",
+    () => caseDetails?.litigants?.find((item) => item?.partyType === "complainant.primary")?.additionalDetails?.uuid || "",
     [caseDetails]
   );
 

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/admission/CaseFileAdmission.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/dristi/src/pages/employee/admission/CaseFileAdmission.js
@@ -20,15 +20,7 @@ import {
 import { reviewCaseFileFormConfig } from "../../citizen/FileCase/Config/reviewcasefileconfig";
 import { getAdvocates, transformCaseDataForFetching } from "../../citizen/FileCase/EfilingValidationUtils";
 import AdmissionActionModal from "./AdmissionActionModal";
-import {
-  advocateCaseFilingStatusTypes,
-  DateUtils,
-  getAuthorizedUuid,
-  getCaseEditAllowedAssignees,
-  getFilingType,
-  runComprehensiveSanitizer,
-} from "../../../Utils";
-import { documentTypeMapping } from "../../citizen/FileCase/Config";
+import { advocateCaseFilingStatusTypes, DateUtils, getAuthorizedUuid, getCaseEditAllowedAssignees, runComprehensiveSanitizer } from "../../../Utils";
 import ScheduleHearing from "../AdmittedCases/ScheduleHearing";
 import { SubmissionWorkflowAction, SubmissionWorkflowState } from "../../../Utils/submissionWorkflow";
 import useDownloadCasePdf from "../../../hooks/dristi/useDownloadCasePdf";
@@ -166,12 +158,6 @@ function CaseFileAdmission({ t, path }) {
   });
 
   const filingNumber = useMemo(() => caseDetails?.filingNumber, [caseDetails?.filingNumber]);
-
-  const { data: filingTypeData, isLoading: isFilingTypeLoading } = Digit.Hooks.dristi.useGetStatuteSection("common-masters", [
-    { name: "FilingType" },
-  ]);
-
-  const filingType = useMemo(() => getFilingType(filingTypeData?.FilingType, "CaseFiling"), [filingTypeData?.FilingType]);
 
   const { data: hearingDetails } = Digit.Hooks.hearings.useGetHearings(
     {
@@ -580,21 +566,6 @@ function CaseFileAdmission({ t, path }) {
       });
   };
 
-  const fetchBasicUserInfo = async () => {
-    const individualData = await window?.Digit.DRISTIService.searchIndividualUser(
-      {
-        Individual: {
-          userUuid: [caseDetails?.auditDetails?.createdBy],
-        },
-      },
-      { tenantId, limit: 1000, offset: 0 },
-      "",
-      caseDetails?.auditDetails?.createdBy
-    );
-
-    return individualData?.Individual?.[0]?.individualId;
-  };
-
   const efilingCreatorMainUser = useMemo(() => {
     // If either an advocate or its associated members(jr. advocate/clerk) created the case.
     const isAdvocateOfficeCreator = caseDetails?.representatives?.find(
@@ -610,103 +581,9 @@ function CaseFileAdmission({ t, path }) {
   const handleRegisterCase = async () => {
     setIsDisabled(true);
     setCaseADmitLoader(true);
-    const individualId = await fetchBasicUserInfo();
-    let documentList = [];
-    documentList = [
-      ...documentList,
-      ...caseDetails?.caseDetails?.chequeDetails?.formdata?.map((form) => ({
-        document: form?.data?.bouncedChequeFileUpload?.document,
-        key: "bouncedChequeFileUpload",
-      })),
-      ...caseDetails?.caseDetails?.chequeDetails?.formdata?.map((form) => ({
-        document: form?.data?.depositChequeFileUpload?.document,
-        key: "depositChequeFileUpload",
-      })),
-      ...caseDetails?.caseDetails?.chequeDetails?.formdata?.map((form) => ({
-        document: form?.data?.returnMemoFileUpload?.document,
-        key: "returnMemoFileUpload",
-      })),
-      ...caseDetails?.caseDetails?.debtLiabilityDetails?.formdata?.map((form) => ({
-        document: form?.data?.debtLiabilityFileUpload?.document,
-        key: "debtLiabilityFileUpload",
-      })),
-      ...caseDetails?.caseDetails?.demandNoticeDetails?.formdata?.map((form) => ({
-        document: form?.data?.legalDemandNoticeFileUpload?.document,
-        key: "legalDemandNoticeFileUpload",
-      })),
-      ...caseDetails?.caseDetails?.demandNoticeDetails?.formdata?.map((form) => ({
-        document: form?.data?.proofOfAcknowledgmentFileUpload?.document,
-        key: "proofOfAcknowledgmentFileUpload",
-      })),
-      ...caseDetails?.caseDetails?.demandNoticeDetails?.formdata?.map((form) => ({
-        document: form?.data?.proofOfDispatchFileUpload?.document,
-        key: "proofOfDispatchFileUpload",
-      })),
-      ...caseDetails?.caseDetails?.demandNoticeDetails?.formdata?.map((form) => ({
-        document: form?.data?.proofOfReplyFileUpload?.document,
-        key: "proofOfReplyFileUpload",
-      })),
-      ...caseDetails?.additionalDetails?.prayerSwornStatement?.formdata?.map((form) => ({
-        document: form?.data?.swornStatement?.document,
-        key: "swornStatement",
-      })),
-      ...caseDetails?.additionalDetails?.respondentDetails?.formdata?.map((form) => ({
-        document: form?.data?.inquiryAffidavitFileUpload?.document,
-        key: "inquiryAffidavitFileUpload",
-      })),
-      ...caseDetails?.advocateDetailBlock?.map((data) => ({
-        document: data?.documents?.vakalatnama?.length > 0 ? data?.documents?.vakalatnama : data?.documents?.pipAffidavit,
-        key: data?.documents?.vakalatnama?.length > 0 ? "vakalatnamaFileUpload" : "pipAffidavitFileUpload",
-      })),
-    ].flat();
 
     try {
       const res = await updateCaseDetails("REGISTER", formdata);
-      await Promise.all(
-        documentList
-          ?.filter((data) => data)
-          ?.map(async (data) => {
-            data?.document?.forEach(async (docFile) => {
-              if (docFile?.fileStore) {
-                try {
-                  await DRISTIService.createEvidence({
-                    artifact: {
-                      artifactType: documentTypeMapping[data?.key],
-                      sourceType: "COMPLAINANT",
-                      sourceID: individualId,
-                      asUser: efilingCreatorMainUser, // Sending uuid of the main advocate even if clerk/jr. adv has filed/edited the case.
-                      caseId: caseDetails?.id,
-                      filingNumber: caseDetails?.filingNumber,
-                      cnrNumber: res?.cases?.[0]?.cnrNumber,
-                      tenantId,
-                      comments: [],
-                      file: {
-                        documentType: docFile?.fileType || docFile?.documentType,
-                        fileStore: docFile?.fileStore,
-                        fileName: docFile?.fileName,
-                        documentName: docFile?.documentName,
-                      },
-                      filingType: filingType,
-                      workflow: {
-                        action: "TYPE DEPOSITION",
-                        documents: [
-                          {
-                            documentType: docFile?.fileType || docFile?.documentType,
-                            fileName: docFile?.fileName,
-                            documentName: docFile?.documentName,
-                            fileStoreId: docFile?.fileStore,
-                          },
-                        ],
-                      },
-                    },
-                  });
-                } catch (error) {
-                  console.error(`Error creating evidence for document ${docFile.fileName}:`, error);
-                }
-              }
-            });
-          })
-      );
       setCaseADmitLoader(false);
       setSubmitModalInfo({
         ...registerCaseConfig,
@@ -1018,7 +895,7 @@ function CaseFileAdmission({ t, path }) {
     );
   }
 
-  if (isLoading || isWorkFlowLoading || isLoader || caseAdmitLoader || isApplicationLoading || isFilingTypeLoading) {
+  if (isLoading || isWorkFlowLoading || isLoader || caseAdmitLoader || isApplicationLoading) {
     return <Loader />;
   }
   const scrollToHeading = (heading) => {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/HomeHearingsTab.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/home/src/pages/employee/HomeHearingsTab.js
@@ -649,6 +649,73 @@ const HomeHearingsTab = ({
 
   const { data: hearingLink } = useGetHearingLink();
 
+  const renderPagination = () => (
+    <div className="pagination-info">
+      <span style={{ color: "#505a5f" }}>Rows per page:</span>
+      <select
+        value={rowsPerPage}
+        onChange={(e) => {
+          setRowsPerPage(Number(e.target.value));
+          setPage(0);
+        }}
+      >
+        {[10, 20, 30, 40, 50].map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+      </select>
+
+      <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
+        <span style={{ color: "#505a5f" }}>
+          {hearingCount === 0 ? "0 of 0" : `${page * rowsPerPage + 1}–${Math.min((page + 1) * rowsPerPage, hearingCount)} of ${hearingCount}`}
+        </span>
+
+        {page > 0 && (
+          <button
+            style={{
+              background: "transparent",
+              border: "none",
+              fontSize: "16px",
+              cursor: "pointer",
+              padding: 0,
+              margin: 0,
+              display: "flex",
+              alignItems: "center",
+            }}
+            onClick={() => setPage((prev) => prev - 1)}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#505a5f" class="cp" width="18px" height="18px">
+              <path d="M0 0h24v24H0z" fill="none"></path>
+              <path d="M11.67 3.87L9.9 2.1 0 12l9.9 9.9 1.77-1.77L3.54 12z"></path>
+            </svg>
+          </button>
+        )}
+
+        {(page + 1) * rowsPerPage < hearingCount && (
+          <button
+            style={{
+              background: "transparent",
+              border: "none",
+              fontSize: "16px",
+              cursor: "pointer",
+              padding: 0,
+              margin: 0,
+              display: "flex",
+              alignItems: "center",
+            }}
+            onClick={() => setPage((prev) => prev + 1)}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#505a5f" width="18px" height="18px">
+              <path d="M0 0h24v24H0z" fill="none" />
+              <path d="M5.88 4.12 13.76 12l-7.88 7.88L8 22l10-10L8 2z" />
+            </svg>
+          </button>
+        )}
+      </div>
+    </div>
+  );
+
   if (isEpostUser) {
     history.push(homePath);
   }
@@ -821,6 +888,7 @@ const HomeHearingsTab = ({
         </div>
       </div>
       <div className="main-table-card">
+        <div className="table-pagination table-pagination-top">{renderPagination()}</div>
         <div className="table-scroll">
           <table className="main-table">
             <thead>
@@ -852,72 +920,7 @@ const HomeHearingsTab = ({
               )}
             </tbody>
           </table>
-          <div className="table-pagination">
-            <div className="pagination-info">
-              <span style={{ color: "#505a5f" }}>Rows per page:</span>
-              <select
-                value={rowsPerPage}
-                onChange={(e) => {
-                  setRowsPerPage(Number(e.target.value));
-                  setPage(0);
-                }}
-              >
-                {[10, 20, 30, 40, 50].map((option) => (
-                  <option key={option} value={option}>
-                    {option}
-                  </option>
-                ))}
-              </select>
-
-              <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
-                <span style={{ color: "#505a5f" }}>
-                  {hearingCount === 0 ? "0 of 0" : `${page * rowsPerPage + 1}–${Math.min((page + 1) * rowsPerPage, hearingCount)} of ${hearingCount}`}
-                </span>
-
-                {page > 0 && (
-                  <button
-                    style={{
-                      background: "transparent",
-                      border: "none",
-                      fontSize: "16px",
-                      cursor: "pointer",
-                      padding: 0,
-                      margin: 0,
-                      display: "flex",
-                      alignItems: "center",
-                    }}
-                    onClick={() => setPage((prev) => prev - 1)}
-                  >
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#505a5f" class="cp" width="18px" height="18px">
-                      <path d="M0 0h24v24H0z" fill="none"></path>
-                      <path d="M11.67 3.87L9.9 2.1 0 12l9.9 9.9 1.77-1.77L3.54 12z"></path>
-                    </svg>
-                  </button>
-                )}
-
-                {(page + 1) * rowsPerPage < hearingCount && (
-                  <button
-                    style={{
-                      background: "transparent",
-                      border: "none",
-                      fontSize: "16px",
-                      cursor: "pointer",
-                      padding: 0,
-                      margin: 0,
-                      display: "flex",
-                      alignItems: "center",
-                    }}
-                    onClick={() => setPage((prev) => prev + 1)}
-                  >
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#505a5f" width="18px" height="18px">
-                      <path d="M0 0h24v24H0z" fill="none" />
-                      <path d="M5.88 4.12 13.76 12l-7.88 7.88L8 22l10-10L8 2z" />
-                    </svg>
-                  </button>
-                )}
-              </div>
-            </div>
-          </div>
+          <div className="table-pagination">{renderPagination()}</div>
         </div>
       </div>
       {showEndHearingModal.openEndHearingModal && (

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/pages/employee/SubmissionsCreate.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/submissions/src/pages/employee/SubmissionsCreate.js
@@ -79,6 +79,9 @@ const SubmissionsCreate = ({ path }) => {
     showModal,
   } = Digit.Hooks.useQueryParams();
   const [formdata, setFormdata] = useState({});
+  // Application object returned directly by create/update submit API. Used as a fallback
+  // source for the review flow so a lagging refetch cannot show/submit stale data.
+  const [submittedApplication, setSubmittedApplication] = useState(null);
   const [showReviewModal, setShowReviewModal] = useState(false);
   const [showsignatureModal, setShowsignatureModal] = useState(false);
   const [showSuccessModal, setShowSuccessModal] = useState(false);
@@ -327,19 +330,37 @@ const SubmissionsCreate = ({ path }) => {
   ]);
   const referenceId = useMemo(() => applicationData?.applicationList?.[0]?.referenceId, [applicationData]);
 
-  const applicationDetails = useMemo(
-    () =>
-      applicationNumber
-        ? applicationData?.applicationList?.[0]
-        : "DELAY_CONDONATION" === formdata?.applicationType?.type
-        ? delayCondonationData?.applicationList?.find(
-            (application) =>
-              !["REJECTED", "COMPLETED", "PENDINGPAYMENT", "PENDINGREVIEW"].includes(application?.status) &&
-              "DELAY_CONDONATION" === application?.applicationType
-          )
-        : undefined,
-    [applicationData?.applicationList, delayCondonationData?.applicationList, formdata?.applicationType?.type]
-  );
+  const applicationDetails = useMemo(() => {
+    const refetchedApplication = applicationNumber
+      ? applicationData?.applicationList?.[0]
+      : "DELAY_CONDONATION" === formdata?.applicationType?.type
+      ? delayCondonationData?.applicationList?.find(
+          (application) =>
+            !["REJECTED", "COMPLETED", "PENDINGPAYMENT", "PENDINGREVIEW"].includes(application?.status) &&
+            "DELAY_CONDONATION" === application?.applicationType
+        )
+      : undefined;
+
+    // Prefer the application returned directly by the create/update submit API over the
+    // refetched copy when the refetch has not caught up yet (backend read lag). We keep
+    // using the refetched copy once it is at least as fresh as the submit response, so
+    // downstream updates (e.g. after e-sign/payment) are not masked by a stale snapshot.
+    if (submittedApplication && applicationNumber && submittedApplication?.applicationNumber === applicationNumber) {
+      const submittedTime = submittedApplication?.auditDetails?.lastModifiedTime || 0;
+      const refetchedTime = refetchedApplication?.auditDetails?.lastModifiedTime || 0;
+      if (!refetchedApplication || submittedTime >= refetchedTime) {
+        return submittedApplication;
+      }
+    }
+
+    return refetchedApplication;
+  }, [
+    applicationData?.applicationList,
+    delayCondonationData?.applicationList,
+    formdata?.applicationType?.type,
+    submittedApplication,
+    applicationNumber,
+  ]);
 
   const submissionType = useMemo(() => {
     return formdata?.submissionType?.code;
@@ -1599,10 +1620,13 @@ const SubmissionsCreate = ({ path }) => {
       const action = isEligibleForSubmission ? SubmissionWorkflowAction.SUBMIT : SubmissionWorkflowAction.SAVEDRAFT;
       if (applicationNumber) {
         const res = await submitSubmission({ update: true, action });
-        await applicationRefetch();
+        // Retain the authoritative submit response so the review flow does not depend on a
+        // possibly-stale refetch (guarded by lastModifiedTime in the applicationDetails memo).
+        setSubmittedApplication(res?.application);
         setShowReviewModal(true);
       } else {
         const res = await submitSubmission({ update: false, action });
+        setSubmittedApplication(res?.application);
         const newapplicationNumber = res?.application?.applicationNumber;
         if (newapplicationNumber) {
           if (action === SubmissionWorkflowAction.SUBMIT) {
@@ -1675,11 +1699,12 @@ const SubmissionsCreate = ({ path }) => {
       }
 
       if (applicationNumber) {
-        await submitSubmission({ update: true, action: SubmissionWorkflowAction.SAVEDRAFT });
-        await applicationRefetch();
+        const res = await submitSubmission({ update: true, action: SubmissionWorkflowAction.SAVEDRAFT });
+        setSubmittedApplication(res?.application);
         setShowToast({ label: t("DRAFT_SAVED_SUCCESSFULLY"), error: false });
       } else {
         const res = await submitSubmission({ update: false, action: SubmissionWorkflowAction.SAVEDRAFT });
+        setSubmittedApplication(res?.application);
         const newapplicationNumber = res?.application?.applicationNumber;
         if (newapplicationNumber) {
           sessionStorage.setItem("DRAFT_SAVED_SUCCESSFULLY", "success");


### PR DESCRIPTION
## Requirements

- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`

## Summary

Cherry-pick of the tickets marked **QA Completed & Ready For UAT release** on the [PUCAR v1.0 board](https://github.com/orgs/pucardotorg/projects/1). No new code — every commit is an unmodified `-x` cherry-pick of a squash commit already merged to `develop`.

| Ticket | Source PR (into `develop`) | Cherry-picked commit |
|---|---|---|
| Cherry-pick for https://github.com/pucardotorg/dristi/issues/5880 | #6872 — Bug 5880 | `97a83f855af7950d68e055d1dcb08e61254bd975` |
| Cherry-pick for https://github.com/pucardotorg/dristi/issues/5880 | #6874 — fixed syntax error in processBailDocuments | `c9413e0f966313c70ed5e4cfa25fe51312babceb` |
| Cherry-pick for https://github.com/pucardotorg/dristi/issues/5908 | #6896 — removed evidence creation logic while registering cases | `6accd960a2f21994d0592adc427125f522063634` |
| Cherry-pick for https://github.com/pucardotorg/dristi/issues/5908 | #6897 — create evidence artifacts on registration via async workflow | `52c5447b356cece70383e622b7faf771aa4dc317` |
| Cherry-pick for https://github.com/pucardotorg/dristi/issues/5922 | #6900 — pagination navigator on top of Today's Hearings | `7938a6b5975500fa1f310f5e4d139cc4a74b3029` |
| Cherry-pick for https://github.com/pucardotorg/dristi/issues/5920 | #6901 — refetch logic to prevent stale data in review flow | `251232d7acb93567310a901e57b5788c1b9440c5` |

Commits are applied in original merge order, which matters for #5908: the frontend removal (#6896) must precede the backend replacement (#6897).

### What each change does

- **#5880 — single complainant/respondent assumptions.** Guards the unguarded `complainant.primary` lookups across 13 case-bundle PDF section files (previously a `TypeError` that crashed case-bundle generation), fixes `EfilingValidationUtils.js` forcing every litigant to `*.primary` on advocate reassignment, and cleans up `CaseFileAdmission.js`. Follow-ups (judgement-order template, docket multi-litigant redesign) were split into separate tickets and are **not** in scope here.
- **#5908 — evidence creation moved to backend.** Evidence-document creation at case registration moves out of the frontend into the `case` service, driven asynchronously over Kafka.
- **#5920 — bail bond surety mobile number lost.** Fixes a persister race: the frontend refetched the application ~300ms after the Kafka draft-save and read a stale row, then PUT that stale snapshot back, wiping the second surety's mobile number.
- **#5922 — pagination navigator at top.** Adds the page navigator above the Today's Hearings table (scoped to that page by standup decision, as it is built independently of `InboxSearchComposer`).

### Not included

https://github.com/pucardotorg/dristi/issues/5925 is also QA-signed-off but is **already on `main`** via #6902 (`9b188efca375ba1ca9edc681446e6f1f4217e651`), so it is intentionally excluded.

## Data Changes

No MDMS or workflow data changes.

**Deployment prerequisite** — #6897 introduces a new Kafka topic that must exist in the target environment before the `case` service starts:

- `egov.case.register.evidence.topic=case-register-evidence` (new key in `case` service `application.properties`, bound in `Configuration.java`)

## Preview

UI changes were verified in QA on the source PRs; screenshots and Jam recordings are attached on the linked tickets (#5920, #5922, #5925).

## Other

- All six commits applied cleanly with **no merge conflicts**.
- Net diff vs `main`: 23 files, +818 / −551.
- Backend surface is limited to the `case` service; frontend touches `dristi-case-pdf` case-bundle sections plus the `dristi`, `home`, `submissions`, and `css` packages.