### PR TITLE
fix(5965): guard null representatives in join case task validation

### DIFF
--- a/backend/dristi-services/case/src/main/java/org/pucar/dristi/service/CaseService.java
+++ b/backend/dristi-services/case/src/main/java/org/pucar/dristi/service/CaseService.java
@@ -5431,11 +5431,17 @@ public class CaseService {
 
             log.info("operation=updateJoinCaseApproved, status=IN_PROGRESS, joinCaseRequest, advocateUuid : {}, {}", joinCaseRequest, advocateUuid);
 
+            // a case with no advocate mapping yet (every litigant in person) comes back with
+            // representatives as null, so normalise it here before anyone reads or adds to it
             List<AdvocateMapping> advocateMappings = courtCase.getRepresentatives();
+            if (advocateMappings == null) {
+                advocateMappings = new ArrayList<>();
+                courtCase.setRepresentatives(advocateMappings);
+            }
 
             // checking weather advocate is present in case or not
             AdvocateMapping advocateTryingToReplace = advocateMappings.stream().filter(advocateMapping ->
-                    advocateMapping.getAdvocateId().equalsIgnoreCase(advocateUuid)).findFirst().orElse(null);
+                    advocateUuid != null && advocateUuid.equalsIgnoreCase(advocateMapping.getAdvocateId())).findFirst().orElse(null);
 
             AuditDetails auditDetails = enrichAuditDetails(requestInfo);
 
