### PR TITLE
fix(5906): waive court fee for attachment and proclamation processes

### DIFF
--- a/backend/dristi-services/order-management/src/main/java/pucar/strategy/ordertype/PublishOrderAttachment.java
+++ b/backend/dristi-services/order-management/src/main/java/pucar/strategy/ordertype/PublishOrderAttachment.java
@@ -6,24 +6,24 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.egov.common.contract.request.RequestInfo;
-import org.egov.common.contract.request.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import pucar.config.StateSlaMap;
-import pucar.service.SmsNotificationService;
 import pucar.strategy.OrderUpdateStrategy;
-import pucar.util.*;
+import pucar.util.CaseUtil;
+import pucar.util.JsonUtil;
+import pucar.util.TaskUtil;
 import pucar.web.models.Order;
 import pucar.web.models.OrderRequest;
-import pucar.web.models.SMSTemplateData;
 import pucar.web.models.adiary.CaseDiaryEntry;
-import pucar.web.models.courtCase.*;
-import pucar.web.models.pendingtask.PendingTask;
-import pucar.web.models.pendingtask.PendingTaskRequest;
+import pucar.web.models.courtCase.CaseCriteria;
+import pucar.web.models.courtCase.CaseSearchRequest;
+import pucar.web.models.courtCase.CourtCase;
 import pucar.web.models.task.TaskRequest;
-import pucar.web.models.task.TaskResponse;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import static pucar.config.ServiceConstants.*;
 