@@ -5450,18 +5456,19 @@ public class CaseService {
             List<ReplacementDetails> replacementDetailsList = joinCaseRequest.getReplacementDetails();
             AdvocateDetails advocateDetails = joinCaseRequest.getAdvocateDetails();
 
-            for (ReplacementDetails replacementDetails : replacementDetailsList) {
+            for (ReplacementDetails replacementDetails : replacementDetailsList == null ? new ArrayList<ReplacementDetails>() : replacementDetailsList) {
 
                 Party party = enrichParty(replacementDetails, courtCase, auditDetails);
                 LitigantDetails litigantDetails = replacementDetails.getLitigantDetails();
                 String partyType = litigantDetails.getPartyType();
                 ReplacementAdvocateDetails advocateDetailsToBeReplaced = new ReplacementAdvocateDetails();
                 String advocateUuidToBeReplaced = null;
-                if (!replacementDetails.getIsLitigantPip()) {
+                boolean isLitigantPip = Boolean.TRUE.equals(replacementDetails.getIsLitigantPip());
+                if (!isLitigantPip) {
                     advocateDetailsToBeReplaced = replacementDetails.getAdvocateDetails();
                     advocateUuidToBeReplaced = advocateDetailsToBeReplaced.getAdvocateUuid();
                 }
-                if (replacementDetails.getIsLitigantPip()) {
+                if (isLitigantPip) {
                     List<Party> litigantParties = courtCase.getLitigants();
                     if (advocateTryingToReplace == null) {
                         // adding the advocate in representatives list as he is new joining the case
@@ -5473,8 +5480,9 @@ public class CaseService {
                                 advocateTryingToReplace, courtCaseObj
                         );
                     }
-                    for (Party litigantParty : litigantParties) {
-                        if (litigantParty.getIndividualId().equalsIgnoreCase(litigantDetails.getIndividualId())) {
+                    for (Party litigantParty : litigantParties == null ? new ArrayList<Party>() : litigantParties) {
+                        if (litigantDetails.getIndividualId() != null
+                                && litigantDetails.getIndividualId().equalsIgnoreCase(litigantParty.getIndividualId())) {
                             // inactive the litigant from pip as advocate going to represent him
                             litigantParty.setPartyInPerson(false);
                         }
@@ -5490,9 +5498,7 @@ public class CaseService {
                                 advocateTryingToReplace, courtCaseObj
                         );
                     }
-                    if (!replacementDetails.getIsLitigantPip()) {
-                        inactivateOldAdvocate(replacementDetails, courtCase);
-                    }
+                    inactivateOldAdvocate(replacementDetails, courtCase);
                 }
 
                 // Enrich advocate office case members for the joining advocate
@@ -5559,9 +5565,13 @@ public class CaseService {
 
     private boolean validateAdvocateAlreadyRepresenting(AdvocateMapping advocateMapping, String
             litigantIndividualId) {
+        if (advocateMapping.getRepresenting() == null) {
+            return false;
+        }
         Party party = advocateMapping.getRepresenting().stream()
-                .filter(representing -> representing.getIndividualId().equalsIgnoreCase(litigantIndividualId)).findFirst().orElse(null);
-        return party != null && party.getIsActive();
+                .filter(representing -> litigantIndividualId != null
+                        && litigantIndividualId.equalsIgnoreCase(representing.getIndividualId())).findFirst().orElse(null);
+        return party != null && Boolean.TRUE.equals(party.getIsActive());
     }
 
     private void inactivateOldAdvocate(ReplacementDetails replacementDetails, CourtCase courtCase) {
@@ -5570,15 +5580,23 @@ public class CaseService {
         String litigantId = replacementDetails.getLitigantDetails().getIndividualId();
         //  remove the litigant in old advocate's representing list as another advocate is trying to replace
 
+        if (courtCase.getRepresentatives() == null) {
+            courtCase.setRepresentatives(new ArrayList<>());
+        }
+
         courtCase.getRepresentatives().stream()
-                .filter(mapping -> mapping.getAdvocateId().equalsIgnoreCase(advocateId))
+                .filter(mapping -> advocateId != null && advocateId.equalsIgnoreCase(mapping.getAdvocateId()))
                 .findFirst()
                 .ifPresent(mapping -> {
+                    if (mapping.getRepresenting() == null) {
+                        mapping.setRepresenting(new ArrayList<>());
+                    }
                     mapping.getRepresenting().stream()
-                            .filter(representing -> representing.getIndividualId().equalsIgnoreCase(litigantId))
+                            .filter(representing -> litigantId != null
+                                    && litigantId.equalsIgnoreCase(representing.getIndividualId()))
                             .forEach(representing -> representing.setIsActive(false)); // Use forEach to modify elements
 
-                    mapping.setIsActive(mapping.getRepresenting().stream().anyMatch(Party::getIsActive));
+                    mapping.setIsActive(mapping.getRepresenting().stream().anyMatch(party -> Boolean.TRUE.equals(party.getIsActive())));
                 });
         producer.push(config.getUpdateRepresentativeJoinCaseTopic(), courtCase);
 
@@ -5839,6 +5857,9 @@ public class CaseService {
         advocateMappingList.add(advocateMapping);
 
         courtCaseObj.setRepresentatives(advocateMappingList);
+        if (courtCase.getRepresentatives() == null) {
+            courtCase.setRepresentatives(new ArrayList<>());
+        }
         courtCase.getRepresentatives().add(advocateMapping);
         return advocateMapping;
     }
@@ -5847,14 +5868,18 @@ public class CaseService {
                                                List<AdvocateMapping> advocateMappings, AdvocateMapping advocateTryingToReplace,
                                                CourtCase courtCaseObj) {
 
-        for (AdvocateMapping advocateMapping : advocateMappings) {
-            if (advocateMapping.getAdvocateId().equalsIgnoreCase(advocateUuid)) {
+        for (AdvocateMapping advocateMapping : advocateMappings == null ? new ArrayList<AdvocateMapping>() : advocateMappings) {
+            if (advocateUuid != null && advocateUuid.equalsIgnoreCase(advocateMapping.getAdvocateId())) {
 
                 boolean isAdvocateAlreadyRepresenting = validateAdvocateAlreadyRepresenting(advocateTryingToReplace, party.getIndividualId());
 
                 if (!isAdvocateAlreadyRepresenting) {
 
                     // Add the party to the representing list of the specific advocate mapping
+                    // representing is null when the mapping has no representing rows
+                    if (advocateMapping.getRepresenting() == null) {
+                        advocateMapping.setRepresenting(new ArrayList<>());
+                    }
                     advocateMapping.getRepresenting().add(party);
 
                     // Update the representatives in the original court case
@@ -5881,11 +5906,13 @@ public class CaseService {
             pendingAdvocateRequest) {
         log.info("operation=updateStatusOfAdvocate, status=IN_PROGRESS,courtCase advocateUuid,pendingAdvocateRequest : {}, {} ,{}", courtCase, advocateUuid,
                 pendingAdvocateRequest);
+        // representatives is null for a case that has no advocate mapping yet, and this is also
+        // reached from the reject path where nothing has normalised it
         List<AdvocateMapping> advocateMappings = courtCase.getRepresentatives();
         List<PendingAdvocateRequest> pendingAdvocateRequests = courtCase.getPendingAdvocateRequests();
 
-        boolean hasMapping = advocateMappings.stream()
-                .anyMatch(mapping -> mapping.getAdvocateId().equalsIgnoreCase(advocateUuid));
+        boolean hasMapping = advocateMappings != null && advocateMappings.stream()
+                .anyMatch(mapping -> advocateUuid != null && advocateUuid.equalsIgnoreCase(mapping.getAdvocateId()));
 
 
         if (hasMapping && pendingAdvocateRequest.getTaskReferenceNoList().isEmpty()) {

--- a/backend/dristi-services/task/src/main/java/org/pucar/dristi/validators/TaskRegistrationValidator.java
+++ b/backend/dristi-services/task/src/main/java/org/pucar/dristi/validators/TaskRegistrationValidator.java
@@ -12,8 +12,10 @@ import org.pucar.dristi.util.OrderUtil;
 import org.pucar.dristi.web.models.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.pucar.dristi.config.ServiceConstants.*;
@@ -131,6 +133,11 @@ public class TaskRegistrationValidator {
         AdvocateDetails advocateDetails = joinCaseTaskRequest.getAdvocateDetails();
         List<ReplacementDetails> replacementDetailsList = joinCaseTaskRequest.getReplacementDetails();
 
+        if (CollectionUtils.isEmpty(replacementDetailsList)) {
+            log.info("operation=isValidJoinCasePendingTask, status=SUCCESS, no replacement details to validate, task request: {}", body);
+            return true;
+        }
+
         for (ReplacementDetails replacement : replacementDetailsList) {
             // Return false immediately if any replacement is invalid
             if (!isValidReplacement(replacement, courtCase, advocateDetails)) {
@@ -145,7 +152,7 @@ public class TaskRegistrationValidator {
     // The rest of the methods remain the same
     private CourtCase getCourtCase(TaskRequest body) {
         List<CourtCase> cases = caseUtil.getCaseDetails(body);
-        if (cases.isEmpty()) {
+        if (CollectionUtils.isEmpty(cases)) {
             throw new CustomException(UPDATE_TASK_ERR, "case not found");
         }
         return cases.get(0);
@@ -154,7 +161,7 @@ public class TaskRegistrationValidator {
     private boolean isValidReplacement(ReplacementDetails replacement, CourtCase courtCase, AdvocateDetails advocateDetails) {
         String litigantId = replacement.getLitigantDetails().getIndividualId();
 
-        if (replacement.getIsLitigantPip()) {
+        if (Boolean.TRUE.equals(replacement.getIsLitigantPip())) {
             return isValidPipLitigantReplacement(litigantId, courtCase);
         } else {
             return isValidAdvocateReplacement(replacement, courtCase, advocateDetails);
@@ -174,23 +181,19 @@ public class TaskRegistrationValidator {
     }
 
     private Party findActiveLitigantById(String litigantId, List<Party> parties) {
-        return parties.stream()
-                .filter(party -> party.getIndividualId().equalsIgnoreCase(litigantId) && party.getIsActive())
+        return emptyIfNull(parties).stream()
+                .filter(party -> isActivePartyOf(party, litigantId))
                 .findFirst()
                 .orElse(null);
     }
 
     private boolean isLitigantStillSelfRepresented(String litigantId, List<AdvocateMapping> advocateMappings) {
         log.info("operation=isLitigantStillSelfRepresented, status=IN_PROGRESS, litigantId , advocateMappings: {} , {}",litigantId, advocateMappings);
-        for (AdvocateMapping mapping : advocateMappings) {
-            Party litigantParty = mapping.getRepresenting().stream()
-                    .filter(party -> party.getIndividualId().equalsIgnoreCase(litigantId) && party.getIsActive())
-                    .findFirst()
-                    .orElse(null);
-
+        // A case with no representatives comes back as null from case service, meaning nobody is represented
+        for (AdvocateMapping mapping : emptyIfNull(advocateMappings)) {
             // If litigant is actively represented by an advocate, they're not self-represented
-            if (litigantParty != null) {
-                log.info("operation=isLitigantStillSelfRepresented, status=FAILURE, litigantId , advocateMappings: {} , {}, {}",litigantId, advocateMappings, litigantParty);
+            if (isRepresentingActiveLitigant(mapping, litigantId)) {
+                log.info("operation=isLitigantStillSelfRepresented, status=FAILURE, litigantId , advocateMappings: {} , {}, {}",litigantId, advocateMappings, mapping);
                 return false;
             }
         }
@@ -212,7 +215,7 @@ public class TaskRegistrationValidator {
         }
 
         // Check if the advocate is representing the specified litigant and the litigant is active
-        if (!isAdvocateRepresentingActiveLitigant(advocateMapping, litigantId)) {
+        if (!isRepresentingActiveLitigant(advocateMapping, litigantId)) {
             log.info("operation=isValidAdvocateReplacement, status=FAILURE, replacement details , courtCase, advocateMapping: {} , {}, {}",replacement,courtCase, advocateMapping);
             return false;
         }
@@ -222,32 +225,39 @@ public class TaskRegistrationValidator {
     }
 
     private AdvocateMapping findActiveAdvocateById(String advocateId, List<AdvocateMapping> advocateMappings) {
-        return advocateMappings.stream()
-                .filter(mapping -> mapping.getAdvocateId().equalsIgnoreCase(advocateId) && mapping.getIsActive())
+        return emptyIfNull(advocateMappings).stream()
+                .filter(mapping -> isSameAdvocate(advocateId, mapping) && Boolean.TRUE.equals(mapping.getIsActive()))
                 .findFirst()
                 .orElse(null);
     }
 
-    private boolean isAdvocateRepresentingActiveLitigant(AdvocateMapping advocateMapping, String litigantId) {
-        return advocateMapping.getRepresenting().stream()
-                .anyMatch(party -> party.getIndividualId().equalsIgnoreCase(litigantId) && party.getIsActive());
-    }
-
     private boolean isAdvocateAlreadyRepresentingLitigant(String advocateId, String litigantId, List<AdvocateMapping> advocateMappings) {
-        for (AdvocateMapping mapping : advocateMappings) {
-            if (mapping.getAdvocateId().equalsIgnoreCase(advocateId)) {
-                Party litigantParty = mapping.getRepresenting().stream()
-                        .filter(party -> party.getIndividualId().equalsIgnoreCase(litigantId) && party.getIsActive())
-                        .findFirst()
-                        .orElse(null);
-
-                if (litigantParty != null) {
-                    log.info("operation=isAdvocateAlreadyRepresentingLitigant, status=SUCCESS, advocateId, litigantId , {} , {}",advocateId, litigantId);
-                    return true;
-                }
+        for (AdvocateMapping mapping : emptyIfNull(advocateMappings)) {
+            if (isSameAdvocate(advocateId, mapping) && isRepresentingActiveLitigant(mapping, litigantId)) {
+                log.info("operation=isAdvocateAlreadyRepresentingLitigant, status=SUCCESS, advocateId, litigantId , {} , {}",advocateId, litigantId);
+                return true;
             }
         }
         log.info("operation=isAdvocateAlreadyRepresentingLitigant, status=FAILURE, advocateId, litigantId , {} , {}",advocateId, litigantId);
         return false;
+    }
+
+    private boolean isRepresentingActiveLitigant(AdvocateMapping advocateMapping, String litigantId) {
+        return emptyIfNull(advocateMapping.getRepresenting()).stream()
+                .anyMatch(party -> isActivePartyOf(party, litigantId));
+    }
+
+    private boolean isActivePartyOf(Party party, String litigantId) {
+        return litigantId != null
+                && litigantId.equalsIgnoreCase(party.getIndividualId())
+                && Boolean.TRUE.equals(party.getIsActive());
+    }
+
+    private boolean isSameAdvocate(String advocateId, AdvocateMapping mapping) {
+        return advocateId != null && advocateId.equalsIgnoreCase(mapping.getAdvocateId());
+    }
+
+    private <T> List<T> emptyIfNull(List<T> list) {
+        return list == null ? Collections.emptyList() : list;
     }
 }


### PR DESCRIPTION
Fixes #5965

PIP litigants could not request an advocate to join a case (ST/846/2026, ST/844/2026). One root cause, two services — both fixed here.

## Root cause

The case service loads representatives with `courtCase.setRepresentatives(representativeMap.get(courtCase.getId()))` (`CaseRepository:611`, `CaseRepositoryV2:636`). `Map.get` returns `null` — not an empty list — when the case has **no advocate mapping at all**, which is exactly the state a fully party-in-person case is in when its litigant asks an advocate to join. `CourtCase` is serialized without `@JsonInclude(NON_NULL)`, so consumers receive `"representatives": null` and Jackson writes that null straight over the `= new ArrayList<>()` field initializer.

Both services then iterated that null list.

## 1. task service — `TaskRegistrationValidator`

`TaskService.updateTask` revalidates every `JOIN_CASE` task. The PIP path reached `isLitigantStillSelfRepresented(litigantId, courtCase.getRepresentatives())`, which iterated directly:

```
Error occurred while updating task: Cannot invoke "java.util.List.iterator()" because "advocateMappings" is null
```

- skip validation when `replacementDetails` is null/empty
- treat a null `representatives` / `litigants` / `representing` list as empty
- `getCourtCase` uses `CollectionUtils.isEmpty` — `getCaseDetails` can return `null`
- collapse the three duplicated `getRepresenting().stream()` blocks into one helper

A PIP litigant on a case with no representatives is now correctly reported as still self-represented, so the task validates and the update proceeds. The advocate-replacement branch on a null `representatives` returns `false`, so the task is force-rejected via the existing stale-task path in `TaskService:231` — unchanged intent, no longer a 500.

## 2. case service — `CaseService`

With the task side fixed, the request reached the Kafka consumer and hit the same null list:

```
java.lang.NullPointerException: Cannot invoke "java.util.List.stream()" because "advocateMappings" is null
    at CaseService.updateCourtCaseObject(CaseService.java:5437)
    at CaseService.updateJoinCaseApproved(CaseService.java:4935)
    at CaseUpdateConsumer.updateCaseObjectApprovedTask(CaseUpdateConsumer.java:80)
```

Fixing only the reported line would have moved the crash two lines down, so all four sites on this path are covered:

| Method | Why it crashes |
|---|---|
| `updateCourtCaseObject:5437` | the reported NPE — representatives normalised once at the top, so every read and add below is safe |
| `enrichAdvocateDetailsInRepresentativesList` | `courtCase.getRepresentatives().add(...)` — the very next step on the PIP path |
| `updateStatusOfAdvocate` | also reached from `updateJoinCaseRejected:4877` with no normalisation at all, so **rejecting** a join request on a zero-advocate case crashed the same way |
| `updateExistingAdvocateMapping` / `validateAdvocateAlreadyRepresenting` / `inactivateOldAdvocate` | additionally guard a null `representing` list |

Also, in both services: compare ids from the request side so a null `advocateId` / `individualId` on the case is a non-match rather than an NPE, and stop unboxing nullable `Boolean`s. Drops one redundant `!isLitigantPip` check that sat inside the branch where it was already false.

## Testing

- both modules compile clean
- `TaskRegistrationValidatorTest` — 4 passing
- `CaseServiceTest` — 64 passing

## Follow-up (deliberately not in this PR)

This is a defensive fix at the two consumers. The source is `Map.get` in `CaseRepository` / `CaseRepositoryV2` returning null instead of an empty list, which still affects every other consumer of the case search. Fixing it there changes the shape of every case search response (`representatives: []` instead of `null`), so it deserves its own ticket and its own regression pass rather than riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