@@ -34,22 +34,14 @@ public class PublishOrderAttachment implements OrderUpdateStrategy {
     private final TaskUtil taskUtil;
     private final ObjectMapper objectMapper;
     private final CaseUtil caseUtil;
-    private final PendingTaskUtil pendingTaskUtil;
     private final JsonUtil jsonUtil;
-    private final AdvocateUtil advocateUtil;
-    private final UserUtil userUtil;
-    private final SmsNotificationService smsNotificationService;
 
     @Autowired
-    public PublishOrderAttachment(TaskUtil taskUtil, ObjectMapper objectMapper, CaseUtil caseUtil, PendingTaskUtil pendingTaskUtil, JsonUtil jsonUtil, AdvocateUtil advocateUtil, UserUtil userUtil, SmsNotificationService smsNotificationService) {
+    public PublishOrderAttachment(TaskUtil taskUtil, ObjectMapper objectMapper, CaseUtil caseUtil, JsonUtil jsonUtil) {
         this.taskUtil = taskUtil;
         this.objectMapper = objectMapper;
         this.caseUtil = caseUtil;
-        this.pendingTaskUtil = pendingTaskUtil;
         this.jsonUtil = jsonUtil;
-        this.advocateUtil = advocateUtil;
-        this.userUtil = userUtil;
-        this.smsNotificationService = smsNotificationService;
     }
 
     @Override
@@ -84,52 +76,6 @@ public class PublishOrderAttachment implements OrderUpdateStrategy {
 
         // add validation here
         CourtCase courtCase = cases.get(0);
-        log.info("fetching litigant advocate mapping for caseId:{}", courtCase.getId());
-        Map<String, List<String>> litigantAdvocateMapping = advocateUtil.getLitigantAdvocateMapping(courtCase);
-        List<Party> complainants = caseUtil.getRespondentOrComplainant(courtCase, "complainant");
-        List<String> assignees = new ArrayList<>();
-        List<User> uniqueAssignee = new ArrayList<>();
-        Set<String> uniqueSet = new HashSet<>();
-        List<String> complainantIndividualId = new ArrayList<>();
-        Map<String, List<POAHolder>> litigantPoaMapping = caseUtil.getLitigantPoaMapping(courtCase);
-
-        for (Party party : complainants) {
-            String uuid = jsonUtil.getNestedValue(party.getAdditionalDetails(), List.of("uuid"), String.class);
-            if (litigantAdvocateMapping.containsKey(uuid)) {
-                assignees.addAll(litigantAdvocateMapping.get(uuid));
-                assignees.add(uuid);
-            }
-            complainantIndividualId.add(party.getIndividualId());
-            if (litigantPoaMapping.containsKey(party.getIndividualId())) {
-                List<POAHolder> poaHolders = litigantPoaMapping.get(party.getIndividualId());
-                if (poaHolders != null) {
-                    for (POAHolder poaHolder : poaHolders) {
-                        if (poaHolder.getAdditionalDetails() != null) {
-                            String poaUUID = jsonUtil.getNestedValue(poaHolder.getAdditionalDetails(), List.of("uuid"), String.class);
-                            if (poaUUID != null) assignees.add(poaUUID);
-                        }
-                    }
-                }
-            }
-
-        }
-
-        for (String userUUID : assignees) {
-            if (uniqueSet.contains(userUUID)) {
-                continue;
-            }
-            User user = User.builder().uuid(userUUID).build();
-            uniqueAssignee.add(user);
-            uniqueSet.add(userUUID);
-        }
-
-        Long sla = pendingTaskUtil.getStateSla(order.getOrderType());
-        String applicationNumber = jsonUtil.getNestedValue(order.getAdditionalDetails(), Arrays.asList("formdata", "refApplicationId"), String.class);
-
-        Map<String, Object> additionalDetails = new HashMap<>();
-        additionalDetails.put("applicationNumber", applicationNumber);
-        additionalDetails.put("litigants", complainantIndividualId);
-
 
         String taskDetails = jsonUtil.getNestedValue(order.getAdditionalDetails(), List.of("taskDetails"), String.class);
         try {
@@ -138,61 +84,16 @@ public class PublishOrderAttachment implements OrderUpdateStrategy {
 
             for (JsonNode taskDetail : taskDetailsArray) {
 
-
                 String taskDetailString = objectMapper.writeValueAsString(taskDetail);
                 Map<String, Object> jsonMap = objectMapper.readValue(taskDetailString, new TypeReference<>() {
                 });
                 String channel = jsonUtil.getNestedValue(jsonMap, Arrays.asList("deliveryChannels", "channelCode"), String.class);
 
-                TaskRequest taskRequest = taskUtil.createTaskRequest(requestInfo, order, taskDetail,courtCase,channel);
-                TaskResponse taskResponse = taskUtil.callCreateTask(taskRequest);
+                TaskRequest taskRequest = taskUtil.createTaskRequest(requestInfo, order, taskDetail, courtCase, channel);
+                taskUtil.callCreateTask(taskRequest);
 
-                // create pending task
-
-                if (channel != null && (!EMAIL.equalsIgnoreCase(channel) && !SMS.equalsIgnoreCase(channel))
-                        && !taskUtil.isCourtWitness(order.getOrderType(), taskDetail) && !LifecycleStatus.LPR.equals(courtCase.getLifecycleStatus())) {
-
-                    PendingTask pendingTask = PendingTask.builder()
-                            .name(PAYMENT_PENDING_FOR_ATTACHMENT)
-                            .referenceId(MANUAL + taskResponse.getTask().getTaskNumber())
-                            .entityType("order-default")
-                            .status("PAYMENT_PENDING_POLICE")
-                            .assignedTo(uniqueAssignee)
-                            .cnrNumber(courtCase.getCnrNumber())
-                            .filingNumber(courtCase.getFilingNumber())
-                            .caseId(courtCase.getId().toString())
-                            .caseTitle(courtCase.getCaseTitle())
-                            .isCompleted(false)
-                            .stateSla(sla)
-                            .additionalDetails(additionalDetails)
-                            .screenType("home")
-                            .build();
-
-                    pendingTaskUtil.createPendingTask(PendingTaskRequest.builder().requestInfo(requestInfo
-                    ).pendingTask(pendingTask).build());
-
-                    String partyType = getPartyType(order);
-                    String orderType = order.getOrderType();
-                    if (orderType != null && !orderType.isEmpty()) {
-                        orderType = orderType.substring(0, 1).toUpperCase()
-                                + orderType.substring(1).toLowerCase();
-                    }
-                    String days = String.valueOf(StateSlaMap.getStateSlaMap().get(ATTACHMENT));
-                    SMSTemplateData smsTemplateData = SMSTemplateData.builder()
-                            .partyType(partyType)
-                            .orderType(orderType)
-                            .tenantId(courtCase.getTenantId())
-                            .days(days)
-                            .courtCaseNumber(courtCase.getCourtCaseNumber())
-                            .cmpNumber(courtCase.getCmpNumber())
-                            .build();
-                    callNotificationService(orderRequest,PROCESS_FEE_PAYMENT, smsTemplateData, uniqueAssignee);
-                    if(pendingTask.getName().contains(RPAD)){
-                        callNotificationService(orderRequest, RPAD_SUBMISSION, smsTemplateData, uniqueAssignee);
-
-                    }
-                }
-
+                // No court fee is applicable for attachment irrespective of case stage (#5906),
+                // so no payment-pending task or fee-payment notification is created.
 
             }
 
@@ -201,41 +102,6 @@ public class PublishOrderAttachment implements OrderUpdateStrategy {
         }
 
         return null;
-    }
-
-    private String getPartyType(Order order) {
-        Object additionalDetails = order.getAdditionalDetails();
-        JsonNode additionalDetailsNode = objectMapper.convertValue(additionalDetails, JsonNode.class);
-
-        JsonNode partyTypeNode = additionalDetailsNode
-                .path("formdata")
-                .path("attachmentFor")
-                .path("party")
-                .path("data")
-                .path("partyType");
-
-        String partyType = partyTypeNode.textValue();
-        return partyType == null ? null : partyType.substring(0, 1).toUpperCase() + partyType.substring(1).toLowerCase();
-    }
-
-    private void callNotificationService(OrderRequest orderRequest, String messageCode, SMSTemplateData smsTemplateData, List<User> users) {
-        try {
-            List<String> uuids = users.stream()
-                    .map(User::getUuid)
-                    .toList();
-
-            List<User> userList = userUtil.getUserListFromUserUuid(uuids);
-            List<String> phoneNumbers = userList.stream()
-                    .map(User::getMobileNumber)
-                    .toList();
-
-            for (String number : phoneNumbers) {
-                smsNotificationService.sendNotification(orderRequest.getRequestInfo(), smsTemplateData, messageCode, number);
-            }
-        }
-        catch (Exception e) {
-            log.error("Error occurred while sending notification", e);
-        }
     }
 
     @Override
@@ -249,7 +115,3 @@ public class PublishOrderAttachment implements OrderUpdateStrategy {
     }
 
 }
-
-
-
-

--- a/backend/dristi-services/order-management/src/main/java/pucar/strategy/ordertype/PublishOrderProclamation.java
+++ b/backend/dristi-services/order-management/src/main/java/pucar/strategy/ordertype/PublishOrderProclamation.java
@@ -6,24 +6,24 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.egov.common.contract.request.RequestInfo;
-import org.egov.common.contract.request.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import pucar.config.StateSlaMap;
-import pucar.service.SmsNotificationService;
 import pucar.strategy.OrderUpdateStrategy;
-import pucar.util.*;
+import pucar.util.CaseUtil;
+import pucar.util.JsonUtil;
+import pucar.util.TaskUtil;
 import pucar.web.models.Order;
 import pucar.web.models.OrderRequest;
-import pucar.web.models.SMSTemplateData;
 import pucar.web.models.adiary.CaseDiaryEntry;
-import pucar.web.models.courtCase.*;
-import pucar.web.models.pendingtask.PendingTask;
-import pucar.web.models.pendingtask.PendingTaskRequest;
+import pucar.web.models.courtCase.CaseCriteria;
+import pucar.web.models.courtCase.CaseSearchRequest;
+import pucar.web.models.courtCase.CourtCase;
 import pucar.web.models.task.TaskRequest;
-import pucar.web.models.task.TaskResponse;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import static pucar.config.ServiceConstants.*;
 
@@ -34,22 +34,14 @@ public class PublishOrderProclamation implements OrderUpdateStrategy {
     private final TaskUtil taskUtil;
     private final ObjectMapper objectMapper;
     private final CaseUtil caseUtil;
-    private final PendingTaskUtil pendingTaskUtil;
     private final JsonUtil jsonUtil;
-    private final AdvocateUtil advocateUtil;
-    private final UserUtil userUtil;
-    private final SmsNotificationService smsNotificationService;
 
     @Autowired
-    public PublishOrderProclamation(TaskUtil taskUtil, ObjectMapper objectMapper, CaseUtil caseUtil, PendingTaskUtil pendingTaskUtil, JsonUtil jsonUtil, AdvocateUtil advocateUtil, UserUtil userUtil, SmsNotificationService smsNotificationService) {
+    public PublishOrderProclamation(TaskUtil taskUtil, ObjectMapper objectMapper, CaseUtil caseUtil, JsonUtil jsonUtil) {
         this.taskUtil = taskUtil;
         this.objectMapper = objectMapper;
         this.caseUtil = caseUtil;
-        this.pendingTaskUtil = pendingTaskUtil;
         this.jsonUtil = jsonUtil;
-        this.advocateUtil = advocateUtil;
-        this.userUtil = userUtil;
-        this.smsNotificationService = smsNotificationService;
     }
 
     @Override
@@ -84,52 +76,6 @@ public class PublishOrderProclamation implements OrderUpdateStrategy {
 
         // add validation here
         CourtCase courtCase = cases.get(0);
-        log.info("fetching litigant advocate mapping for caseId:{}", courtCase.getId());
-        Map<String, List<String>> litigantAdvocateMapping = advocateUtil.getLitigantAdvocateMapping(courtCase);
-        List<Party> complainants = caseUtil.getRespondentOrComplainant(courtCase, "complainant");
-        List<String> assignees = new ArrayList<>();
-        List<User> uniqueAssignee = new ArrayList<>();
-        Set<String> uniqueSet = new HashSet<>();
-        List<String> complainantIndividualId = new ArrayList<>();
-        Map<String, List<POAHolder>> litigantPoaMapping = caseUtil.getLitigantPoaMapping(courtCase);
-
-        for (Party party : complainants) {
-            String uuid = jsonUtil.getNestedValue(party.getAdditionalDetails(), List.of("uuid"), String.class);
-            if (litigantAdvocateMapping.containsKey(uuid)) {
-                assignees.addAll(litigantAdvocateMapping.get(uuid));
-                assignees.add(uuid);
-            }
-            complainantIndividualId.add(party.getIndividualId());
-            if (litigantPoaMapping.containsKey(party.getIndividualId())) {
-                List<POAHolder> poaHolders = litigantPoaMapping.get(party.getIndividualId());
-                if (poaHolders != null) {
-                    for (POAHolder poaHolder : poaHolders) {
-                        if (poaHolder.getAdditionalDetails() != null) {
-                            String poaUUID = jsonUtil.getNestedValue(poaHolder.getAdditionalDetails(), List.of("uuid"), String.class);
-                            if (poaUUID != null) assignees.add(poaUUID);
-                        }
-                    }
-                }
-            }
-
-        }
-
-        for (String userUUID : assignees) {
-            if (uniqueSet.contains(userUUID)) {
-                continue;
-            }
-            User user = User.builder().uuid(userUUID).build();
-            uniqueAssignee.add(user);
-            uniqueSet.add(userUUID);
-        }
-
-        Long sla = pendingTaskUtil.getStateSla(order.getOrderType());
-        String applicationNumber = jsonUtil.getNestedValue(order.getAdditionalDetails(), Arrays.asList("formdata", "refApplicationId"), String.class);
-
-        Map<String, Object> additionalDetails = new HashMap<>();
-        additionalDetails.put("applicationNumber", applicationNumber);
-        additionalDetails.put("litigants", complainantIndividualId);
-
 
         String taskDetails = jsonUtil.getNestedValue(order.getAdditionalDetails(), List.of("taskDetails"), String.class);
         try {
@@ -138,61 +84,16 @@ public class PublishOrderProclamation implements OrderUpdateStrategy {
 
             for (JsonNode taskDetail : taskDetailsArray) {
 
-
                 String taskDetailString = objectMapper.writeValueAsString(taskDetail);
                 Map<String, Object> jsonMap = objectMapper.readValue(taskDetailString, new TypeReference<>() {
                 });
                 String channel = jsonUtil.getNestedValue(jsonMap, Arrays.asList("deliveryChannels", "channelCode"), String.class);
 
-                TaskRequest taskRequest = taskUtil.createTaskRequest(requestInfo, order, taskDetail,courtCase,channel);
-                TaskResponse taskResponse = taskUtil.callCreateTask(taskRequest);
+                TaskRequest taskRequest = taskUtil.createTaskRequest(requestInfo, order, taskDetail, courtCase, channel);
+                taskUtil.callCreateTask(taskRequest);
 
-                // create pending task
-
-                if (channel != null && (!EMAIL.equalsIgnoreCase(channel) && !SMS.equalsIgnoreCase(channel))
-                        && !taskUtil.isCourtWitness(order.getOrderType(), taskDetail) && !LifecycleStatus.LPR.equals(courtCase.getLifecycleStatus())) {
-
-                    PendingTask pendingTask = PendingTask.builder()
-                            .name(PAYMENT_PENDING_FOR_PROCLAMATION)
-                            .referenceId(MANUAL + taskResponse.getTask().getTaskNumber())
-                            .entityType("order-default")
-                            .status("PAYMENT_PENDING_POLICE")
-                            .assignedTo(uniqueAssignee)
-                            .cnrNumber(courtCase.getCnrNumber())
-                            .filingNumber(courtCase.getFilingNumber())
-                            .caseId(courtCase.getId().toString())
-                            .caseTitle(courtCase.getCaseTitle())
-                            .isCompleted(false)
-                            .stateSla(sla)
-                            .additionalDetails(additionalDetails)
-                            .screenType("home")
-                            .build();
-
-                    pendingTaskUtil.createPendingTask(PendingTaskRequest.builder().requestInfo(requestInfo
-                    ).pendingTask(pendingTask).build());
-
-                    String partyType = getPartyType(order);
-                    String orderType = order.getOrderType();
-                    if (orderType != null && !orderType.isEmpty()) {
-                        orderType = orderType.substring(0, 1).toUpperCase()
-                                + orderType.substring(1).toLowerCase();
-                    }
-                    String days = String.valueOf(StateSlaMap.getStateSlaMap().get(PROCLAMATION));
-                    SMSTemplateData smsTemplateData = SMSTemplateData.builder()
-                            .partyType(partyType)
-                            .orderType(orderType)
-                            .tenantId(courtCase.getTenantId())
-                            .days(days)
-                            .courtCaseNumber(courtCase.getCourtCaseNumber())
-                            .cmpNumber(courtCase.getCmpNumber())
-                            .build();
-                    callNotificationService(orderRequest,PROCESS_FEE_PAYMENT, smsTemplateData, uniqueAssignee);
-                    if(pendingTask.getName().contains(RPAD)){
-                        callNotificationService(orderRequest, RPAD_SUBMISSION, smsTemplateData, uniqueAssignee);
-
-                    }
-                }
-
+                // No court fee is applicable for proclamation irrespective of case stage (#5906),
+                // so no payment-pending task or fee-payment notification is created.
 
             }
 
@@ -201,41 +102,6 @@ public class PublishOrderProclamation implements OrderUpdateStrategy {
         }
 
         return null;
-    }
-
-    private String getPartyType(Order order) {
-        Object additionalDetails = order.getAdditionalDetails();
-        JsonNode additionalDetailsNode = objectMapper.convertValue(additionalDetails, JsonNode.class);
-
-        JsonNode partyTypeNode = additionalDetailsNode
-                .path("formdata")
-                .path("proclamationFor")
-                .path("party")
-                .path("data")
-                .path("partyType");
-
-        String partyType = partyTypeNode.textValue();
-        return partyType == null ? null : partyType.substring(0, 1).toUpperCase() + partyType.substring(1).toLowerCase();
-    }
-
-    private void callNotificationService(OrderRequest orderRequest, String messageCode, SMSTemplateData smsTemplateData, List<User> users) {
-        try {
-            List<String> uuids = users.stream()
-                    .map(User::getUuid)
-                    .toList();
-
-            List<User> userList = userUtil.getUserListFromUserUuid(uuids);
-            List<String> phoneNumbers = userList.stream()
-                    .map(User::getMobileNumber)
-                    .toList();
-
-            for (String number : phoneNumbers) {
-                smsNotificationService.sendNotification(orderRequest.getRequestInfo(), smsTemplateData, messageCode, number);
-            }
-        }
-        catch (Exception e) {
-            log.error("Error occurred while sending notification", e);
-        }
     }
 
     @Override
@@ -249,7 +115,3 @@ public class PublishOrderProclamation implements OrderUpdateStrategy {
     }
 
 }
-
-
-
-

--- a/backend/dristi-services/order-management/src/main/java/pucar/util/TaskUtil.java
+++ b/backend/dristi-services/order-management/src/main/java/pucar/util/TaskUtil.java
@@ -120,7 +120,9 @@ public class TaskUtil {
         }
 
         WorkflowObject workflowObject = new WorkflowObject();
+        // Proclamation and attachment are always fee-free irrespective of case stage (#5906)
         if (EMAIL.equalsIgnoreCase(channel) || SMS.equalsIgnoreCase(channel) || LifecycleStatus.LPR.equals(courtCase.getLifecycleStatus()) ||
+                PROCLAMATION.equalsIgnoreCase(order.getOrderType()) || ATTACHMENT.equalsIgnoreCase(order.getOrderType()) ||
                 isCourtWitness(order.getOrderType(), objectMapper.convertValue(taskDetails, JsonNode.class))) {
             workflowObject.setAction("CREATE_WITH_OUT_PAYMENT");
             // There is no pending collection when payment is not made


### PR DESCRIPTION
Proclamation and attachment no longer charge a court fee irrespective of case stage: their tasks are always created with CREATE_WITH_OUT_PAYMENT and the payment-pending task + fee-payment notification are removed. Warrants remain fee-free only in the LPR stage (already implemented).

## Requirements

https://github.com/pucardotorg/dristi/issues/5906

- [x] This PR has a proper title that briefly describes the work done
- [x] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [x] I have referenced the  github issues('s)
- [x] I performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->
